### PR TITLE
add cap_add SYS_PTACE to enable reading of process names

### DIFF
--- a/compose.linux.yaml
+++ b/compose.linux.yaml
@@ -17,3 +17,6 @@ services:
       - ./docker-data:/data
 
     restart: unless-stopped
+    
+    cap_add:
+      - SYS_PTRACE


### PR DESCRIPTION
adding`SYS_PTRACE` cap to the container enables it to read the porcess names without having to run the stack as `privileged: true`