### PR TITLE
feat(release): add macos arm64 and x86_64 builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        include:
+          - os: windows-latest
+            name: windows
+          - os: ubuntu-latest
+            name: linux
+          - os: macos-latest
+            name: macos-arm64
+            arch: arm64
+          - os: macos-latest
+            name: macos-x86_64
+            arch: x86_64
 
     steps:
       - name: Checkout
@@ -64,35 +74,54 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        shell: bash
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-tests.txt
-          pip install pyinstaller
+          if [[ "$RUNNER_OS" == "macOS" && "${{ matrix.arch }}" == "x86_64" ]]; then
+            arch -x86_64 python -m pip install --upgrade pip
+            arch -x86_64 python -m pip install -r requirements-tests.txt
+            arch -x86_64 python -m pip install pyinstaller
+          else
+            python -m pip install --upgrade pip
+            pip install -r requirements-tests.txt
+            pip install pyinstaller
+          fi
 
       - name: Run tests
+        shell: bash
         run: |
-          pytest -q
+          if [[ "$RUNNER_OS" == "macOS" && "${{ matrix.arch }}" == "x86_64" ]]; then
+            arch -x86_64 python -m pytest -q
+          else
+            pytest -q
+          fi
 
       - name: Build (same as local)
+        shell: bash
         run: |
-          python tools/build.py
+          if [[ "$RUNNER_OS" == "macOS" && "${{ matrix.arch }}" == "x86_64" ]]; then
+            arch -x86_64 python tools/build.py
+          else
+            python tools/build.py
+          fi
 
       - name: Package artifact
         shell: bash
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
           python - << 'PY'
           import os
           import zipfile
           from pathlib import Path
 
-          os_name = os.environ["RUNNER_OS"].lower()
+          name = os.environ["MATRIX_NAME"]
 
           dist = Path("dist")
-          exe = dist / ("tapmap.exe" if os_name == "windows" else "tapmap")
+          exe = dist / ("tapmap.exe" if name == "windows" else "tapmap")
           if not exe.exists():
               raise FileNotFoundError(f"Expected build output not found: {exe}")
 
-          out = Path(f"tapmap-{os_name}.zip")
+          out = Path(f"tapmap-{name}.zip")
 
           with zipfile.ZipFile(out, "w", compression=zipfile.ZIP_DEFLATED) as zf:
               zf.write(exe, exe.name)
@@ -108,9 +137,9 @@ jobs:
           import os
           from pathlib import Path
 
-          os_name = os.environ["RUNNER_OS"].lower()
+          name = os.environ["MATRIX_NAME"]
+          file = Path(f"tapmap-{name}.zip")
 
-          file = Path(f"tapmap-{os_name}.zip")
           if not file.exists():
               raise FileNotFoundError(file)
 
@@ -125,10 +154,10 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7
         with:
-          name: tapmap-${{ runner.os }}
+          name: tapmap-${{ matrix.name }}
           path: |
-            tapmap-${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}.zip
-            tapmap-${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}.zip.sha256
+            tapmap-${{ matrix.name }}.zip
+            tapmap-${{ matrix.name }}.zip.sha256
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
Add native macOS builds for both architectures.

- arm64 (Apple Silicon)
- x86_64 (Intel via Rosetta)

Clean up artifact naming and remove OS-based conditions.
Artifacts are now consistent between build and release.
