### PR TITLE
Test: add coverage and standardize socket family values

### DIFF
--- a/model/netinfo_lsof.py
+++ b/model/netinfo_lsof.py
@@ -40,7 +40,8 @@ class LsofNetInfo:
 
             command = self._decode_lsof_text(parts[0])
             pid = self._safe_int(parts[1])
-            family = self._socket_family(parts[4])
+            value = parts[4]
+            family = value if value in ("IPv4", "IPv6") else None
             proto = parts[7].lower()
             socket_type = self._socket_type(proto)
             name_field = " ".join(parts[8:])
@@ -180,15 +181,6 @@ class LsofNetInfo:
         return None
 
     @staticmethod
-    def _socket_family(value: str) -> str | None:
-        """Map lsof TYPE to OS address family code (psutil-compatible)."""
-        if value == "IPv4":
-            return "2"  # AF_INET
-        if value == "IPv6":
-            return "30"  # AF_INET6 on macOS
-        return None
-
-    @staticmethod
     def _socket_type(proto: str) -> str | None:
         """Return psutil-like socket type code from protocol."""
         if proto == "tcp":
@@ -262,7 +254,7 @@ class LsofNetInfo:
         if value is None:
             return None
         if value == "*":
-            if family == "10":
+            if family == "IPv6":
                 return "::"
             return "0.0.0.0"
         return value

--- a/model/netinfo_psutil.py
+++ b/model/netinfo_psutil.py
@@ -112,10 +112,9 @@ class PsutilNetInfo:
             except (OSError, RuntimeError):
                 return None
 
