### PR TITLE
fix(ci): build macos x86_64 binary for compatibility

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,8 +41,13 @@ jobs:
           pytest -q
 
       - name: Build (same as local)
+        shell: bash
         run: |
-          python tools/build.py
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            arch -x86_64 python tools/build.py
+          else
+            python tools/build.py
+          fi
 
       - name: Package artifact
         shell: bash

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -32,9 +32,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-tests.txt
-          pip install pyinstaller
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            arch -x86_64 python -m pip install --upgrade pip
+            arch -x86_64 python -m pip install -r requirements-tests.txt
+            arch -x86_64 python -m pip install pyinstaller
+          else
+            python -m pip install --upgrade pip
+            pip install -r requirements-tests.txt
+            pip install pyinstaller
+          fi
 
       - name: Run tests
         run: |

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,6 +31,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        shell: bash
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             arch -x86_64 python -m pip install --upgrade pip
@@ -43,8 +44,13 @@ jobs:
           fi
 
       - name: Run tests
+        shell: bash
         run: |
-          pytest -q
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            arch -x86_64 python -m pytest -q
+          else
+            pytest -q
+          fi
 
       - name: Build (same as local)
         shell: bash


### PR DESCRIPTION
Fixes macOS binary not running on Intel (bad CPU type).

CI now builds macOS artifact using x86_64 instead of arm64.

Test:
- CI builds macOS artifact
- To be tested on Intel Mac by reporter