### PR TITLE
chore(ci): fix docker latest tag publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,15 +195,22 @@ jobs:
           docker build -t tapmap:release .
           docker run --rm tapmap:release -v | grep -q "tapmap"
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: olalie/tapmap
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            olalie/tapmap:latest
-            olalie/tapmap:${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       # Finalize release
       # After this step the release becomes immutable


### PR DESCRIPTION
Fix Docker tagging to ensure latest is published correctly.

Test:
- Verified v1.6.0 missing correct latest tag
- Updated workflow to use docker/metadata-action
- Will verify via new release