### PR TITLE
Chore: update actions and skip CI for docs changes

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yaml"
+      - "README.md"
+      - ".github/workflows/docs.yaml"
 
 jobs:
   build:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -43,6 +43,9 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update GitHub Actions and refine CI trigger.

Changes:
- Upgraded:
  - actions/upload-pages-artifact v4 to v5
  - actions/deploy-pages v4 to v5
- Added actions/configure-pages to docs workflow
- build-test.yaml no longer runs for docs-only changes

Test:
- CI executed
- No functional changes to the application