### PR TITLE
Refactor: modal controller structure and routing

### DIFF
--- a/state/modal.py
+++ b/state/modal.py
@@ -1,21 +1,32 @@
 """Modal state transition logic.
 
-Provide pure decision functions for closing,
-opening, and switching modal screens.
+Provide pure decision functions for closing, opening, and switching modal screens.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(frozen=True)
-class ModalDecision:
-    """Describe the next modal_state value for the modal controller."""
-    modal_state: dict[str, Any] | None
+class ModalRoute:
+    """Describe the next high level modal controller route.
+
+    action:
+      - "apply": apply modal_state (open, switch, or close)
+      - "open_data": request opening the GeoIP data folder
+      - "noop": no change
+
+    modal_state:
+      - full next modal_state dict, or None to close, used when action == "apply"
+    """
+
+    action: Literal["apply", "open_data", "noop"]
+    modal_state: dict[str, Any] | None = None
 
 
-def decide_close(
+def _decide_close(
     *,
     trigger: Any,
     is_open: bool,
@@ -23,29 +34,22 @@ def decide_close(
     action: Any,
     is_geo_enabled: bool,
     missing_geo_screen: str,
-) -> ModalDecision | None:
-    """Decide whether the modal should close.
-
-    Return ModalDecision(modal_state=None) to close the modal.
-    Return None if no close rule applies.
-    """
+) -> dict[str, Any] | None:
+    """Return None to close the modal, or no decision if not applicable."""
     # Auto close the missing Geo DB modal once GeoIP is enabled.
-    if (
-        is_open
-        and current_screen == missing_geo_screen
-        and is_geo_enabled
-    ):
-        return ModalDecision(modal_state=None)
+    if is_open and current_screen == missing_geo_screen and is_geo_enabled:
+        return None
 
     if trigger == "btn_close" and is_open:
-        return ModalDecision(modal_state=None)
+        return None
 
     if trigger == "key_action" and action == "escape" and is_open:
-        return ModalDecision(modal_state=None)
+        return None
 
-    return None
+    return ...  # sentinel meaning "no decision"
 
-def decide_screen_change(
+
+def _decide_screen_change(
     *,
     trigger: Any,
     is_open: bool,
@@ -54,12 +58,9 @@ def decide_screen_change(
     action: Any,
     menu_screens: set[str],
     open_ports_prefs: dict[str, Any] | None,
+    now_iso: str,
 ) -> dict[str, Any] | None:
-    """Decide whether the modal should switch to a different screen.
-
-    Return a partial modal_state dict with "screen" and optional "payload".
-    Return None if no screen change applies.
-    """
+    """Return full modal_state for screen transitions, or None if not applicable."""
     # Open a modal screen from keyboard action.
     if trigger == "key_action" and isinstance(action, str) and action in menu_screens:
         screen = action
@@ -69,20 +70,13 @@ def decide_screen_change(
             prefs = open_ports_prefs or {}
             payload["show_system"] = bool(prefs.get("show_system", False))
 
-        return {
-            "screen": screen,
-            "payload": payload,
-        }
+        return {"screen": screen, "t": now_iso, "payload": payload}
 
     # Update Open Ports payload when the toggle changes.
     if trigger == "toggle_open_ports_system":
         if not is_open or current_screen != "menu_open_ports":
             return None
-
-        return {
-            "screen": "menu_open_ports",
-            "payload": {"show_system": show_system},
-        }
+        return {"screen": "menu_open_ports", "t": now_iso, "payload": {"show_system": show_system}}
 
     # Open a modal screen from menu click.
     if trigger in menu_screens:
@@ -93,33 +87,81 @@ def decide_screen_change(
             prefs = open_ports_prefs or {}
             payload["show_system"] = bool(prefs.get("show_system", False))
 
-        return {
-            "screen": screen,
-            "payload": payload,
-        }
+        return {"screen": screen, "t": now_iso, "payload": payload}
 
     return None
 
-def decide_map_click(
+
+def _decide_map_click(
     *,
     trigger: Any,
     click_data: Any,
     now_iso: str,
-) -> ModalDecision | None:
-    """Open the map_click modal for valid map click data.
-
-    Return ModalDecision for the map_click screen, or None if not applicable.
-    """
+) -> dict[str, Any] | None:
+    """Return full modal_state for map click, or None if not applicable."""
     if trigger != "map":
         return None
-
     if click_data is None:
         return None
 
-    return ModalDecision(
-        modal_state={
-            "screen": "map_click",
-            "t": now_iso,
-            "payload": {"click_data": click_data},
-        },
+    return {"screen": "map_click", "t": now_iso, "payload": {"click_data": click_data}}
+
+
+def decide_modal_route(
+    *,
+    trigger: Any,
+    is_open: bool,
+    current_screen: str | None,
+    action: Any,
+    show_system: bool,
+    menu_screens: set[str],
+    open_ports_prefs: dict[str, Any] | None,
+    click_data: Any,
+    is_geo_enabled: bool,
+    missing_geo_screen: str,
+    now_iso: str,
+) -> ModalRoute:
+    """Decide modal routing in a single priority ordered function."""
+    # 1) Close has highest priority (ESC, Close button, auto close).
+    close_result = _decide_close(
+        trigger=trigger,
+        is_open=is_open,
+        current_screen=current_screen,
+        action=action,
+        is_geo_enabled=is_geo_enabled,
+        missing_geo_screen=missing_geo_screen,
     )
+    if close_result is None:
+        return ModalRoute(action="apply", modal_state=None)
+    if close_result is not ...:
+        # This should never happen, but keeps the contract explicit.
+        return ModalRoute(action="noop")
+
+    # 2) Screen routing (menu, keyboard, toggle).
+    next_state = _decide_screen_change(
+        trigger=trigger,
+        is_open=is_open,
+        current_screen=current_screen,
+        show_system=show_system,
+        action=action,
+        menu_screens=menu_screens,
+        open_ports_prefs=open_ports_prefs,
+        now_iso=now_iso,
+    )
+    if next_state is not None:
+        return ModalRoute(action="apply", modal_state=next_state)
+
+    # 3) Side-effect request.
+    if trigger == "btn_open_data":
+        return ModalRoute(action="open_data")
+
+    # 4) Map click.
+    next_state = _decide_map_click(
+        trigger=trigger,
+        click_data=click_data,
+        now_iso=now_iso,
+    )
+    if next_state is not None:
+        return ModalRoute(action="apply", modal_state=next_state)
+
+    return ModalRoute(action="noop")

--- a/tapmap.py
+++ b/tapmap.py
@@ -39,7 +39,7 @@ from model.public_ip import iter_public_ip_candidates
 from runtime import AppMeta, RuntimeContext, build_runtime
 from state.keyboard import build_key_action
 from state.menu import compute_menu_open_state
-from state.modal import decide_close, decide_map_click, decide_screen_change
+from state.modal import decide_modal_route
 from state.open_ports_prefs import set_show_system_pref
 from state.poll import (
     ACTION_CACHE_TERMINAL,
@@ -702,6 +702,7 @@ class TapMap:
             Input("menu_about", "n_clicks"),
             Input("menu_help", "n_clicks"),
             Input("btn_close", "n_clicks"),
+            Input("btn_check_databases", "n_clicks", allow_optional=True),
             Input("toggle_open_ports_system", "value", allow_optional=True),
             Input("map", "clickData"),
             Input("btn_open_data", "n_clicks", allow_optional=True),
@@ -720,6 +721,7 @@ class TapMap:
             _about_clicks: int,
             _help_clicks: int,
             _close_clicks: int,
+            _check_db_clicks: int | None,
             toggle_system_value: Any,
             click_data: Any,
             open_data_clicks: int | None,
@@ -729,16 +731,23 @@ class TapMap:
             ui_view: Any,
             open_ports_prefs_data: Any,
         ):
+            # Identify which Dash Input triggered this callback.
             trigger = ctx.triggered_id
             geo_path = str(self.ctx.geo_data_dir)
 
+            # Apply a modal_state to the UI by rendering and updating overlay classes.
             def _apply_modal_state(next_state: dict[str, Any] | None) -> tuple[Any, Any, Any, Any]:
                 children, body_class = self._render_modal(next_state, snapshot, ui_view, geo_path)
                 overlay_open = next_state is not None
                 overlay_class = self._modal_overlay_class(overlay_open)
-                return next_state, overlay_class, children, body_class          
+                return next_state, overlay_class, children, body_class
 
+            # Close About immediately when the GeoIP recheck button is pressed.
+            # The actual recheck work is executed by poll_model.
+            if trigger == "btn_check_databases":
+                return _apply_modal_state(None)
 
+            # Normalize current modal state.
             current_state = modal_state_data if isinstance(modal_state_data, dict) else None
             is_open = current_state is not None
             current_screen = (
@@ -747,58 +756,43 @@ class TapMap:
                 else None
             )
 
+            # Normalize keyboard action payload.
             action = None
             if trigger == "key_action" and isinstance(key_action, dict):
                 action = key_action.get("action")
 
-            close_decision = decide_close(
+            # Delegate routing decisions to the state layer.
+            now_iso = datetime.now().isoformat()
+            open_ports_prefs = (
+                open_ports_prefs_data
+                if isinstance(open_ports_prefs_data, dict)
+                else None
+            )
+            route = decide_modal_route(
                 trigger=trigger,
                 is_open=is_open,
                 current_screen=current_screen if isinstance(current_screen, str) else None,
                 action=action,
+                show_system=self._toggle_on(toggle_system_value),
+                menu_screens=self.MENU_SCREENS,
+                open_ports_prefs=open_ports_prefs,
+                click_data=click_data,
                 is_geo_enabled=self._is_geo_enabled(snapshot),
                 missing_geo_screen=self.SCR_MISSING_GEO_DB,
-            )
-            if close_decision is not None:
-                return _apply_modal_state(close_decision.modal_state)
-            
-            show_system = self._toggle_on(toggle_system_value)
-            screen_change = decide_screen_change(
-                trigger=trigger,
-                is_open=is_open,
-                current_screen=current_screen if isinstance(current_screen, str) else None,
-                show_system=show_system,
-                action=action,
-                menu_screens=self.MENU_SCREENS,
-                open_ports_prefs=(
-                    open_ports_prefs_data
-                    if isinstance(open_ports_prefs_data, dict)
-                    else None
-                ),
-            )
-            
-            now_iso = datetime.now().isoformat()
-            if screen_change is not None:
-                next_state = {
-                    "screen": screen_change["screen"],
-                    "t": now_iso,
-                    "payload": screen_change.get("payload", {}),
-                }
-                return _apply_modal_state(next_state)
-
-            if trigger == "btn_open_data":
-                if isinstance(open_data_clicks, int) and open_data_clicks >= 1:
-                    open_folder(Path(geo_path))
-                return no_update, no_update, no_update, no_update
-
-            map_decision = decide_map_click(
-                trigger=trigger,
-                click_data=click_data,
                 now_iso=now_iso,
             )
 
-            if map_decision is not None:
-                return _apply_modal_state(map_decision.modal_state)
+            # Execute the decided route.
+            if route.action == "apply":
+                return _apply_modal_state(route.modal_state)
+
+            if (
+                route.action == "open_data"
+                and isinstance(open_data_clicks, int)
+                and open_data_clicks >= 1
+            ):
+                open_folder(Path(geo_path))
+                # fall through to default no_update return
 
             return no_update, no_update, no_update, no_update
         


### PR DESCRIPTION
- Simplify modal_controller with local apply helper and cleaner flow
- Finalize callback signature order and remove dead logic
- Move routing priority into state layer via decide_modal_route
- Close About immediately when GeoIP recheck is requested (poll_model performs recheck)