-        with proc.oneshot():
-            name = read(proc.name)
-            exe = read(proc.exe)
-            cmdline = read(proc.cmdline)
+        name = read(proc.name)
+        exe = read(proc.exe)
+        cmdline = read(proc.cmdline)
 
         if isinstance(name, str) and name:
             info = ProcessInfo(

--- a/model/netinfo_psutil.py
+++ b/model/netinfo_psutil.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 from collections.abc import Callable
 from typing import Any
 
@@ -44,7 +45,7 @@ class PsutilNetInfo:
                         "pid": pid,
                         "proto": proto,
                         "status": conn.status or "NONE",
-                        "family": str(conn.family).replace("AddressFamily.", ""),
+                        "family": self._socket_family(conn.family),
                         "type": str(conn.type).replace("SocketKind.", ""),
                         "laddr_ip": l_ip,
                         "laddr_port": l_port,
@@ -141,3 +142,12 @@ class PsutilNetInfo:
             return addr.ip, addr.port
         except AttributeError:
             return addr[0], addr[1]
+    
+    @staticmethod   
+    def _socket_family(family):
+        if family == socket.AF_INET:
+            return "IPv4"
+        if family == socket.AF_INET6:
+            return "IPv6"
+        return None
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ version = "1.4.3"
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+per-file-ignores = { "tests/*" = ["D101", "D102", "D103"] }
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/tests/test_geoinfo.py
+++ b/tests/test_geoinfo.py
@@ -1,0 +1,262 @@
+"""Test GeoInfo lookup, enrichment, and cache behavior."""
+
+from pathlib import Path
+
+import model.geoinfo as geoinfo
+from model.geoinfo import GeoInfo
+
+
+class FakeReader:
+    """Provide a minimal MaxMind reader stub."""
+
+    def __init__(self, mapping):
+        self._mapping = mapping
+        self.calls = []
+        self.closed = False
+
+    def get(self, ip):
+        """Return mapped value for IP."""
+        self.calls.append(ip)
+        return self._mapping.get(ip)
+
+    def close(self):
+        """Mark reader as closed."""
+        self.closed = True
+
+
+def test_lookup_returns_empty_result_for_empty_ip(tmp_path: Path) -> None:
+    """Verify empty IP returns an empty lookup result."""
+    geo = GeoInfo(tmp_path)
+
+    assert geo.lookup("") == {
+        "lat": None,
+        "lon": None,
+        "city": None,
+        "country": None,
+        "asn": None,
+        "asn_org": None,
+    }
+
+
+def test_lookup_combines_city_and_asn_data(monkeypatch, tmp_path: Path) -> None:
+    """Verify lookup merges city and ASN fields into one result."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    asn_db = tmp_path / GeoInfo.ASN_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+    asn_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader(
+        {
+            "203.0.113.10": {
+                "location": {"latitude": 59.91, "longitude": 10.75},
+                "city": {"names": {"en": "Oslo"}},
+                "country": {"names": {"en": "Norway"}},
+            }
+        }
+    )
+    asn_reader = FakeReader(
+        {
+            "203.0.113.10": {
+                "autonomous_system_number": 64500,
+                "autonomous_system_organization": "Example Networks",
+            }
+        }
+    )
+
+    def fake_open_database(path):
+        if path == city_db:
+            return city_reader
+        if path == asn_db:
+            return asn_reader
+        raise AssertionError(f"Unexpected database path: {path}")
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", fake_open_database)
+
+    geo = GeoInfo(tmp_path)
+
+    assert geo.city_enabled is True
+    assert geo.asn_enabled is True
+    assert geo.enabled is True
+
+    result = geo.lookup("203.0.113.10")
+
+    assert result == {
+        "lat": 59.91,
+        "lon": 10.75,
+        "city": "Oslo",
+        "country": "Norway",
+        "asn": 64500,
+        "asn_org": "Example Networks",
+    }
+
+
+def test_lookup_uses_cache_for_repeated_ip(monkeypatch, tmp_path: Path) -> None:
+    """Verify repeated lookup uses cached result."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader(
+        {
+            "203.0.113.20": {
+                "location": {"latitude": 60.0, "longitude": 11.0},
+                "city": {"names": {"en": "Test City"}},
+                "country": {"names": {"en": "Test Country"}},
+            }
+        }
+    )
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", lambda path: city_reader)
+
+    geo = GeoInfo(tmp_path)
+
+    first = geo.lookup("203.0.113.20")
+    second = geo.lookup("203.0.113.20")
+
+    assert first == second
+    assert city_reader.calls == ["203.0.113.20"]
+
+
+def test_enrich_updates_connections_in_place(monkeypatch, tmp_path: Path) -> None:
+    """Verify enrich updates connection dictionaries in place."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    asn_db = tmp_path / GeoInfo.ASN_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+    asn_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader(
+        {
+            "203.0.113.30": {
+                "location": {"latitude": 51.5, "longitude": -0.1},
+                "city": {"names": {"en": "London"}},
+                "country": {"names": {"en": "United Kingdom"}},
+            }
+        }
+    )
+    asn_reader = FakeReader(
+        {
+            "203.0.113.30": {
+                "autonomous_system_number": 64530,
+                "autonomous_system_organization": "Example ISP",
+            }
+        }
+    )
+
+    def fake_open_database(path):
+        if path == city_db:
+            return city_reader
+        if path == asn_db:
+            return asn_reader
+        raise AssertionError(f"Unexpected database path: {path}")
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", fake_open_database)
+
+    geo = GeoInfo(tmp_path)
+
+    connections = [
+        {"raddr_ip": "203.0.113.30", "proto": "tcp"},
+        {"raddr_ip": "", "proto": "tcp"},
+        {"proto": "udp"},
+        "not-a-dict",
+    ]
+
+    result = geo.enrich(connections)
+
+    assert result is connections
+    assert connections[0]["lat"] == 51.5
+    assert connections[0]["lon"] == -0.1
+    assert connections[0]["city"] == "London"
+    assert connections[0]["country"] == "United Kingdom"
+    assert connections[0]["asn"] == 64530
+    assert connections[0]["asn_org"] == "Example ISP"
+    assert "lat" not in connections[1]
+    assert "lat" not in connections[2]
+
+
+def test_close_closes_open_readers(monkeypatch, tmp_path: Path) -> None:
+    """Verify close closes readers and clears enabled state."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    asn_db = tmp_path / GeoInfo.ASN_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+    asn_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader({})
+    asn_reader = FakeReader({})
+
+    def fake_open_database(path):
+        if path == city_db:
+            return city_reader
+        if path == asn_db:
+            return asn_reader
+        raise AssertionError(f"Unexpected database path: {path}")
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", fake_open_database)
+
+    geo = GeoInfo(tmp_path)
+    geo.close()
+
+    assert city_reader.closed is True
+    assert asn_reader.closed is True
+    assert geo.city_enabled is False
+    assert geo.asn_enabled is False
+    assert geo.enabled is False
+
+
+def test_reload_reopens_readers(monkeypatch, tmp_path: Path) -> None:
+    """Verify reload closes and reopens database readers."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+
+    readers = [FakeReader({}), FakeReader({})]
+
+    def fake_open_database(path):
+        assert path == city_db
+        return readers.pop(0)
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", fake_open_database)
+
+    geo = GeoInfo(tmp_path)
+    first_reader = geo._city_reader
+
+    assert first_reader is not None
+    assert geo.reload() is True
+    assert first_reader.closed is True
+    assert geo._city_reader is not first_reader
+
+
+def test_cache_eviction_discards_oldest_entry(monkeypatch, tmp_path: Path) -> None:
+    """Verify cache evicts the least recently used entry."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader(
+        {
+            "203.0.113.1": {"location": {"latitude": 1.0, "longitude": 1.0}},
+            "203.0.113.2": {"location": {"latitude": 2.0, "longitude": 2.0}},
+            "203.0.113.3": {"location": {"latitude": 3.0, "longitude": 3.0}},
+        }
+    )
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", lambda path: city_reader)
+
+    geo = GeoInfo(tmp_path, cache_size=2)
+
+    geo.lookup("203.0.113.1")
+    geo.lookup("203.0.113.2")
+    geo.lookup("203.0.113.3")
+
+    assert list(geo._ip_cache.keys()) == ["203.0.113.2", "203.0.113.3"]
+
+
+def test_context_manager_closes_readers(monkeypatch, tmp_path: Path) -> None:
+    """Verify context manager closes readers on exit."""
+    city_db = tmp_path / GeoInfo.CITY_DB_NAME
+    city_db.write_text("", encoding="utf-8")
+
+    city_reader = FakeReader({})
+
+    monkeypatch.setattr(geoinfo.maxminddb, "open_database", lambda path: city_reader)
+
+    with GeoInfo(tmp_path) as geo:
+        assert geo.city_enabled is True
+
+    assert city_reader.closed is True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,85 @@
+"""Test classification helpers in model.Model."""
+
+from model.model import Model
+
+
+def test_service_scope_classifies_addresses() -> None:
+    """Verify service scope classification for common address types."""
+    assert Model._service_scope("127.0.0.1") == "LOCAL"
+    assert Model._service_scope("::1") == "LOCAL"
+    assert Model._service_scope("192.168.1.10") == "LAN"
+    assert Model._service_scope("fe80::1") == "LAN"
+    assert Model._service_scope("8.8.8.8") == "PUBLIC"
+    assert Model._service_scope(None) == "UNKNOWN"
+    assert Model._service_scope("bad-ip") == "UNKNOWN"
+
+
+def test_bind_scope_classifies_addresses() -> None:
+    """Verify bind scope classification for common bind addresses."""
+    assert Model._bind_scope("127.0.0.1") == "LOCAL"
+    assert Model._bind_scope("::1") == "LOCAL"
+    assert Model._bind_scope("192.168.1.10") == "LAN"
+    assert Model._bind_scope("fe80::1") == "LAN"
+    assert Model._bind_scope("8.8.8.8") == "PUBLIC"
+    assert Model._bind_scope("0.0.0.0") == "PUBLIC"
+    assert Model._bind_scope("::") == "PUBLIC"
+    assert Model._bind_scope(None) == "UNKNOWN"
+    assert Model._bind_scope("bad-ip") == "UNKNOWN"
+
+
+def test_is_map_candidate_requires_public_scope_and_coordinates() -> None:
+    """Verify map candidate classification requires PUBLIC scope and coordinates."""
+    assert (
+        Model._is_map_candidate(
+            {
+                "service_scope": "PUBLIC",
+                "lat": 59.91,
+                "lon": 10.75,
+            }
+        )
+        is True
+    )
+
+    assert (
+        Model._is_map_candidate(
+            {
+                "service_scope": "LAN",
+                "lat": 59.91,
+                "lon": 10.75,
+            }
+        )
+        is False
+    )
+
+    assert (
+        Model._is_map_candidate(
+            {
+                "service_scope": "PUBLIC",
+                "lat": None,
+                "lon": 10.75,
+            }
+        )
+        is False
+    )
+
+    assert (
+        Model._is_map_candidate(
+            {
+                "service_scope": "PUBLIC",
+                "lat": 59.91,
+                "lon": None,
+            }
+        )
+        is False
+    )
+
+    assert (
+        Model._is_map_candidate(
+            {
+                "service_scope": "UNKNOWN",
+                "lat": 59.91,
+                "lon": 10.75,
+            }
+        )
+        is False
+    )

