### PR TITLE
fix(modal): remove dead established state check

### DIFF
--- a/src/tapmap/model/model.py
+++ b/src/tapmap/model/model.py
@@ -244,9 +244,11 @@ class Model:
         local_address = self._format_local_address(l_ip, l_port)
 
         process_status = conn.get("process_status") or "Unavailable"
+        # Raw OS process name if available.
         process_name = conn.get("process_name") or None
         exe = conn.get("exe") or None
 
+        # User-facing display label with fallback semantics.
         if process_name:
             process_label = process_name
         elif process_status == "No process":
@@ -305,6 +307,10 @@ class Model:
             "lat": lat_value,
             "lon": lon_value,
             "pid": conn.get("pid"),
+            # CacheItem.process_name intentionally stores the display-oriented
+            # process label, not the raw backend process name. Cache items are
+            # used for UI aggregation, grouping, and summaries where fallback
+            # labels such as "System" are required.
             "process_name": conn.get("process_label"),
             "exe": conn.get("exe"),
             "cmdline": conn.get("cmdline"),

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -450,10 +450,8 @@ class ModalTextBuilder:
         cleaned: list[dict[str, Any]] = [r for r in rows if isinstance(r, dict)]
 
         def is_established_tcp(row: dict[str, Any]) -> bool:
-            state = row.get("state")
-            if isinstance(state, str) and state.strip() and state.strip().upper() != "ESTABLISHED":
-                return False
-
+            # CacheItem rows only contain ESTABLISHED TCP or remote UDP endpoints.
+            # The model pre-filters all other TCP states, so no explicit state check is needed here.
             proto = row.get("proto")
             return not (isinstance(proto, str) and proto.strip() and proto.strip().lower() != "tcp")
 


### PR DESCRIPTION
## Summary

Remove dead TCP state filtering in the LAN/LOCAL modal view.

The model already guarantees that `CacheItem` rows only contain:
- ESTABLISHED TCP connections
- remote UDP endpoints

Also add clarifying comments for `process_name` and `process_label` semantics.

## Testing

- Verified locally