### PR TITLE
refactor(menu): accordion-style grouped menu

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -75,7 +75,7 @@ class TapMap:
     """Coordinate Dash callbacks, model polling, and UI state."""
 
     MENU_SCREENS: ClassVar[frozenset[str]] = frozenset(
-        {"menu_unmapped", "menu_lan_local", "menu_open_ports", "menu_help", "menu_about"}
+        {"menu_unmapped", "menu_lan_local", "menu_open_ports", "menu_help", "menu_about", "menu_daily_report"}
     )
     MENU_COMMANDS: ClassVar[frozenset[str]] = frozenset(
         {"menu_clear_cache", "menu_cache_terminal", "menu_recheck_geoip"}
@@ -544,6 +544,7 @@ class TapMap:
             Input("menu_overlay", "n_clicks"),
             Input("key_action", "data"),
             Input("menu_insights", "n_clicks"),
+            Input("menu_daily_report", "n_clicks"),
             Input("menu_open_ports", "n_clicks"),
             Input("menu_unmapped", "n_clicks"),
             Input("menu_lan_local", "n_clicks"),
@@ -561,6 +562,7 @@ class TapMap:
             _overlay: int,
             key_action: Any,
             _insights: int,
+            _daily_report: int,
             _open_ports: int,
             _unmapped: int,
             _lan_local: int,
@@ -724,6 +726,28 @@ class TapMap:
                 # fall through to default no_update return
 
             return no_update, no_update, no_update, no_update
+
+        @self.app.callback(
+            Output("modal_state", "data", allow_duplicate=True),
+            Output("modal_overlay", "className", allow_duplicate=True),
+            Output("modal_body", "children", allow_duplicate=True),
+            Output("modal_body", "className", allow_duplicate=True),
+            Input("menu_daily_report", "n_clicks"),
+            State("model_snapshot", "data"),
+            State("ui_view", "data"),
+            prevent_initial_call=True,
+        )
+        def daily_report_controller(
+            _n_clicks: int,
+            snapshot: Any,
+            ui_view: Any,
+        ) -> tuple[Any, str, list[Any], str]:
+            geo_path = str(self.runtime.geo_data_dir)
+            now_iso = datetime.now().isoformat()
+            modal_state = {"screen": "menu_daily_report", "t": now_iso, "payload": {}}
+            children, body_class = self._render_modal(modal_state, snapshot, ui_view, geo_path)
+            overlay_class = self._modal_overlay_class(True)
+            return modal_state, overlay_class, children, body_class
 
         @self.app.callback(
             Output("open_ports_prefs", "data"),

--- a/src/tapmap/assets/keys.js
+++ b/src/tapmap/assets/keys.js
@@ -55,9 +55,25 @@
         return;
       }
 
-      if (k === "i" || k === "u" || k === "o" || k === "l" || k === "t" || k === "c" || k === "r" || k === "h" || k === "a") {
+      if (k === "i" || k === "u" || k === "o" || k === "l" || k === "t" || k === "c" || k === "r" || k === "h" || k === "a" || k === "d") {
         sendToken("__" + k + "__");
       }
+    },
+    true
+  );
+
+  // Enforce mutual exclusion: only one accordion section open at a time.
+  // Scoped to #menu_panel — ignores <details> elements elsewhere in the page.
+  document.addEventListener(
+    "toggle",
+    function (e) {
+      if (!e.target || e.target.tagName !== "DETAILS") return;
+      if (!e.target.open) return;
+      var panel = document.getElementById("menu_panel");
+      if (!panel || !panel.contains(e.target)) return;
+      panel.querySelectorAll("details.mx-acc-section").forEach(function (d) {
+        if (d !== e.target) d.open = false;
+      });
     },
     true
   );

--- a/src/tapmap/assets/styles.css
+++ b/src/tapmap/assets/styles.css
@@ -208,8 +208,56 @@ body {
   letter-spacing: 0.2px;
 }
 