--- a/tests/test_netinfo.py
+++ b/tests/test_netinfo.py
@@ -1,0 +1,50 @@
+"""Test backend selection and delegation in netinfo facade."""
+
+from model.netinfo import NetInfo
+
+
+def test_select_backend_windows_uses_psutil(monkeypatch) -> None:
+    """Verify Windows selects psutil backend."""
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+
+    from model.netinfo_psutil import PsutilNetInfo
+
+    netinfo = NetInfo()
+
+    assert isinstance(netinfo._backend, PsutilNetInfo)
+
+
+def test_select_backend_linux_uses_psutil(monkeypatch) -> None:
+    """Verify Linux selects psutil backend."""
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    from model.netinfo_psutil import PsutilNetInfo
+
+    netinfo = NetInfo()
+
+    assert isinstance(netinfo._backend, PsutilNetInfo)
+
+
+def test_select_backend_macos_uses_lsof(monkeypatch) -> None:
+    """Verify macOS selects lsof backend."""
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+
+    from model.netinfo_lsof import LsofNetInfo
+
+    netinfo = NetInfo()
+
+    assert isinstance(netinfo._backend, LsofNetInfo)
+
+
+def test_select_backend_raises_for_unsupported_os(monkeypatch) -> None:
+    """Verify unsupported OS raises error."""
+    monkeypatch.setattr("platform.system", lambda: "UnsupportedOS")
+
+    netinfo = NetInfo.__new__(NetInfo)
+
+    try:
+        netinfo._select_backend()
+    except NotImplementedError as exc:
+        assert "UnsupportedOS" in str(exc)
+    else:
+        raise AssertionError("Expected NotImplementedError")

