### PR TITLE
Fix: support TAPMAP_HOST with Docker-aware default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENV TAPMAP_PORT=8050
-ENV TAPMAP_HOST=127.0.0.1
+ENV TAPMAP_HOST=0.0.0.0
 ENV TAPMAP_DATA_DIR=/data
 
 EXPOSE 8050

--- a/README.md
+++ b/README.md
@@ -263,9 +263,17 @@ Place the GeoLite2 database files in:
 
     docker compose -f compose.linux.yaml up --build
 
-Open in browser:
+The server binds to 0.0.0.0 by default in Docker.
+
+Override in compose if needed:
+
+    TAPMAP_HOST: "127.0.0.1"
+
+Open in browser on the host:
 
     http://127.0.0.1:8050
+
+If you access the app from another machine, use the host IP address instead.
 
 ### Notes
 
@@ -299,9 +307,17 @@ Place the GeoLite2 database files in that folder:
       -e TAPMAP_IN_DOCKER=1 \
       olalie/tapmap:latest
 
-Open in browser:
+The server binds to 0.0.0.0 by default in Docker.
+
+To override the bind address:
+
+    -e TAPMAP_HOST=127.0.0.1
+
+Open in browser on the host:
 
     http://127.0.0.1:8050
+
+If you access the app from another machine, use the host IP address instead.
 
 ### Notes
 

--- a/compose.linux.yaml
+++ b/compose.linux.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       TAPMAP_IN_DOCKER: "1"
       TAPMAP_PORT: "8050"
-      TAPMAP_HOST: "127.0.0.1"
+      TAPMAP_HOST: "0.0.0.0"
       TAPMAP_DATA_DIR: /data
 
     volumes:

--- a/runtime.py
+++ b/runtime.py
@@ -57,9 +57,16 @@ def _get_app_data_dir(meta: AppMeta) -> Path:
 
     return ensure_native_app_data_dir(meta.name)
 
-def _get_server_host() -> str:
+def _get_server_host(is_docker: bool) -> str:
     """Return server bind host for the current runtime."""
-    return os.environ.get("TAPMAP_HOST", "127.0.0.1")
+    host = os.environ.get("TAPMAP_HOST")
+    if host:
+        return host
+
+    if is_docker:
+        return "0.0.0.0"
+
+    return "127.0.0.1"
 
 def _get_server_port() -> int:
     """Return server port for the current runtime."""
@@ -78,9 +85,9 @@ def build_runtime(meta: AppMeta) -> RuntimeContext:
 
     app_data_dir = _get_app_data_dir(meta)
     net_backend, net_backend_version = _detect_network_backend()
-    server_host = _get_server_host()
-    server_port = _get_server_port()
     is_docker = _detect_docker()
+    server_host = _get_server_host(is_docker)
+    server_port = _get_server_port()
 
     return RuntimeContext(
         meta=meta,

--- a/ui/about_view.py
+++ b/ui/about_view.py
@@ -31,6 +31,8 @@ def render_about(
         if isinstance(info, dict):
             app_info = info
 
+    server_host_val = app_info.get("server_host")
+    server_host = server_host_val if isinstance(server_host_val, str) else "-"
     server_port = app_info.get("server_port")
     poll_ms = app_info.get("poll_interval_ms")
     coord_precision = app_info.get("coord_precision")
@@ -89,6 +91,8 @@ def render_about(
         ("Python", py_text),
         ("Network backend", net_backend),
         ("Backend version", net_backend_version),
+        ("Server host", server_host),
+        ("Docker", "Yes" if is_docker else "No"),
     ]
 
     return [


### PR DESCRIPTION
Add support for configuring server bind host via TAPMAP_HOST.

Changes:
- runtime: resolve host with priority
  1. TAPMAP_HOST if set
  2. 0.0.0.0 when TAPMAP_IN_DOCKER=1
  3. 127.0.0.1 otherwise
- Dockerfile and compose: set default host to 0.0.0.0
- About view: show server host and Docker status
- README: document Docker bind behavior and override

Test:
- Run locally: host = 127.0.0.1, app reachable via localhost
- Run in Docker: host = 0.0.0.0, app reachable via host IP
- Override TAPMAP_HOST and verify behavior