### PR TITLE
Refactor: extract poll logic and remove UI event system

### DIFF
--- a/state/__init__.py
+++ b/state/__init__.py
@@ -1,0 +1,5 @@
+"""Pure state and decision logic for the TapMap UI.
+
+Modules in this package contain no Dash code.
+They implement deterministic state transitions.
+"""

--- a/state/keyboard.py
+++ b/state/keyboard.py
@@ -1,3 +1,8 @@
+"""Keyboard action parsing and normalization.
+
+Translate raw key input into high level action strings
+used by the application state layer.
+"""
 from __future__ import annotations
 
 from datetime import datetime
@@ -15,8 +20,8 @@ def build_key_action(value: str) -> dict[str, Any] | None:
         "__l__": "menu_lan_local",
         "__o__": "menu_open_ports",
         "__t__": "menu_cache_terminal",
-        "__c__": "menu_clear",
-        "__r__": "menu_recheck_geo",
+        "__c__": "menu_clear_cache",
+        "__r__": "menu_recheck_geoip",
         "__h__": "menu_help",
         "__a__": "menu_about",
         "__esc__": "escape",

--- a/state/menu.py
+++ b/state/menu.py
@@ -1,3 +1,8 @@
+"""Menu open/close state decisions.
+
+Contain pure functions that decide menu visibility
+based on triggers and keyboard actions.
+"""
 from __future__ import annotations
 
 from typing import Any

--- a/state/modal.py
+++ b/state/modal.py
@@ -1,3 +1,8 @@
+"""Modal state transition logic.
+
+Provide pure decision functions for closing,
+opening, and switching modal screens.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -6,9 +11,8 @@ from typing import Any
 
 @dataclass(frozen=True)
 class ModalDecision:
-    """Describe next modal state and optional UI event."""
+    """Describe the next modal_state value for the modal controller."""
     modal_state: dict[str, Any] | None
-    ui_event: dict[str, Any] | None
 
 
 def decide_close(
@@ -20,22 +24,24 @@ def decide_close(
     is_geo_enabled: bool,
     missing_geo_screen: str,
 ) -> ModalDecision | None:
-    """Return close decision for modal overlay.
+    """Decide whether the modal should close.
 
-    Return None if no close decision applies.
+    Return ModalDecision(modal_state=None) to close the modal.
+    Return None if no close rule applies.
     """
+    # Auto close the missing Geo DB modal once GeoIP is enabled.
     if (
         is_open
         and current_screen == missing_geo_screen
         and is_geo_enabled
     ):
-        return ModalDecision(modal_state=None, ui_event=None)
+        return ModalDecision(modal_state=None)
 
     if trigger == "btn_close" and is_open:
-        return ModalDecision(modal_state=None, ui_event=None)
+        return ModalDecision(modal_state=None)
 
     if trigger == "key_action" and action == "escape" and is_open:
-        return ModalDecision(modal_state=None, ui_event=None)
+        return ModalDecision(modal_state=None)
 
     return None
 
