### PR TITLE
Fix: configurable server port via config and TAPMAP_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,25 @@ TapMap runs locally and opens in your browser.
 
 The web interface runs on a local server at:
 
-```
-http://127.0.0.1:8050/
-```
+    http://127.0.0.1:8050/
 
 If it does not open automatically, enter the address manually in your browser.
 
+The default port is defined by `SERVER_PORT` in `config.py`.
+
+The port can be overridden using the environment variable `TAPMAP_PORT`.
+
+Examples:
+
+Linux / macOS:
+
+    TAPMAP_PORT=8060 python tapmap.py
+
+PowerShell:
+
+    $env:TAPMAP_PORT="8060"
+    python tapmap.py
+    
 ---
 
 ## GeoIP databases (required for map locations)
@@ -182,10 +195,15 @@ TapMap reads settings from `config.py`.
 
 Common settings:
 
-- `MY_LOCATION`  
-- `POLL_INTERVAL_MS`  
-- `COORD_PRECISION`  
-- `ZOOM_NEAR_KM`  
+- `SERVER_PORT`
+- `MY_LOCATION`
+- `POLL_INTERVAL_MS`
+- `COORD_PRECISION`
+- `ZOOM_NEAR_KM`
+
+`SERVER_PORT` defines the default port used by the local Dash server.
+
+The port can be overridden at runtime using the environment variable `TAPMAP_PORT`.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 from typing import Final, Literal
 
 # Configure local map marker behavior.
-
 LocationMode = Literal["auto", "none"]
 
+# Configure local Dash server.
+SERVER_PORT: Final[int] = 8050
+"""HTTP port used by the local Dash server."""
 
 MY_LOCATION: Final[tuple[float, float] | LocationMode] = "auto"
 """Local map marker options:

--- a/tapmap.py
+++ b/tapmap.py
@@ -21,6 +21,7 @@ requires one return value. For example, modal_controller returns:
 from __future__ import annotations
 
 import logging
+import os
 import platform
 import sys
 import threading
@@ -32,7 +33,7 @@ from typing import Any, ClassVar, Final
 from dash import Dash, Input, Output, State, ctx, html, no_update
 
 from app_dirs import open_folder
-from config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
+from config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, SERVER_PORT, ZOOM_NEAR_KM
 from model.geoinfo import GeoInfo
 from model.model import Model
 from model.netinfo import NetInfo
@@ -245,6 +246,7 @@ class TapMap:
     def _build_app_info(self) -> dict[str, Any]:
         return {
             "version": self.ctx.meta.version,
+            "server_port": int(os.getenv("TAPMAP_PORT", str(SERVER_PORT))),
             "poll_interval_ms": POLL_INTERVAL_MS,
             "coord_precision": COORD_PRECISION,
             "zoom_near_km": ZOOM_NEAR_KM,
@@ -705,7 +707,7 @@ class TapMap:
     def run(self) -> None:
         """Start the Dash server and launch the local UI."""
         host = "127.0.0.1"
-        port = 8050
+        port = int(os.getenv("TAPMAP_PORT", str(SERVER_PORT)))
         url = f"http://{host}:{port}/"
         self._open_browser(url)
 

--- a/ui/about_view.py
+++ b/ui/about_view.py
@@ -30,6 +30,7 @@ def render_about(
         if isinstance(info, dict):
             app_info = info
 
+    server_port = app_info.get("server_port")
     poll_ms = app_info.get("poll_interval_ms")
     coord_precision = app_info.get("coord_precision")
     near_km = app_info.get("zoom_near_km")
@@ -64,6 +65,7 @@ def render_about(
         ("Name", app_name),
         ("Version", app_version),
         ("Author", app_author),
+        ("Server port", str(server_port) if isinstance(server_port, int) else "-"),
         ("Poll interval", f"{poll_ms} ms" if isinstance(poll_ms, int) else "-"),
         ("Coord precision", str(coord_precision) if coord_precision is not None else "-"),
         ("Near distance", f"{near_km} km" if isinstance(near_km, (int, float)) else "-"),

--- a/ui/help_view.py
+++ b/ui/help_view.py
@@ -446,6 +446,16 @@ def render_help() -> list[Any]:
                     [
                         html.Tr(
                             [
+                                html.Td("SERVER_PORT"),
+                                html.Td(
+                                    "Default port used by the local Dash server. "
+                                    "Can be overridden at startup using the "
+                                    "TAPMAP_PORT environment variable."
+                                ),
+                            ]
+                        ),
+                        html.Tr(
+                            [
                                 html.Td("MY_LOCATION"),
                                 html.Td(
                                     "'none' hides the local marker. Use (lon, lat) for fixed "


### PR DESCRIPTION
Changes
- Add SERVER_PORT to config.py
- Allow override via TAPMAP_PORT environment variable
- Show active port in About view
- Document configuration in README and Help
Test
- Default start on port 8050
- config.py changed to another port
- TAPMAP_PORT override verified in PowerShell