--- a/tests/test_netinfo_lsof.py
+++ b/tests/test_netinfo_lsof.py
@@ -1,0 +1,106 @@
+"""Test normalization of lsof network connections."""
+
+from types import SimpleNamespace
+
+from model.netinfo_lsof import LsofNetInfo
+
+
+def test_lsof_ipv4_and_ipv6_normalized(monkeypatch) -> None:
+    """Verify IPv4 and IPv6 connections are normalized correctly."""
+    lsof_output = """COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
+ControlCenter 626 user 9u IPv4 0x0 0t0 TCP *:7000 (LISTEN)
+rapportd 709 user 22u IPv4 0x0 0t0 TCP 192.168.1.10:49152->192.168.1.20:52916 (ESTABLISHED)
+firefox 1070 user 31u IPv6 0x0 0t0 TCP [2a01::1]:49165->[2600::1]:80 (ESTABLISHED)
+firefox 1070 user 176u IPv6 0x0 0t0 UDP *:52569
+"""
+
+    ps_data = {
+        ("626", "comm="): "/System/ControlCenter",
+        ("626", "args="): "/System/ControlCenter",
+        ("709", "comm="): "/usr/libexec/rapportd",
+        ("709", "args="): "/usr/libexec/rapportd",
+        ("1070", "comm="): "/Applications/firefox",
+        ("1070", "args="): "/Applications/firefox",
+    }
+
+    def fake_run(cmd, capture_output, text, check):
+        if cmd[0] == "lsof":
+            return SimpleNamespace(stdout=lsof_output)
+
+        if cmd[0] == "ps":
+            pid = cmd[2]
+            field = cmd[4]
+            value = ps_data.get((pid, field), "")
+            return SimpleNamespace(stdout=value)
+
+        raise ValueError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    results = LsofNetInfo().get_data()
+
+    assert len(results) == 4
+
+    r = results[0]
+    assert r["pid"] == 626
+    assert r["proto"] == "tcp"
+    assert r["status"] == "LISTEN"
+    assert r["family"] == "IPv4"
+    assert r["type"] == "1"
+    assert r["laddr_ip"] == "0.0.0.0"
+    assert r["laddr_port"] == 7000
+    assert r["raddr_ip"] is None
+    assert r["raddr_port"] is None
+    assert r["process_status"] == "OK"
+    assert r["process_label"] == "ControlCenter"
+    assert r["process_name"] == "ControlCenter"
+    assert r["exe"] == "/System/ControlCenter"
+    assert r["cmdline"] == ["/System/ControlCenter"]
+
+    r = results[1]
+    assert r["pid"] == 709
+    assert r["proto"] == "tcp"
+    assert r["status"] == "ESTABLISHED"
+    assert r["family"] == "IPv4"
+    assert r["type"] == "1"
+    assert r["laddr_ip"] == "192.168.1.10"
+    assert r["laddr_port"] == 49152
+    assert r["raddr_ip"] == "192.168.1.20"
+    assert r["raddr_port"] == 52916
+    assert r["process_status"] == "OK"
+    assert r["process_label"] == "rapportd"
+    assert r["process_name"] == "rapportd"
+    assert r["exe"] == "/usr/libexec/rapportd"
+    assert r["cmdline"] == ["/usr/libexec/rapportd"]
+
+    r = results[2]
+    assert r["pid"] == 1070
+    assert r["proto"] == "tcp"
+    assert r["status"] == "ESTABLISHED"
+    assert r["family"] == "IPv6"
+    assert r["type"] == "1"
+    assert r["laddr_ip"] == "2a01::1"
+    assert r["laddr_port"] == 49165
+    assert r["raddr_ip"] == "2600::1"
+    assert r["raddr_port"] == 80
+    assert r["process_status"] == "OK"
+    assert r["process_label"] == "firefox"
+    assert r["process_name"] == "firefox"
+    assert r["exe"] == "/Applications/firefox"
+    assert r["cmdline"] == ["/Applications/firefox"]
+
+    r = results[3]
+    assert r["pid"] == 1070
+    assert r["proto"] == "udp"
+    assert r["status"] == "NONE"
+    assert r["family"] == "IPv6"
+    assert r["type"] == "2"
+    assert r["laddr_ip"] == "::"
+    assert r["laddr_port"] == 52569
+    assert r["raddr_ip"] is None
+    assert r["raddr_port"] is None
+    assert r["process_status"] == "OK"
+    assert r["process_label"] == "firefox"
+    assert r["process_name"] == "firefox"
+    assert r["exe"] == "/Applications/firefox"
+    assert r["cmdline"] == ["/Applications/firefox"]

