### PR TITLE
Refactor: Decouple map view from config

### DIFF
--- a/tapmap.py
+++ b/tapmap.py
@@ -89,7 +89,7 @@ class TapMap:
             suppress_callback_exceptions=True,
         )
 
-        self.ui = MapUI(debug=self.DEBUG_COORDS)
+        self.ui = MapUI(zoom_near_km=ZOOM_NEAR_KM, debug=self.DEBUG_COORDS)
         self.view_builder = CacheViewBuilder(
             coord_precision=COORD_PRECISION,
             debug=self.DEBUG_COORDS,

--- a/ui/map_view.py
+++ b/ui/map_view.py
@@ -13,8 +13,6 @@ from typing import Final, TypeAlias
 
 import plotly.graph_objects as go
 
-from config import ZOOM_NEAR_KM
-
 LonLat: TypeAlias = tuple[float, float]
 PointSets: TypeAlias = tuple[list[LonLat], list[LonLat]]  # (targets, my_location)
 CustomData: TypeAlias = dict[str, object]
@@ -249,7 +247,8 @@ class MapUI:
 
     EARTH_RADIUS_KM: Final[float] = 6371.0
 
-    def __init__(self, debug: bool = False) -> None:
+    def __init__(self, *, zoom_near_km: float, debug: bool = False) -> None:
+        self.zoom_near_km = zoom_near_km
         self.debug = debug
         self.logger = logging.getLogger(__name__)
 
@@ -329,7 +328,7 @@ class MapUI:
                         targets[j],
                         radius_km=self.EARTH_RADIUS_KM,
                     )
-                    <= ZOOM_NEAR_KM
+                    <= self.zoom_near_km
                 ):
                     zoom_flags[i] = True
                     zoom_flags[j] = True


### PR DESCRIPTION
Changes
- Remove config import from ui.map_view
- Add zoom_near_km parameter to MapUI
- Pass ZOOM_NEAR_KM from tapmap controller when creating MapUI
Behavior
No functional changes. Map rendering, clustering and coloring behave exactly as before.
Test
- Start TapMap
- Verify map renders normally
- Verify nearby targets still turn yellow within the same distance threshold
- Verify connection lines render as before