@@ -47,14 +53,14 @@ def decide_screen_change(
     show_system: bool,
     action: Any,
     menu_screens: set[str],
-    menu_commands: set[str],
     open_ports_prefs: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Return new modal_state for screen transitions.
+    """Decide whether the modal should switch to a different screen.
 
+    Return a partial modal_state dict with "screen" and optional "payload".
     Return None if no screen change applies.
     """
-    # Keyboard open modal
+    # Open a modal screen from keyboard action.
     if trigger == "key_action" and isinstance(action, str) and action in menu_screens:
         screen = action
         payload: dict[str, Any] = {}
@@ -68,7 +74,7 @@ def decide_screen_change(
             "payload": payload,
         }
 
-    # Toggle inside Open Ports modal
+    # Update Open Ports payload when the toggle changes.
     if trigger == "toggle_open_ports_system":
         if not is_open or current_screen != "menu_open_ports":
             return None
@@ -78,7 +84,7 @@ def decide_screen_change(
             "payload": {"show_system": show_system},
         }
 
-    # Open modal from menu_* click
+    # Open a modal screen from menu click.
     if trigger in menu_screens:
         screen = str(trigger)
         payload: dict[str, Any] = {}
@@ -100,10 +106,9 @@ def decide_map_click(
     click_data: Any,
     now_iso: str,
 ) -> ModalDecision | None:
-    """Return modal decision for map click.
+    """Open the map_click modal for valid map click data.
 
-    Open the map_click screen when the map is clicked
-    and click_data is present. Return None otherwise.
+    Return ModalDecision for the map_click screen, or None if not applicable.
     """
     if trigger != "map":
         return None
@@ -117,28 +122,4 @@ def decide_map_click(
             "t": now_iso,
             "payload": {"click_data": click_data},
         },
-        ui_event=None,
-    )
-
-def decide_geo_recheck(
-    *,
-    trigger: Any,
-    check_db_clicks: int | None,
-    evt_type: str,
-    now_iso: str,
-) -> ModalDecision | None:
-    """Return modal decision for GeoIP recheck request.
-
-    Emit EVT_GEO_RECHECK event when the check databases
-    button is triggered. Return None otherwise.
-    """
-    if trigger != "btn_check_databases":
-        return None
-
-    if not isinstance(check_db_clicks, int) or check_db_clicks < 1:
-        return None
-
-    return ModalDecision(
-        modal_state=None,
-        ui_event={"type": evt_type, "t": now_iso},
     )

--- a/state/open_ports_prefs.py
+++ b/state/open_ports_prefs.py
@@ -1,3 +1,8 @@
+"""Open Ports modal preference handling.
+
+Contain pure helpers for storing and updating
+user preferences related to the Open Ports view.
+"""
 from __future__ import annotations
 
 from typing import Any

--- a/state/poll.py
+++ b/state/poll.py
@@ -1,0 +1,56 @@
+"""High level poll action decisions.
+
+Decide which model operation to execute
+based on triggers and keyboard actions.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+ACTION_GEO_RECHECK = "geo_recheck"
+ACTION_CLEAR_CACHE = "clear_cache"
+ACTION_CACHE_TERMINAL = "cache_terminal"
+ACTION_NORMAL_POLL = "normal_poll"
+
+
+@dataclass(frozen=True)
+class PollDecision:
+    """Describe which poll action to execute."""
+    action: str
+
+
+def _extract_key_action(key_action: Any) -> str | None:
+    """Extract action string from key_action store payload."""
+    if not isinstance(key_action, dict):
+        return None
+    action = key_action.get("action")
+    return action if isinstance(action, str) and action else None
+
+
+def decide_poll_action(*, trigger: Any, key_action: Any) -> PollDecision:
+    """Decide which high level poll action to execute.
+
+    Handles direct menu clicks and keyboard actions. Otherwise returns normal_poll.
+    """
+    RECHECK_TRIGGERS = {"menu_recheck_geoip", "btn_check_databases"}
+
+    if trigger in RECHECK_TRIGGERS:
+        return PollDecision(action=ACTION_GEO_RECHECK)
+
+    if trigger == "menu_clear_cache":
+        return PollDecision(action=ACTION_CLEAR_CACHE)
+
+    if trigger == "menu_cache_terminal":
+        return PollDecision(action=ACTION_CACHE_TERMINAL)
+
+    if trigger == "key_action":
+        action = _extract_key_action(key_action)
+        if action == "menu_recheck_geoip":
+            return PollDecision(action=ACTION_GEO_RECHECK)
+        if action == "menu_clear_cache":
+            return PollDecision(action=ACTION_CLEAR_CACHE)
+        if action == "menu_cache_terminal":
+            return PollDecision(action=ACTION_CACHE_TERMINAL)
+
+    return PollDecision(action=ACTION_NORMAL_POLL)

--- a/state/status_line.py
+++ b/state/status_line.py
@@ -1,6 +1,10 @@
+"""Status line rendering logic.
+
+Build human readable status text from
+snapshot, cache state, and flash messages.
+"""
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from ui.status_cache import StatusCache
@@ -11,20 +15,13 @@ def render_status_text(
     snapshot: Any,
     status_cache_data: Any,
     status_flash: Any,
-    now: datetime,
     myloc_label: str,
     to_int: Any,
 ) -> str:
     """Render status bar text."""
     if isinstance(status_flash, dict):
         message = status_flash.get("message")
-        until = status_flash.get("until")
-        if (
-            isinstance(message, str)
-            and message
-            and isinstance(until, (int, float))
-            and now.timestamp() < float(until)
-        ):
+        if isinstance(message, str) and message:
             return message
 
     status_cache = StatusCache.from_store(status_cache_data)

--- a/tapmap.py
+++ b/tapmap.py
@@ -20,8 +20,15 @@ from model.public_ip import iter_public_ip_candidates
 from runtime import AppMeta, RuntimeContext, build_runtime
 from state.keyboard import build_key_action
 from state.menu import compute_menu_open_state
-from state.modal import decide_close, decide_geo_recheck, decide_map_click, decide_screen_change
+from state.modal import decide_close, decide_map_click, decide_screen_change
 from state.open_ports_prefs import set_show_system_pref
+from state.poll import (
+    ACTION_CACHE_TERMINAL,
+    ACTION_CLEAR_CACHE,
+    ACTION_GEO_RECHECK,
+    ACTION_NORMAL_POLL,
+    decide_poll_action,
+)
 from state.status_line import render_status_text
 from ui.cache_view import CacheViewBuilder
 from ui.map_view import MapUI
@@ -40,7 +47,7 @@ class TapMap:
         {"menu_unmapped", "menu_lan_local", "menu_open_ports","menu_help", "menu_about"}
     )
     MENU_COMMANDS: ClassVar[frozenset[str]] = frozenset(
-        {"menu_clear", "menu_cache_terminal", "menu_recheck_geo"}
+        {"menu_clear_cache", "menu_cache_terminal", "menu_recheck_geoip"}
     )
 
     DASH_DEBUG = False