--- a/tests/test_netinfo_psutil.py
+++ b/tests/test_netinfo_psutil.py
@@ -1,0 +1,103 @@
+"""Test normalization of psutil network connections."""
+import socket
+from types import SimpleNamespace
+
+import psutil
+
+from model.netinfo_psutil import PsutilNetInfo
+
+
+class FakeProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+    def name(self) -> str:
+        return "app.exe"
+
+    def exe(self) -> str:
+        return r"C:\Program Files\App\app.exe"
+
+    def cmdline(self) -> list[str]:
+        return [r"C:\Program Files\App\app.exe", "--flag"]
+
+
+def test_psutil_normalizes_tcp_listen_ipv4(monkeypatch) -> None:
+    """Verify IPv4 connection is normalized correctly."""
+    raw_conn = SimpleNamespace(
+        pid=1001,
+        status="LISTEN",
+        family=socket.AF_INET,
+        type=socket.SOCK_STREAM,
+        laddr=SimpleNamespace(ip="127.0.0.1", port=8080),
+        raddr=(),
+    )
+
+    def fake_net_connections(kind: str):
+        if kind == "tcp":
+            return [raw_conn]
+        return []
+
+    monkeypatch.setattr(psutil, "net_connections", fake_net_connections)
+    monkeypatch.setattr(psutil, "Process", FakeProcess)
+
+    data = PsutilNetInfo().get_data()
+
+    assert data == [
+        {
+            "pid": 1001,
+            "proto": "tcp",
+            "status": "LISTEN",
+            "family": "IPv4",
+            "type": "1",
+            "laddr_ip": "127.0.0.1",
+            "laddr_port": 8080,
+            "raddr_ip": None,
+            "raddr_port": None,
+            "process_status": "OK",
+            "process_label": "app.exe",
+            "process_name": "app.exe",
+            "exe": r"C:\Program Files\App\app.exe",
+            "cmdline": [r"C:\Program Files\App\app.exe", "--flag"],
+        }
+    ]
+
+
+def test_psutil_normalizes_tcp_established_ipv6(monkeypatch) -> None:
+    """Verify IPv6 connection is normalized correctly."""
+    raw_conn = SimpleNamespace(
+        pid=2002,
+        status="ESTABLISHED",
+        family=socket.AF_INET6,
+        type=socket.SOCK_STREAM,
+        laddr=SimpleNamespace(ip="2001:db8::10", port=55000),
+        raddr=SimpleNamespace(ip="2001:db8::20", port=443),
+    )
+
+    def fake_net_connections(kind: str):
+        if kind == "tcp":
+            return [raw_conn]
+        return []
+
+    monkeypatch.setattr(psutil, "net_connections", fake_net_connections)
+    monkeypatch.setattr(psutil, "Process", FakeProcess)
+
+    data = PsutilNetInfo().get_data()
+
+    assert data == [
+        {
+            "pid": 2002,
+            "proto": "tcp",
+            "status": "ESTABLISHED",
+            "family": "IPv6",
+            "type": "1",
+            "laddr_ip": "2001:db8::10",
+            "laddr_port": 55000,
+            "raddr_ip": "2001:db8::20",
+            "raddr_port": 443,
+            "process_status": "OK",
+            "process_label": "app.exe",
+            "process_name": "app.exe",
+            "exe": r"C:\Program Files\App\app.exe",
+            "cmdline": [r"C:\Program Files\App\app.exe", "--flag"],
+        }
+    ]

