### PR TITLE
Docs: add docs requirements workflow

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,9 @@
+mkdocs>=1.6.1
+mkdocs-autorefs>=1.4.4
+mkdocs-gen-files>=0.6.0
+mkdocs-get-deps>=0.2.0
+mkdocs-literate-nav>=0.6.2
+mkdocs-material>=9.7.4
+mkdocs-material-extensions>=1.3.1
+mkdocstrings>=1.0.3
+mkdocstrings-python>=2.0.3

--- a/tools/mkdocsreq.ps1
+++ b/tools/mkdocsreq.ps1
@@ -1,0 +1,11 @@
+# Generate docs-requirements.txt with MkDocs packages.
+# Run from project root:
+#     powershell -ExecutionPolicy Bypass -File tools/mkdocsreq.ps1
+
+$root = Split-Path -Parent $PSScriptRoot
+
+Set-Location $root
+
+pip freeze | Select-String '^mkdocs' | ForEach-Object { $_.Line } | Set-Content docs-requirements.txt
+
+Write-Host "docs-requirements.txt generated in $root"


### PR DESCRIPTION
Add docs-requirements.txt and script for generating it.
Test:
Generated docs-requirements.txt with the script.
mkdocs build runs successfully.