### PR TITLE
Docs: generate documentation home page from README.md

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,24 +11,26 @@ from typing import Final, Literal
 
 LocationMode = Literal["auto", "none"]
 
-# Local map marker options:
-# - (lon, lat): fixed manual coordinates
-# - "auto": approximate location based on public IP
-# - "none": disable local marker
-# MY_LOCATION: Final[tuple[float, float] | LocationMode] = (11.3421, 59.5950)
-MY_LOCATION: Final[tuple[float, float] | LocationMode] = "auto"
-# MY_LOCATION: Final[tuple[float, float] | LocationMode] = "none"
 
+MY_LOCATION: Final[tuple[float, float] | LocationMode] = "auto"
+"""Local map marker options:
+- (lon, lat): fixed manual coordinates
+- "auto": approximate location based on public IP
+- "none": disable local marker
+"""
 
 # Configure polling interval and map behavior.
-
-# Interval between model snapshots and cache updates.
 POLL_INTERVAL_MS: Final[int] = 5_000
+"""Interval between model snapshots and cache updates."""
 
-# Decimal precision used when grouping services into map markers.
-# 3 corresponds to approximately 100 m precision.
 COORD_PRECISION: Final[int] = 3
+"""Decimal precision used when grouping services into map markers.
 
-# Distance threshold in kilometers for marking locations as nearby.
-# Locations within this distance are shown in yellow.
+3 corresponds to approximately 100 m precision.
+"""
+
 ZOOM_NEAR_KM: Final[float] = 25.0
+"""Distance threshold in kilometers for marking locations as far.
+
+Locations within this distance are shown in yellow.
+"""

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,1 @@
-# TapMap documentation
-
-Welcome to the TapMap documentation.
-cd..
+--8<-- "README.md"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,6 +3,11 @@ site_name: TapMap
 theme:
   name: material
 
+markdown_extensions:
+  - pymdownx.snippets:
+      base_path:
+        - ..
+
 plugins:
   - search
   - gen-files:

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,7 @@
+"""Snapshot building and data shaping for TapMap.
+
+Modules in this package build structured snapshot payloads
+from network data.
+
+They contain no UI rendering or state transition logic.
+"""

--- a/model/model.py
+++ b/model/model.py
@@ -1,3 +1,9 @@
+"""Snapshot building logic and payload definitions.
+
+Provide the typed payload structures returned from Model.snapshot()
+and the Model class that builds one live snapshot from network data.
+"""
+
 from __future__ import annotations
 
 import ipaddress
@@ -54,10 +60,7 @@ class SnapshotPayload(TypedDict):
 
 
 class Model:
-    """Build a live snapshot for the UI.
-
-    Treat as stateless; caching and aggregation over time occur in the UI.
-    """
+    """Build one live snapshot from current network data."""
 
     INTERNET_TARGETS: Final[tuple[tuple[str, int], ...]] = (
         ("1.1.1.1", 53),

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import mkdocs_gen_files
 
 ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_ROOT = Path("reference")
+README_PATH = ROOT / "README.md"
+INDEX_PATH = Path("index.md")
 
 EXCLUDE_DIRS = {
     ".venv",
@@ -13,31 +16,63 @@ EXCLUDE_DIRS = {
     "tools",
 }
 
-nav = mkdocs_gen_files.Nav()
+
+def iter_python_files(root: Path) -> list[Path]:
+    """Return Python files to document."""
+    files: list[Path] = []
+
+    for path in sorted(root.rglob("*.py")):
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        files.append(path)
+
+    return files
 
 
-for path in sorted(ROOT.rglob("*.py")):
-    if any(part in EXCLUDE_DIRS for part in path.parts):
-        continue
+def write_home_page() -> None:
+    """Write docs home page from README.md."""
+    content = README_PATH.read_text(encoding="utf-8")
+    content = content.replace("(docs/images/", "(images/")
+    content = content.replace('src="docs/images/', 'src="images/')
 
-    module_path = path.relative_to(ROOT).with_suffix("")
-    parts = module_path.parts
+    with mkdocs_gen_files.open(INDEX_PATH, "w") as file:
+        file.write(content)
 
-    if parts[-1] == "__init__":
-        module_name = ".".join(parts[:-1])
-        doc_rel_path = Path(*parts[:-1], "index.md")
-        nav_parts = parts[:-1]
-    else:
-        module_name = ".".join(parts)
-        doc_rel_path = Path(*parts).with_suffix(".md")
-        nav_parts = parts
 
-    doc_path = Path("reference", doc_rel_path)
-    nav[nav_parts] = doc_rel_path.as_posix()
+def write_reference_page(doc_path: Path, module_name: str) -> None:
+    """Write one generated API reference page."""
+    with mkdocs_gen_files.open(doc_path, "w") as file:
+        file.write(f"# `{module_name}`\n\n")
+        file.write(f"::: {module_name}\n")
+        file.write("    options:\n")
+        file.write("      members: true\n")
 
-    with mkdocs_gen_files.open(doc_path, "w") as f:
-        f.write(f"# `{module_name}`\n\n")
-        f.write(f"::: {module_name}\n")
 
-with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
-    nav_file.writelines(nav.build_literate_nav())
+def main() -> None:
+    """Build generated docs pages."""
+    nav = mkdocs_gen_files.Nav()
+
+    write_home_page()
+
+    for path in iter_python_files(ROOT):
+        module_path = path.relative_to(ROOT).with_suffix("")
+        parts = module_path.parts
+
+        if parts[-1] == "__init__":
+            module_name = ".".join(parts[:-1])
+            doc_rel_path = Path(*parts[:-1], "index.md")
+            nav_parts = parts[:-1]
+        else:
+            module_name = ".".join(parts)
+            doc_rel_path = Path(*parts).with_suffix(".md")
+            nav_parts = parts
+
+        doc_path = REFERENCE_ROOT / doc_rel_path
+        nav[nav_parts] = doc_rel_path.as_posix()
+        write_reference_page(doc_path, module_name)
+
+    with mkdocs_gen_files.open(REFERENCE_ROOT / "SUMMARY.md", "w") as nav_file:
+        nav_file.writelines(nav.build_literate_nav())
+
+
+main()


### PR DESCRIPTION
Changes
- build_docs.py now generates index.md from README.md
- rewrite image paths for MkDocs rendering
- add module docstrings for the model package
- convert config comments to constant docstrings

Result
- README and docs share the same content
- images render correctly in both GitHub and MkDocs
- API docs include module descriptions