--- a/tests/test_public_ip.py
+++ b/tests/test_public_ip.py
@@ -1,0 +1,105 @@
+"""Test public IP lookup helpers."""
+
+from urllib.error import URLError
+
+import model.public_ip as public_ip
+
+
+class FakeResponse:
+    """Provide a minimal urlopen response stub."""
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        """Return response body as bytes."""
+        return self._body.encode("utf-8")
+
+    def __enter__(self) -> "FakeResponse":
+        """Return context manager entry value."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        """Propagate exceptions from the context block."""
+        return False
+
+
+def test_iter_public_ip_candidates_yields_valid_addresses(monkeypatch) -> None:
+    """Verify valid IPv4 and IPv6 responses are yielded."""
+    responses = iter(
+        [
+            FakeResponse("203.0.113.10\n"),
+            FakeResponse("2001:db8::10\n"),
+        ]
+    )
+
+    monkeypatch.setattr(public_ip.ssl, "create_default_context", lambda cafile: object())
+    monkeypatch.setattr(public_ip.certifi, "where", lambda: "/fake/cacert.pem")
+    monkeypatch.setattr(public_ip, "IP_SERVICES", ("https://svc1", "https://svc2"))
+    monkeypatch.setattr(
+        public_ip,
+        "urlopen",
+        lambda request, timeout, context: next(responses),
+    )
+
+    result = list(public_ip.iter_public_ip_candidates())
+
+    assert result == ["203.0.113.10", "2001:db8::10"]
+
+
+def test_iter_public_ip_candidates_skips_errors_and_invalid_values(monkeypatch) -> None:
+    """Verify lookup skips failing and invalid responses."""
+    responses = iter(
+        [
+            URLError("boom"),
+            FakeResponse("not-an-ip\n"),
+            FakeResponse("203.0.113.20\n"),
+        ]
+    )
+
+    def fake_urlopen(request, timeout, context):
+        value = next(responses)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(public_ip.ssl, "create_default_context", lambda cafile: object())
+    monkeypatch.setattr(public_ip.certifi, "where", lambda: "/fake/cacert.pem")
+    monkeypatch.setattr(
+        public_ip,
+        "IP_SERVICES",
+        ("https://svc1", "https://svc2", "https://svc3"),
+    )
+    monkeypatch.setattr(public_ip, "urlopen", fake_urlopen)
+
+    result = list(public_ip.iter_public_ip_candidates())
+
+    assert result == ["203.0.113.20"]
+
+
+def test_get_public_ip_returns_first_valid_candidate(monkeypatch) -> None:
+    """Verify get_public_ip returns the first valid address."""
+    monkeypatch.setattr(
+        public_ip,
+        "iter_public_ip_candidates",
+        lambda timeout_s=public_ip.DEFAULT_TIMEOUT_S: iter(
+            ["203.0.113.30", "2001:db8::30"]
+        ),
+    )
+
+    result = public_ip.get_public_ip()
+
+    assert result == "203.0.113.30"
+
+
+def test_get_public_ip_returns_none_when_no_candidates(monkeypatch) -> None:
+    """Verify get_public_ip returns None when no address is found."""
+    monkeypatch.setattr(
+        public_ip,
+        "iter_public_ip_candidates",
+        lambda timeout_s=public_ip.DEFAULT_TIMEOUT_S: iter(()),
+    )
+
+    result = public_ip.get_public_ip()
+
+    assert result is None


### PR DESCRIPTION
## Summary
Add unit tests for netinfo backends, model classification, geoinfo and public IP utilities.

Also standardize socket family values across psutil and lsof backends.

Covers:
- psutil backend
- lsof backend
- netinfo facade backend selection
- model classification and aggregation helpers
- geoinfo lookup, enrich, cache and reload
- public IP lookup helpers

Changes:
- standardize family to IPv4 and IPv6 across psutil and lsof backends
- remove oneshot() in psutil backend to simplify testing
- ignore D101, D102 and D103 in tests for Ruff

## Test
- pytest -q
- 97 passed on Windows