@@ -53,7 +60,6 @@ class TapMap:
     FLASH_SHORT_S = 1.5
     FLASH_LONG_S = 3.0
 
-    EVT_GEO_RECHECK = "geo_recheck"
     SCR_MISSING_GEO_DB = "missing_geo_db"
 
     def __init__(self, runtime_ctx: RuntimeContext) -> None:
@@ -156,8 +162,6 @@ class TapMap:
                 dcc.Store(id="ui_cache", data={}),
                 dcc.Store(id="status_cache", data=StatusCache().to_store()),
                 dcc.Store(id="ui_view", data={"points": [], "summaries": {}, "details": {}}),
-                dcc.Store(id="ui_event", data=None),
-                dcc.Store(id="ui_event_seen", data=None),
                 dcc.Store(id="modal_state", data=initial_modal_state),
                 dcc.Store(id="open_ports_prefs", data={"show_system": False}),
                 dcc.Input(
@@ -177,7 +181,6 @@ class TapMap:
                     },
                 ),
                 dcc.Interval(id="tick_status", interval=self.MODEL_TICK_MS, n_intervals=0),
-                dcc.Interval(id="tick_ui", interval=self.UI_TICK_MS, n_intervals=0),
                 dcc.Graph(
                     id="map",
                     figure=start_fig,
@@ -217,14 +220,14 @@ class TapMap:
                                 self._menu_button(
                                     "Show cache in terminal (T)", "menu_cache_terminal"
                                 ),
-                                self._menu_button("Clear cache (C)", "menu_clear"),
+                                self._menu_button("Clear cache (C)", "menu_clear_cache"),
                             ],
                             className="mx-menu-group",
                         ),
                         html.Div(
                             [
                                 self._menu_button(
-                                    "Recheck GeoIP databases (R)", "menu_recheck_geo"
+                                    "Recheck GeoIP databases (R)", "menu_recheck_geoip"
                                 ),
                                 self._menu_button("Help (H)", "menu_help"),
                                 self._menu_button("About (A)", "menu_about"),
@@ -302,15 +305,6 @@ class TapMap:
     @staticmethod
     def _flash(message: str, seconds: float) -> dict[str, Any]:
         return {"message": message, "until": (datetime.now().timestamp() + float(seconds))}
-
-    def _event_signature(self, ev: Any) -> str | None:
-        if not isinstance(ev, dict):
-            return None
-        et = ev.get("type")
-        t = ev.get("t")
-        if isinstance(et, str) and et:
-            return f"{et}|{t}" if isinstance(t, str) else f"{et}|"
-        return None
 
     def _myloc_label(self) -> str:
         if isinstance(MY_LOCATION, tuple):
@@ -547,62 +541,53 @@ class TapMap:
             Output("status_cache", "data"),
             Output("ui_view", "data"),
             Output("status_flash", "data"),
-            Output("ui_event_seen", "data"),
             Input("tick_status", "n_intervals"),
-            Input("ui_event", "data"),
             Input("key_action", "data"),
-            Input("menu_clear", "n_clicks"),
+            Input("menu_clear_cache", "n_clicks"),
             Input("menu_cache_terminal", "n_clicks"),
+            Input("menu_recheck_geoip", "n_clicks"),
+            Input("btn_check_databases", "n_clicks", allow_optional=True),
             State("ui_cache", "data"),
             State("status_cache", "data"),
-            State("ui_event_seen", "data"),
             prevent_initial_call=False,
         )
         def poll_model(
             tick_n: int,
-            ui_event: Any,
             key_action: Any,
             _clear_clicks: int,
             _cache_terminal_clicks: int,
+            _recheck_clicks: int,
+            _check_db_clicks: int | None,
             ui_cache_data: Any,
             status_cache_data: Any,
-            event_seen: Any,
         ):
             status_cache = StatusCache.from_store(status_cache_data)
             ui_cache = self._ensure_dict(ui_cache_data)
-
-            sig = self._event_signature(ui_event)
-            if sig and sig != event_seen and isinstance(ui_event, dict):
-                if ui_event.get("type") == self.EVT_GEO_RECHECK:
-                    snap, cache, sc_store, view, flash = self._handle_geo_recheck(status_cache)
-                    return snap, cache, sc_store, view, flash, sig
-                return no_update, no_update, no_update, no_update, no_update, sig
-
             trigger = ctx.triggered_id
-
-            if trigger == "key_action" and isinstance(key_action, dict):
-                action = key_action.get("action")
-
-                if action == "menu_clear":
-                    snap, cache, sc_store, view, flash = self._handle_clear_cache(status_cache)
-                    return snap, cache, sc_store, view, flash, event_seen
-
-                if action == "menu_cache_terminal":
-                    a, b, c, d, flash = self._handle_cache_terminal(status_cache, ui_cache)
-                    return a, b, c, d, flash, event_seen
-
-            if trigger == "menu_clear":
-                snap, cache, sc_store, view, flash = self._handle_clear_cache(status_cache)
-                return snap, cache, sc_store, view, flash, event_seen
-
-            if trigger == "menu_cache_terminal":
-                a, b, c, d, flash = self._handle_cache_terminal(status_cache, ui_cache)
-                return a, b, c, d, flash, event_seen
-
-            snap, cache, sc_store, view, flash = self._handle_normal_poll(
-                tick_n, status_cache, ui_cache
+            decision = decide_poll_action(
+                trigger=trigger,
+                key_action=key_action,
             )
-            return snap, cache, sc_store, view, flash, event_seen
+
+            if decision.action == ACTION_CACHE_TERMINAL:
+                a, b, c, d, flash = self._handle_cache_terminal(status_cache, ui_cache)
+                return a, b, c, d, flash
+
+            if decision.action == ACTION_CLEAR_CACHE:
+                snap, cache, sc_store, view, flash = self._handle_clear_cache(status_cache)
+                return snap, cache, sc_store, view, flash
+
+            if decision.action == ACTION_GEO_RECHECK:
+                snap, cache, sc_store, view, flash = self._handle_geo_recheck(status_cache)
+                return snap, cache, sc_store, view, flash
+
+            if decision.action == ACTION_NORMAL_POLL:
+                snap, cache, sc_store, view, _flash = self._handle_normal_poll(
+                    tick_n, status_cache, ui_cache
+                )
+                return snap, cache, sc_store, view, None
+
+            return no_update, no_update, no_update, no_update, no_update
 
         @self.app.callback(
             Output("map", "figure"),
@@ -619,21 +604,16 @@ class TapMap:
             Input("model_snapshot", "data"),
             Input("status_cache", "data"),
             Input("status_flash", "data"),
-            Input("ui_view", "data"),
-            Input("tick_ui", "n_intervals"),
         )
         def render_status(
             snapshot: Any,
             status_cache_data: Any,
             status_flash: Any,
-            ui_view: Any,
-            _tick_ui: int,
         ) -> str:
             return render_status_text(
                 snapshot=snapshot,
                 status_cache_data=status_cache_data,
                 status_flash=status_flash,
-                now=datetime.now(),
                 myloc_label=self._myloc_label(),
                 to_int=self._to_int,
             )
@@ -658,8 +638,8 @@ class TapMap:
             Input("menu_cache_terminal", "n_clicks"),
             Input("menu_about", "n_clicks"),
             Input("menu_help", "n_clicks"),
-            Input("menu_clear", "n_clicks"),
-            Input("menu_recheck_geo", "n_clicks"),
+            Input("menu_clear_cache", "n_clicks"),
+            Input("menu_recheck_geoip", "n_clicks"),
             State("menu_open", "data"),
             prevent_initial_call=True,
         )
@@ -693,7 +673,6 @@ class TapMap:
 
         @self.app.callback(
             Output("modal_state", "data"),
-            Output("ui_event", "data"),
             Output("modal_overlay", "className"),
             Output("modal_body", "children"),
             Output("modal_body", "className"),
@@ -703,11 +682,9 @@ class TapMap:
             Input("menu_lan_local", "n_clicks"),
             Input("menu_about", "n_clicks"),
             Input("menu_help", "n_clicks"),
-            Input("menu_recheck_geo", "n_clicks"),
             Input("toggle_open_ports_system", "value", allow_optional=True),
             Input("map", "clickData"),
             Input("btn_open_data", "n_clicks", allow_optional=True),
-            Input("btn_check_databases", "n_clicks", allow_optional=True),
             Input("btn_close", "n_clicks"),
             Input("key_action", "data"),
             State("modal_state", "data"),
@@ -723,11 +700,9 @@ class TapMap:
             _lan_local_clicks: int,
             _about_clicks: int,
             _help_clicks: int,
-            _recheck_clicks: int,
             toggle_system_value: Any,
             click_data: Any,
             open_data_clicks: int | None,
-            check_db_clicks: int | None,
             _close_clicks: int,
             key_action: Any,
             modal_state_data: Any,
@@ -738,22 +713,18 @@ class TapMap:
             trigger = ctx.triggered_id
             geo_path = str(self.ctx.geo_data_dir)
             now_iso = datetime.now().isoformat()
-            current_state = (
-                modal_state_data if isinstance(modal_state_data, dict) else None
-            )
+
+            current_state = modal_state_data if isinstance(modal_state_data, dict) else None
             is_open = current_state is not None
             current_screen = (
                 current_state.get("screen")
                 if isinstance(current_state, dict)
                 else None
             )
-            action = None
 
+            action = None
             if trigger == "key_action" and isinstance(key_action, dict):
-                action = key_action.get("action")            
-            
-            def make_state(screen: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-                return {"screen": screen, "t": datetime.now().isoformat(), "payload": payload or {}}
+                action = key_action.get("action")
 
             show_system = self._toggle_on(toggle_system_value)
 
@@ -765,19 +736,17 @@ class TapMap:
                 is_geo_enabled=self._is_geo_enabled(snapshot),
                 missing_geo_screen=self.SCR_MISSING_GEO_DB,
             )
-
             if close_decision is not None:
-                new_state = close_decision.modal_state
-                children, class_name = self._render_modal(new_state, snapshot, ui_view, geo_path)
-                overlay_open = new_state is not None
+                next_state = close_decision.modal_state
+                children, body_class = self._render_modal(next_state, snapshot, ui_view, geo_path)
+                overlay_open = next_state is not None
                 return (
-                    new_state,
-                    close_decision.ui_event,
+                    next_state,
                     self._modal_overlay_class(overlay_open),
                     children,
-                    class_name,
+                    body_class,
                 )
-            
+
             screen_change = decide_screen_change(
                 trigger=trigger,
                 is_open=is_open,
@@ -785,79 +754,47 @@ class TapMap:
                 show_system=show_system,
                 action=action,
                 menu_screens=self.MENU_SCREENS,
-                menu_commands=self.MENU_COMMANDS,
                 open_ports_prefs=(
                     open_ports_prefs_data
                     if isinstance(open_ports_prefs_data, dict)
                     else None
                 ),
             )
-
             if screen_change is not None:
-                new_state = {
+                next_state = {
                     "screen": screen_change["screen"],
-                    "t": datetime.now().isoformat(),
+                    "t": now_iso,
                     "payload": screen_change.get("payload", {}),
                 }
-                children, class_name = self._render_modal(new_state, snapshot, ui_view, geo_path)
+                children, body_class = self._render_modal(next_state, snapshot, ui_view, geo_path)
                 return (
-                    new_state,
-                    None,
+                    next_state,
                     self._modal_overlay_class(True),
                     children,
-                    class_name,
-                )            
+                    body_class,
+                )
 
             if trigger == "btn_open_data":
                 if isinstance(open_data_clicks, int) and open_data_clicks >= 1:
                     open_folder(Path(geo_path))
-                return no_update, None, no_update, no_update, no_update
-
-            geo_decision = decide_geo_recheck(
-                trigger=trigger,
-                check_db_clicks=check_db_clicks,
-                evt_type=self.EVT_GEO_RECHECK,
-                now_iso=now_iso,
-            )
-
-            if geo_decision is not None:
-                return (
-                    no_update,
-                    geo_decision.ui_event,
-                    no_update,
-                    no_update,
-                    no_update,
-                )
-
-            if trigger == "menu_recheck_geo":
-                return (
-                    no_update,
-                    {"type": self.EVT_GEO_RECHECK, "t": datetime.now().isoformat()},
-                    no_update,
-                    no_update,
-                    no_update,
-                )
+                return no_update, no_update, no_update, no_update
 
             map_decision = decide_map_click(
                 trigger=trigger,
                 click_data=click_data,
                 now_iso=now_iso,
             )
-
             if map_decision is not None:
-                new_state = map_decision.modal_state
-                children, class_name = self._render_modal(
-                    new_state, snapshot, ui_view, geo_path
-                )
+                next_state = map_decision.modal_state
+                children, body_class = self._render_modal(next_state, snapshot, ui_view, geo_path)
                 return (
-                    new_state,
-                    None,
+                    next_state,
                     self._modal_overlay_class(True),
                     children,
-                    class_name,
+                    body_class,
                 )
-            
-            return no_update, None, no_update, no_update, no_update
+
+            return no_update, no_update, no_update, no_update
         
         @self.app.callback(
             Output("open_ports_prefs", "data"),
@@ -866,7 +803,7 @@ class TapMap:
             prevent_initial_call=True,
         )
         def open_ports_toggle(toggle_value: Any, prefs_data: Any) -> dict[str, Any]:
-            return set_show_system_pref(toggle_value=toggle_value, prefs_data=prefs_data)
+            return set_show_system_pref(toggle_value=toggle_value, prefs_data=prefs_data)   
 
     def run(self) -> None:
         """Start the Dash server and launch the local UI."""

--- a/ui/modal_view.py
+++ b/ui/modal_view.py
@@ -34,7 +34,7 @@ class ModalTextBuilder:
             "menu_lan_local": "Show established LAN/LOCAL services",
             "menu_open_ports": "Show open ports",
             "menu_cache_terminal": "Show cache in terminal",
-            "menu_clear": "Clear cache",
+            "menu_clear_cache": "Clear cache",
             "menu_help": "Help",
             "menu_about": "About",
         }


### PR DESCRIPTION

This refactor extracts poll decision logic into state.poll
and removes the ui_event-based mechanism.

GeoIP recheck (R) is now handled directly in poll_model.
Dead code and unused stores have been removed.