-.mx-menu-group + .mx-menu-group {
-  margin-top: 20px;
+.mx-acc-section {
+  list-style: none;
+}
+
+.mx-acc-section + .mx-acc-section {
+  margin-top: 2px;
+}
+
+summary.mx-acc-header {
+  list-style: none;
+  cursor: pointer;
+  padding: 6px 10px;
+  color: var(--mx-green);
+  font-family: var(--mx-font);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  opacity: 0.6;
+  user-select: none;
+  border-radius: var(--mx-radius);
+  transition: opacity 80ms linear, background-color 80ms linear;
+}
+
+summary.mx-acc-header::-webkit-details-marker {
+  display: none;
+}
+
+summary.mx-acc-header::marker {
+  display: none;
+  content: "";
+}
+
+summary.mx-acc-header::before {
+  content: "\25B6  ";
+  font-size: 8px;
+  vertical-align: middle;
+}
+
+details[open] > summary.mx-acc-header::before {
+  content: "\25BC  ";
+}
+
+summary.mx-acc-header:hover {
+  opacity: 1;
+  background: var(--mx-bg-hover);
+}
+
+.mx-acc-body {
+  padding: 2px 0 4px 0;
 }
 
 /* Insights panel */

--- a/src/tapmap/state/keyboard.py
+++ b/src/tapmap/state/keyboard.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any
 
 KEY_MAP = {
+    "__d__": "menu_daily_report",
     "__i__": "menu_insights",
     "__u__": "menu_unmapped",
     "__l__": "menu_lan_local",

--- a/src/tapmap/ui/daily_activity_report_view.py
+++ b/src/tapmap/ui/daily_activity_report_view.py
@@ -1,0 +1,15 @@
+"""Daily Activity Report view rendering for the TapMap UI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dash import html
+
+
+def render_daily_activity_report() -> list[Any]:
+    """Render placeholder content for the Daily Activity Report modal."""
+    return [
+        html.H1("Daily Activity Report"),
+        html.P("Daily activity report is not yet available.", className="mx-note"),
+    ]

--- a/src/tapmap/ui/layout_view.py
+++ b/src/tapmap/ui/layout_view.py
@@ -92,31 +92,60 @@ def render_layout(
                 id="menu_panel",
                 className=menu_panel_class,
                 children=[
-                    html.Div(
+                    html.Details(
                         [
-                            _menu_button("Insights (I)", "menu_insights"),
-                        ],
-                        className="mx-menu-group",
-                    ),
-                    html.Div(
-                        [
-                            _menu_button("Show unmapped public services (U)", "menu_unmapped"),
-                            _menu_button(
-                                "Show established LAN/LOCAL services (L)", "menu_lan_local"
+                            html.Summary("Insights", className="mx-acc-header"),
+                            html.Div(
+                                [
+                                    _menu_button("Daily activity report (D)", "menu_daily_report"),
+                                    _menu_button("Insights panel (I)", "menu_insights"),
+                                ],
+                                className="mx-acc-body",
                             ),
-                            _menu_button("Show open ports (O)", "menu_open_ports"),
-                            _menu_button("Show cache in terminal (T)", "menu_cache_terminal"),
-                            _menu_button("Clear cache (C)", "menu_clear_cache"),
                         ],
-                        className="mx-menu-group",
+                        className="mx-acc-section",
+                        open=True,
                     ),
-                    html.Div(
+                    html.Details(
                         [
-                            _menu_button("Recheck GeoIP databases (R)", "menu_recheck_geoip"),
-                            _menu_button("Help (H)", "menu_help"),
-                            _menu_button("About (A)", "menu_about"),
+                            html.Summary("Network", className="mx-acc-header"),
+                            html.Div(
+                                [
+                                    _menu_button("Unmapped public services (U)", "menu_unmapped"),
+                                    _menu_button("LAN/LOCAL services (L)", "menu_lan_local"),
+                                    _menu_button("Open ports (O)", "menu_open_ports"),
+                                ],
+                                className="mx-acc-body",
+                            ),
                         ],
-                        className="mx-menu-group",
+                        className="mx-acc-section",
+                    ),
+                    html.Details(
+                        [
+                            html.Summary("Actions", className="mx-acc-header"),
+                            html.Div(
+                                [
+                                    _menu_button("Show cache in terminal (T)", "menu_cache_terminal"),
+                                    _menu_button("Clear cache (C)", "menu_clear_cache"),
+                                    _menu_button("Recheck GeoIP databases (R)", "menu_recheck_geoip"),
+                                ],
+                                className="mx-acc-body",
+                            ),
+                        ],
+                        className="mx-acc-section",
+                    ),
+                    html.Details(
+                        [
+                            html.Summary("Info", className="mx-acc-header"),
+                            html.Div(
+                                [
+                                    _menu_button("Help (H)", "menu_help"),
+                                    _menu_button("About (A)", "menu_about"),
+                                ],
+                                className="mx-acc-body",
+                            ),
+                        ],
+                        className="mx-acc-section",
                     ),
                 ],
             ),

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -11,6 +11,7 @@ from typing import Any
 from dash import dcc, html
 
 from .about_view import render_about
+from .daily_activity_report_view import render_daily_activity_report
 from .formatting import (
     port_from_local,
     pretty_bind_ip,
@@ -35,6 +36,7 @@ class ModalTextBuilder:
         self.app_author = app_author
 
         self._label_map: dict[str, str] = {
+            "menu_daily_report": "Daily Activity Report",
             "menu_unmapped": "Show unmapped public services",
             "menu_lan_local": "Show established LAN/LOCAL services",
             "menu_open_ports": "Show open ports",
@@ -63,6 +65,9 @@ class ModalTextBuilder:
         Returns:
             Dash components for the modal body.
         """
+        if action == "menu_daily_report":
+            return render_daily_activity_report()
+
         if action == "menu_unmapped":
             return self._render_unmapped(snapshot)
 


### PR DESCRIPTION
## Summary
Refactor the menu into an accordion-style grouped layout and prepare the UI structure for Daily Activity Report.

## Changes
- Replace flat menu groups with accordion sections
- Add grouped sections:
  - Insights
  - Network
  - Actions
  - Info
- Add keyboard shortcut:
  - D → Daily Activity Report
- Add placeholder Daily Activity Report modal
- Add `daily_activity_report_view.py`
- Add accordion mutual exclusion behavior in `keys.js`
- Keep Insights expanded by default
- Preserve existing menu actions and keyboard shortcuts

## Notes
- The actual Daily Activity Report implementation is not included yet
- All tests passing (97/97)