### PR TITLE
fix(release): add missing MATRIX_NAME env for sha256 step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,8 @@ jobs:
 
       - name: Create SHA256
         shell: bash
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
           python - << 'PY'
           import hashlib


### PR DESCRIPTION
Fix missing env variable in SHA256 step.

Ensures artifact naming works for all matrix builds.
------------------ >8 ------------------------

Please Enter the title on the first line and the body on subsequent lines.
Lines below dotted lines will be ignored, and an empty title aborts the creation process.