### PR TITLE
chore: skip CI for changelog updates

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,6 +9,7 @@ on:
       - "docs/**"
       - "mkdocs.yaml"
       - "README.md"
+      - "CHANGELOG.md"
       - ".github/workflows/docs.yaml"
 
 jobs:


### PR DESCRIPTION
Skip build-test workflow for changes to CHANGELOG.md.

- add CHANGELOG.md to paths-ignore

No functional changes.