### PR TITLE
feat: add Daily Activity Report and insights log

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -21,6 +21,7 @@ requires one return value. For example, modal_controller returns:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import logging
 import platform
@@ -38,7 +39,9 @@ from tapmap.model.geoinfo import GeoInfo
 from tapmap.model.model import Model
 from tapmap.model.netinfo import NetInfo
 from tapmap.model.public_ip import iter_public_ip_candidates
+from tapmap.state.daily_report import build_report_data
 from tapmap.state.insights import process_insights
+from tapmap.state.insights_log import write_insights_log
 from tapmap.state.keyboard import build_key_action
 from tapmap.state.menu import compute_menu_open_state
 from tapmap.state.modal import decide_modal_route
@@ -53,12 +56,13 @@ from tapmap.state.poll import (
 from tapmap.state.status_cache import StatusCache
 from tapmap.state.status_line import render_status_text
 from tapmap.ui.cache_view import CacheViewBuilder
+from tapmap.ui.daily_activity_report_view import render_daily_activity_report
 from tapmap.ui.insights_view import render_insights_panel
 from tapmap.ui.layout_view import render_layout
 from tapmap.ui.map_view import MapUI
 from tapmap.ui.modal_view import ModalTextBuilder
 
-from .app_dirs import open_folder
+from .app_dirs import open_file, open_folder
 from .config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
 from .runtime import AppMeta, RuntimeContext, build_runtime
 
@@ -155,6 +159,7 @@ class TapMap:
         start_fig = self.ui.create_figure(([], self.my_location))
         self.app.layout = self._build_layout(start_fig)
         self._register_callbacks()
+        self._register_routes()
 
     # Layout helpers (CSS classes)
     @staticmethod
@@ -449,6 +454,19 @@ class TapMap:
                 return [], "modal-body"
             return self._as_children(body), "modal-body"
 
+        if screen == "menu_daily_report":
+            report = build_report_data(self.insights)
+            log_path = None
+            with contextlib.suppress(Exception):
+                log_path = write_insights_log(
+                    self.insights,
+                    self.insights_path.with_suffix(".log"),
+                )
+            return (
+                render_daily_activity_report(report, log_path=log_path),
+                self._class_for_modal_screen(screen),
+            )
+
         if screen in self.MENU_SCREENS:
             show_system = bool(payload.get("show_system", False))
             body = self.modal_text.for_action(
@@ -489,7 +507,7 @@ class TapMap:
             State("ui_cache", "data"),
             State("status_cache", "data"),
             State("status_flash", "data"),
-            prevent_initial_call=False,
+            prevent_initial_call=True,
         )
         def poll_model(
             tick_n: int,
@@ -865,6 +883,20 @@ class TapMap:
                 snapshot.get("cache_items", []),
                 self.insights,
                 now,
+            )
+
+    def _register_routes(self) -> None:
+        """Register Flask routes."""
+        from flask import Response
+
+        @self.app.server.route("/open-log")
+        def _open_log_route() -> Response:
+            if not self.runtime.is_docker:
+                open_file(self.insights_path.with_suffix(".log"))
+            return Response(
+                b"<html><head><title>TapMap</title></head>"
+                b"<body onload=\"window.close()\">&#10003;</body></html>",
+                mimetype="text/html",
             )
 
     def run(self) -> None:

--- a/src/tapmap/app_dirs.py
+++ b/src/tapmap/app_dirs.py
@@ -103,3 +103,38 @@ def open_folder(path: Path) -> tuple[bool, str]:
 
     except Exception as exc:
         return False, f"Failed to open folder: {path}. Error: {exc}"
+
+
+def open_file(path: Path) -> tuple[bool, str]:
+    """Open path with the system default application."""
+    try:
+        path = path.expanduser()
+        if not path.is_file():
+            return False, f"File not found: {path}"
+
+        system = platform.system()
+
+        if system == "Windows":
+            os.startfile(str(path))
+            return True, f"Opened: {path}"
+
+        if system == "Darwin":
+            subprocess.Popen(["open", str(path)])
+            return True, f"Opened: {path}"
+
+        xdg_open = shutil.which("xdg-open")
+        if not xdg_open:
+            return False, "xdg-open is not available on this system."
+
+        cp = subprocess.run([xdg_open, str(path)], capture_output=True, text=True, check=False)
+        if cp.returncode == 0:
+            return True, f"Opened: {path}"
+
+        detail = (cp.stderr or cp.stdout or "").strip()
+        msg = "xdg-open failed."
+        if detail:
+            msg += f" {detail}"
+        return False, msg
+
+    except Exception as exc:
+        return False, f"Failed to open file: {path}. Error: {exc}"

--- a/src/tapmap/assets/styles.css
+++ b/src/tapmap/assets/styles.css
@@ -89,6 +89,17 @@ body {
   text-shadow: 0 0 10px rgba(0, 255, 102, 0.18);
 }
 
+#key_capture {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  z-index: 1000;
+  pointer-events: none;
+}
+
 /* Buttons */
 
 .mx-btn {
@@ -150,11 +161,9 @@ body {
   white-space: nowrap;
 }
 
-.mx-btn--floating {
-  position: absolute;
-  right: 48px;
-  bottom: 16px;
-  z-index: 5;
+a.mx-btn {
+  display: inline-block;
+  text-decoration: none;
 }
 
 /* Menu */
@@ -198,14 +207,6 @@ body {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
-}
-
-.mx-panel__title {
-  margin: 0 0 8px 0;
-  color: var(--mx-green);
-  font-size: 14px;
-  opacity: 0.9;
-  letter-spacing: 0.2px;
 }
 
 .mx-acc-section {
@@ -334,26 +335,6 @@ summary.mx-acc-header:hover {
   opacity: 0.8;
 }
 
-.insights-details {
-  margin-top: 4px;
-  margin-left: 29px;
-  font-size: 12px;
-}
-.insights-detail-row {
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
-}
-.insights-label {
-  flex: 0 0 85px;
-  opacity: 0.55;
-}
-
-.insights-value {
-  flex: 1;
-  opacity: 0.70;
-}
-
 /* Cells */
 .insights-flag {
   flex: 0 0 21px;
@@ -371,16 +352,6 @@ summary.mx-acc-header:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.insights-ip {
-  flex: 1 1 auto;
-  min-width: 85px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  opacity: 0.85;
 }
 
 /* Modal */
@@ -663,6 +634,43 @@ summary.mx-acc-header:hover {
   letter-spacing: 0.2px;
   opacity: 0.96;
   user-select: none;
+}
+
+/* Daily Activity Report */
+
+.rpt-h2 {
+  margin-top: 32px;
+}
+
+.rpt-recurrence {
+  margin-top: 16px;
+  margin-left: 140px;
+}
+
+.rpt-cat-label {
+  display: inline-block;
+  min-width: 140px;
+  color: #00e85c;
+  font-weight: bold;
+  font-size: 11px;
+}
+
+.rpt-day-strip {
+  letter-spacing: 1px;
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.rpt-day--on {
+  color: rgba(0, 220, 88, 0.80);
+  text-shadow: none;
+  -webkit-text-stroke: 0px;
+}
+
+.rpt-day--off {
+  color: rgba(0, 185, 72, 0.70);
+  text-shadow: none;
+  -webkit-text-stroke: 0.6px rgba(0, 185, 72, 0.90);
 }
 
 /* Reduced motion */

--- a/src/tapmap/assets/styles.css
+++ b/src/tapmap/assets/styles.css
@@ -89,15 +89,11 @@ body {
   text-shadow: 0 0 10px rgba(0, 255, 102, 0.18);
 }
 
-#key_capture {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  z-index: 1000;
-  pointer-events: none;
+/* key_capture input: hide the Dash-generated container entirely.
+   keys.js uses the native value setter + a dispatched input event,
+   so the element does not need to be visible or focusable. */
+.app > .dash-input-container.dash-input {
+  display: none !important;
 }
 
 /* Buttons */

--- a/src/tapmap/state/daily_report.py
+++ b/src/tapmap/state/daily_report.py
@@ -1,0 +1,459 @@
+"""Daily activity report analytics for TapMap.
+
+Pure computation layer: insights data in → DailyReportData out.
+No Dash, no Plotly, no I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+NUMBER_WORDS = {
+    0: "zero",
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+    10: "ten",
+}
+
+MIN_RELIABLE_HISTORY_DAYS = 7
+HISTORY_WINDOW_DAYS = 30
+MIN_APPENDIX_HISTORY_DAYS = 8
+
+OCCASIONAL_RATIO = 8 / 30
+STABLE_RATIO = 21 / 30
+STABLE_ACTIVITY_THRESHOLD = 0.70
+VARIABLE_ACTIVITY_THRESHOLD = 0.45
+PROVIDER_HIGH_CONCENTRATION_THRESHOLD = 0.10
+PROVIDER_MODERATE_CONCENTRATION_THRESHOLD = 0.25
+
+# One per recurrence category: (category_name, example_name_or_None, day_strip_or_None)
+RecurrenceExample = tuple[str, str | None, list[bool] | None]
+
+
+class ProviderConcentration(TypedDict):
+    total_providers: int
+    cumulative_pcts: list[float]
+
+
+class CountryMapPoint(TypedDict):
+    lat: float
+    lon: float
+    active_days: int
+    code: str
+
+
+class DailyReportData(TypedDict):
+    history_days: int
+    intro_text: str
+    today_text: str
+    activity_pattern_text: str
+    # applications
+    application_total: int
+    application_counts: dict[str, int]
+    recurrence_labels: dict[str, str]
+    recurrence_examples: list[RecurrenceExample]
+    applications_summary: str
+    # providers
+    provider_concentration: ProviderConcentration
+    providers_summary: str
+    # countries
+    country_total: int
+    countries_summary: str
+    country_map_points: list[CountryMapPoint]
+
+
+def format_count(value: int) -> str:
+    """Return human-readable count string."""
+    return NUMBER_WORDS.get(value, str(value))
+
+
+def count_history_days(bitmask: int) -> int:
+    """Return observed history length from leftmost set bit."""
+    return bitmask.bit_length()
+
+
+def get_max_history_days(insights: dict[str, Any]) -> int:
+    """Return maximum observed history across all insight categories."""
+    categories = ["countries", "providers", "ports", "applications"]
+    max_days = 0
+    for category in categories:
+        for item in insights.get(category, {}).values():
+            bitmask = item.get("m")
+            if isinstance(bitmask, int):
+                max_days = max(max_days, count_history_days(bitmask))
+    return max_days
+
+
+def count_new_today(state: dict[str, dict[str, Any]]) -> int:
+    """Return number of entries observed for the first time today."""
+    return sum(1 for item in state.values() if item.get("m") == 1)
+
+
+def classify_recurrence(active_days: int, history_days: int) -> str:
+    """Return recurrence category from active day count."""
+    if active_days == 1:
+        return "Seen once"
+    ratio = active_days / history_days
+    if ratio < OCCASIONAL_RATIO:
+        return "Occasional"
+    if ratio < STABLE_RATIO:
+        return "Recurring"
+    return "Stable"
+
+
+def build_recurrence_labels(history_days: int) -> dict[str, str]:
+    """Return display labels derived from actual category bins."""
+    bins: dict[str, list[int]] = {
+        cat: [] for cat in ("Stable", "Recurring", "Occasional", "Seen once")
+    }
+    for d in range(1, history_days + 1):
+        bins[classify_recurrence(d, history_days)].append(d)
+    labels: dict[str, str] = {}
+    for cat, days in bins.items():
+        if not days:
+            labels[cat] = cat
+        elif days[0] == days[-1]:
+            n = days[0]
+            labels[cat] = f"{cat} ({n} day{'s' if n > 1 else ''})"
+        else:
+            labels[cat] = f"{cat} ({days[0]}\u2013{days[-1]} days)"
+    return labels
+
+
+def build_recurrence_counts(
+    state: dict[str, dict[str, Any]],
+    history_days: int = HISTORY_WINDOW_DAYS,
+) -> dict[str, int]:
+    """Return recurrence category counts."""
+    counts: dict[str, int] = {
+        "Stable": 0,
+        "Recurring": 0,
+        "Occasional": 0,
+        "Seen once": 0,
+    }
+    for item in state.values():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int):
+            continue
+        active_days = bitmask.bit_count()
+        if active_days == 0:
+            continue
+        counts[classify_recurrence(active_days, history_days)] += 1
+    return counts
+
+
+def build_recurrence_examples(
+    state: dict[str, dict[str, Any]],
+    history_days: int,
+) -> list[RecurrenceExample]:
+    """Return one (category, name, day-strip) per recurrence category."""
+    categories = ["Stable", "Recurring", "Occasional", "Seen once"]
+    found: dict[str, tuple[str, int] | None] = {cat: None for cat in categories}
+    for name, item in state.items():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int) or bitmask.bit_count() == 0:
+            continue
+        cat = classify_recurrence(bitmask.bit_count(), history_days)
+        if found[cat] is None:
+            found[cat] = (name, bitmask)
+        if all(v is not None for v in found.values()):
+            break
+    result: list[RecurrenceExample] = []
+    for cat in categories:
+        entry = found[cat]
+        if entry is None:
+            result.append((cat, None, None))
+        else:
+            name, bitmask = entry
+            days = [
+                bool((bitmask >> i) & 1)
+                for i in range(HISTORY_WINDOW_DAYS - 1, -1, -1)
+            ]
+            result.append((cat, name, days))
+    return result
+
+
+def build_today_text(insights: dict[str, Any]) -> str:
+    """Return summary of newly observed activity today."""
+    new_items = [
+        {
+            "count": count_new_today(insights.get("applications", {})),
+            "singular": "app",
+            "plural": "apps",
+        },
+        {
+            "count": count_new_today(insights.get("providers", {})),
+            "singular": "provider",
+            "plural": "providers",
+        },
+        {
+            "count": count_new_today(insights.get("countries", {})),
+            "singular": "country",
+            "plural": "countries",
+        },
+    ]
+    total_new = sum(item["count"] for item in new_items)
+
+    if total_new == 0:
+        return "No new apps, providers or countries appeared today."
+
+    active = [item for item in new_items if item["count"] > 0]
+    parts = [
+        (
+            f"{format_count(item['count'])} new "
+            f"{item['singular'] if item['count'] == 1 else item['plural']}"
+        )
+        for item in active
+    ]
+    parts[0] = parts[0].capitalize()
+
+    if len(parts) == 1:
+        summary = parts[0]
+    elif len(parts) == 2:
+        summary = f"{parts[0]} and {parts[1]}"
+    else:
+        summary = f"{', '.join(parts[:-1])} and {parts[-1]}"
+
+    return f"{summary} appeared today. See details in the Insights panel."
+
+
+def compute_activity_days_fraction(
+    state: dict[str, dict[str, Any]],
+    history_days: int,
+) -> float:
+    """Return fraction of total entity-days from Stable+Recurring entities."""
+    recurring_days = 0
+    total_days = 0
+    for item in state.values():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int):
+            continue
+        active = bitmask.bit_count()
+        if active == 0:
+            continue
+        total_days += active
+        if classify_recurrence(active, history_days) in ("Stable", "Recurring"):
+            recurring_days += active
+    return recurring_days / total_days if total_days > 0 else 0.0
+
+
+def build_activity_pattern(
+    app_state: dict[str, dict[str, Any]],
+    country_state: dict[str, dict[str, Any]],
+    history_days: int,
+) -> str:
+    """Return global behavioral pattern summary, or empty string if insufficient history."""
+    if history_days < MIN_RELIABLE_HISTORY_DAYS:
+        return ""
+    app_fraction = compute_activity_days_fraction(app_state, history_days)
+    country_fraction = compute_activity_days_fraction(country_state, history_days)
+    core_fraction = (app_fraction + country_fraction) / 2
+    if core_fraction >= STABLE_ACTIVITY_THRESHOLD:
+        return (
+            "Most recurring internet activity remained centered "
+            "around a stable everyday pattern."
+        )
+    if core_fraction < VARIABLE_ACTIVITY_THRESHOLD:
+        return (
+            "Internet activity varied considerably over time, "
+            "with many connections appearing only intermittently."
+        )
+    return (
+        "Internet activity showed a steady mix of recurring "
+        "and occasional patterns throughout the observed history."
+    )
+
+
+def build_intro_text(history_days: int) -> str:
+    """Return summary of available connection history."""
+    history_days_text = format_count(history_days)
+    if history_days < MIN_RELIABLE_HISTORY_DAYS:
+        day_label = (
+            "one day"
+            if history_days == 1
+            else f"the last {history_days_text} days"
+        )
+        return (
+            f"TapMap currently has connection data from only {day_label}. "
+            "The report will become more reliable with more history."
+        )
+    if history_days >= HISTORY_WINDOW_DAYS:
+        return "TapMap is currently using a rolling 30-day activity window."
+    return f"TapMap now has {history_days_text} days of connection history."
+
+
+def build_applications_summary(
+    application_total: int,
+    counts: dict[str, int],
+) -> str:
+    """Return applications summary text."""
+    application_label = "application" if application_total == 1 else "applications"
+    application_total_text = format_count(application_total)
+    frequent = counts["Stable"] + counts["Recurring"]
+    total = frequent + counts["Occasional"] + counts["Seen once"]
+    fraction = frequent / total if total > 0 else 0.0
+
+    if fraction < 0.33:
+        distribution_text = (
+            "Most appeared only briefly or for the first time. "
+            "Some ran consistently throughout the period."
+        )
+    elif fraction <= 0.66:
+        distribution_text = (
+            "Some apps ran consistently throughout the period. "
+            "Many others appeared only occasionally or briefly."
+        )
+    else:
+        distribution_text = (
+            "Many apps ran consistently throughout the period. "
+            "Others appeared only occasionally or briefly."
+        )
+
+    return (
+        f"{application_total_text.capitalize()} "
+        f"{application_label} used the internet during this period. "
+        "Some were applications you used directly. "
+        f"Others were background services running on your system. "
+        f"{distribution_text}"
+    )
+
+
+def build_provider_concentration(
+    state: dict[str, dict[str, Any]],
+) -> ProviderConcentration:
+    """Return sorted cumulative activity percentages for provider concentration curve."""
+    provider_days = sorted(
+        (
+            item["m"].bit_count()
+            for item in state.values()
+            if isinstance(item.get("m"), int) and item["m"].bit_count() > 0
+        ),
+        reverse=True,
+    )
+    if not provider_days:
+        return ProviderConcentration(total_providers=0, cumulative_pcts=[])
+    total_days = sum(provider_days)
+    cumulative = 0
+    cumulative_pcts: list[float] = []
+    for days in provider_days:
+        cumulative += days
+        cumulative_pcts.append(cumulative / total_days * 100)
+    return ProviderConcentration(
+        total_providers=len(provider_days),
+        cumulative_pcts=cumulative_pcts,
+    )
+
+
+def build_providers_summary(concentration: ProviderConcentration) -> str:
+    """Return providers concentration summary text."""
+    total = concentration["total_providers"]
+    if total == 0:
+        return "No provider activity was recorded during this period."
+    total_text = format_count(total)
+    provider_label = "provider" if total == 1 else "providers"
+    return (
+        f"{total_text.capitalize()} {provider_label} were observed. "
+        "These are the network operators at the destinations used by your applications. "
+        "A single app may use several."
+    )
+
+
+def build_providers_concentration_narrative(concentration: ProviderConcentration) -> str:
+    """Return narrative sentence describing provider concentration."""
+    total = concentration["total_providers"]
+    if total == 0:
+        return ""
+    cumulative_pcts = concentration["cumulative_pcts"]
+    top_50_count = next(
+        (i + 1 for i, pct in enumerate(cumulative_pcts) if pct >= 50.0),
+        total,
+    )
+    provider_50_fraction = top_50_count / total
+    if provider_50_fraction <= PROVIDER_HIGH_CONCENTRATION_THRESHOLD:
+        return (
+            "Most observed activity was handled by "
+            "a relatively small group of providers."
+        )
+    if provider_50_fraction <= PROVIDER_MODERATE_CONCENTRATION_THRESHOLD:
+        return (
+            "Much of the observed activity was handled by a smaller "
+            "established group of providers, alongside a broader set "
+            "of occasional ones."
+        )
+    return "Observed activity was distributed across a broad range of providers."
+
+
+def build_countries_summary(country_total: int) -> str:
+    """Return countries summary text."""
+    country_total_text = format_count(country_total)
+    return (
+        f"Applications on your computer connected to systems "
+        f"in {country_total_text} different countries."
+    )
+
+
+def _build_country_map_points(
+    country_state: dict[str, dict[str, Any]],
+) -> list[CountryMapPoint]:
+    """Return map point data for all observed countries with known centroids."""
+    from tapmap.ui.country_centers import get_center  # deferred to avoid import cycle
+
+    points: list[CountryMapPoint] = []
+    for code, item in country_state.items():
+        try:
+            lat, lon = get_center(code)
+        except KeyError:
+            continue
+        bitmask = item.get("m", 0)
+        active_days = bitmask.bit_count() if isinstance(bitmask, int) else 0
+        if active_days == 0:
+            continue
+        points.append(CountryMapPoint(lat=lat, lon=lon, active_days=active_days, code=code))
+    return points
+
+
+def build_report_data(insights: dict[str, Any]) -> DailyReportData:
+    """Compute DailyReportData from the insights state."""
+    history_days = get_max_history_days(insights)
+
+    app_state = insights.get("applications", {})
+    country_state = insights.get("countries", {})
+    provider_state = insights.get("providers", {})
+
+    recurrence_labels = build_recurrence_labels(history_days)
+    application_counts = build_recurrence_counts(app_state, history_days)
+    application_total = sum(application_counts.values())
+
+    concentration = build_provider_concentration(provider_state)
+    providers_narrative = build_providers_concentration_narrative(concentration)
+    providers_full_summary = (
+        build_providers_summary(concentration)
+        + (f" {providers_narrative}" if providers_narrative else "")
+    )
+
+    country_counts = build_recurrence_counts(country_state, history_days)
+    country_total = sum(country_counts.values())
+
+    return DailyReportData(
+        history_days=history_days,
+        intro_text=build_intro_text(history_days),
+        today_text=build_today_text(insights),
+        activity_pattern_text=build_activity_pattern(app_state, country_state, history_days),
+        application_total=application_total,
+        application_counts=application_counts,
+        recurrence_labels=recurrence_labels,
+        recurrence_examples=build_recurrence_examples(app_state, history_days),
+        applications_summary=build_applications_summary(application_total, application_counts),
+        provider_concentration=concentration,
+        providers_summary=providers_full_summary,
+        country_total=country_total,
+        countries_summary=build_countries_summary(country_total),
+        country_map_points=_build_country_map_points(country_state),
+    )

--- a/src/tapmap/state/insights_log.py
+++ b/src/tapmap/state/insights_log.py
@@ -1,0 +1,303 @@
+"""Insights log writer for TapMap.
+
+Writes a fixed-width ASCII companion log alongside insights.json.
+No ANSI escape codes.
+"""
+
+from __future__ import annotations
+
+import datetime
+import math
+import socket
+from pathlib import Path
+from typing import Any
+
+import pycountry
+
+from tapmap.state.daily_report import (
+    HISTORY_WINDOW_DAYS,
+    OCCASIONAL_RATIO,
+    STABLE_RATIO,
+    classify_recurrence,
+    get_max_history_days,
+)
+
+WIDTH = 86
+MAX_LABEL_WIDTH = 36
+BOX_FILLED = "\u25a0"
+BOX_EMPTY = "\u25a1"
+
+
+def _country_label(code: str) -> str:
+    country = pycountry.countries.get(alpha_2=code)
+    if country:
+        return f"{country.name} ({code})"
+    return code
+
+
+def _port_service_name(port: str) -> str | None:
+    if int(port) >= 1024:
+        return None
+    for proto in ("tcp", "udp"):
+        try:
+            name = socket.getservbyport(int(port), proto)
+            if name:
+                return name.upper()
+        except OSError:
+            pass
+    return None
+
+
+def _timeline(bitmask: int) -> str:
+    """Return a 30-character timeline string, oldest on the left."""
+    bits = [
+        BOX_FILLED if (bitmask >> i) & 1 else BOX_EMPTY
+        for i in range(HISTORY_WINDOW_DAYS - 1, -1, -1)
+    ]
+    return "[" + "".join(bits) + "]"
+
+
+def _active_days(bitmask: int) -> int:
+    return bitmask.bit_count()
+
+
+def _entry_line(label: str, bitmask: int) -> str:
+    if len(label) > MAX_LABEL_WIDTH:
+        label = label[: MAX_LABEL_WIDTH - 1] + "\u2026"
+    days = _active_days(bitmask)
+    timeline = _timeline(bitmask)
+    day_count = f"{days:>2}/{HISTORY_WINDOW_DAYS} days"
+    padded_label = f"- {label:<{MAX_LABEL_WIDTH}}"
+    return f"{padded_label}  {timeline}  {day_count}"
+
+
+def _divider(char: str = "-") -> str:
+    return char * WIDTH
+
+
+def _header(title: str, char: str = "=") -> str:
+    return f"{char * WIDTH}\n  {title}\n{char * WIDTH}"
+
+
+def _section_header(title: str) -> str:
+    return f"{_divider()}\n  {title}\n{_divider()}"
+
+
+def _coverage_boundary(sorted_days: list[int], threshold: float) -> int:
+    total = sum(sorted_days)
+    if total == 0:
+        return 0
+    target = total * threshold
+    cumulative = 0
+    for i, d in enumerate(sorted_days, start=1):
+        cumulative += d
+        if cumulative >= target:
+            return i
+    return len(sorted_days)
+
+
+def _build_applications_section(
+    state: dict[str, dict[str, Any]],
+    history_days: int,
+) -> list[str]:
+    lines: list[str] = []
+    categories = ["Stable", "Recurring", "Occasional", "Seen once"]
+    grouped: dict[str, list[tuple[str, int]]] = {c: [] for c in categories}
+
+    for name, item in state.items():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int) or bitmask.bit_count() == 0:
+            continue
+        cat = classify_recurrence(bitmask.bit_count(), history_days)
+        grouped[cat].append((name, bitmask))
+
+    for cat in categories:
+        grouped[cat].sort(key=lambda x: (-_active_days(x[1]), x[0]))
+
+    stable_min = math.ceil(STABLE_RATIO * history_days)
+    recurring_min = math.ceil(OCCASIONAL_RATIO * history_days)
+    category_labels = {
+        "Stable": f"Stable ({stable_min}-{history_days} days)",
+        "Recurring": f"Recurring ({recurring_min}-{stable_min - 1} days)",
+        "Occasional": f"Occasional (2-{recurring_min - 1} days)",
+        "Seen once": "Seen once (1 day)",
+    }
+
+    for cat in categories:
+        entries = grouped[cat]
+        if not entries:
+            continue
+        lines.append(f"  {category_labels[cat]}")
+        lines.append("")
+        for name, bitmask in entries:
+            lines.append("  " + _entry_line(name, bitmask))
+        lines.append("")
+
+    if lines and lines[-1] == "":
+        lines.pop()
+
+    return lines
+
+
+def _build_providers_section(state: dict[str, dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    entries: list[tuple[str, int]] = []
+
+    for name, item in state.items():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int) or bitmask.bit_count() == 0:
+            continue
+        entries.append((name, bitmask))
+
+    entries.sort(key=lambda x: (-_active_days(x[1]), x[0]))
+    sorted_days = [_active_days(bitmask) for _, bitmask in entries]
+    top_50 = _coverage_boundary(sorted_days, 0.50)
+    top_80 = _coverage_boundary(sorted_days, 0.80)
+
+    one_day_tail: list[tuple[str, int]] = []
+    for i, (name, bitmask) in enumerate(entries):
+        rank = i + 1
+        active = _active_days(bitmask)
+        if active == 1 and rank > top_80:
+            one_day_tail.append((name, bitmask))
+            continue
+        lines.append("  " + _entry_line(name, bitmask))
+        if rank == top_50:
+            lines.append("")
+            lines.append(
+                f"  -- 50% of activity covered by top {top_50} of {len(entries)} providers"
+            )
+            lines.append("")
+        if rank == top_80 and top_80 != top_50:
+            lines.append("")
+            lines.append(
+                f"  -- 80% of activity covered by top {top_80} of {len(entries)} providers"
+            )
+            lines.append("")
+
+    if one_day_tail:
+        lines.append("")
+        lines.append(f"  -- One-day providers ({len(one_day_tail)} entries)")
+        lines.append("")
+        for name, bitmask in one_day_tail:
+            lines.append("  " + _entry_line(name, bitmask))
+
+    lines.append("")
+    lines.append(
+        f"  Coverage:  50% -> top {top_50}   |   80% -> top {top_80}   |   100% -> {len(entries)}"
+    )
+    return lines
+
+
+def _build_countries_section(state: dict[str, dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    entries: list[tuple[str, int]] = []
+
+    for code, item in state.items():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int) or bitmask.bit_count() == 0:
+            continue
+        entries.append((code, bitmask))
+
+    entries.sort(key=lambda x: (-_active_days(x[1]), x[0]))
+    labels = {code: _country_label(code) for code, _ in entries}
+    sorted_days = [_active_days(bitmask) for _, bitmask in entries]
+    top_50 = _coverage_boundary(sorted_days, 0.50)
+    top_80 = _coverage_boundary(sorted_days, 0.80)
+
+    for i, (code, bitmask) in enumerate(entries):
+        rank = i + 1
+        lines.append("  " + _entry_line(labels[code], bitmask))
+        if rank == top_50:
+            lines.append("")
+            lines.append(
+                f"  -- 50% of activity covered by top {top_50} of {len(entries)} countries"
+            )
+            lines.append("")
+        if rank == top_80 and top_80 != top_50:
+            lines.append("")
+            lines.append(
+                f"  -- 80% of activity covered by top {top_80} of {len(entries)} countries"
+            )
+            lines.append("")
+
+    lines.append("")
+    lines.append(
+        f"  Coverage:  50% -> top {top_50}   |   80% -> top {top_80}   |   100% -> {len(entries)}"
+    )
+    return lines
+
+
+def _build_ports_section(state: dict[str, dict[str, Any]]) -> list[str]:
+    lines: list[str] = []
+    entries: list[tuple[str, int]] = []
+
+    for port, item in state.items():
+        bitmask = item.get("m")
+        if not isinstance(bitmask, int) or bitmask.bit_count() == 0:
+            continue
+        entries.append((port, bitmask))
+
+    entries.sort(key=lambda x: (-_active_days(x[1]), int(x[0])))
+
+    def _port_label(port: str) -> str:
+        name = _port_service_name(port)
+        return f"{port} ({name})" if name else port
+
+    for port, bitmask in entries:
+        lines.append("  " + _entry_line(_port_label(port), bitmask))
+
+    return lines
+
+
+def write_insights_log(
+    insights: dict[str, Any],
+    log_path: Path,
+) -> Path:
+    """Write a plain-text insights log to log_path and return the path."""
+    history_days = min(get_max_history_days(insights), HISTORY_WINDOW_DAYS)
+    generated_at = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    lines: list[str] = []
+    lines.append(_header("TAPMAP INSIGHTS LOG"))
+    lines.append("")
+    lines.append(f"  Generated : {generated_at}")
+    lines.append(f"  Window    : {HISTORY_WINDOW_DAYS} days shown  ({history_days} days with data)")
+    lines.append("")
+    lines.append(
+        f"  Legend : {BOX_FILLED} Active day   {BOX_EMPTY} No activity   "
+        "Timeline: oldest left, today right"
+    )
+    lines.append("")
+
+    app_entries = insights.get("applications", {})
+    lines.append(_section_header(f"1. APPLICATIONS  ({len(app_entries)})"))
+    lines.append("")
+    lines.extend(_build_applications_section(app_entries, history_days))
+    lines.append("")
+
+    country_entries = insights.get("countries", {})
+    lines.append(_section_header(f"2. COUNTRIES  ({len(country_entries)})"))
+    lines.append("")
+    lines.extend(_build_countries_section(country_entries))
+    lines.append("")
+
+    port_entries = insights.get("ports", {})
+    lines.append(_section_header(f"3. PORTS  ({len(port_entries)})"))
+    lines.append("")
+    lines.extend(_build_ports_section(port_entries))
+    lines.append("")
+
+    prov_entries = insights.get("providers", {})
+    lines.append(_section_header(f"4. PROVIDERS  ({len(prov_entries)})"))
+    lines.append("")
+    lines.extend(_build_providers_section(prov_entries))
+    lines.append("")
+
+    lines.append(_divider("="))
+    lines.append("  End of TapMap Insights Log")
+    lines.append(_divider("="))
+    lines.append("")
+
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+    return log_path

--- a/src/tapmap/ui/daily_activity_report_view.py
+++ b/src/tapmap/ui/daily_activity_report_view.py
@@ -2,14 +2,348 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
-from dash import html
+import plotly.graph_objects as go
+from dash import dcc, html
+
+from tapmap.state.daily_report import (
+    HISTORY_WINDOW_DAYS,
+    MIN_APPENDIX_HISTORY_DAYS,
+    DailyReportData,
+)
+
+_MONO = (
+    "ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace"
+)
 
 
-def render_daily_activity_report() -> list[Any]:
-    """Render placeholder content for the Daily Activity Report modal."""
+def _build_applications_figure(
+    application_counts: dict[str, int],
+) -> go.Figure:
+    categories = list(application_counts.keys())
+    values = list(application_counts.values())
+
+    fig = go.Figure(
+        go.Bar(
+            x=values,
+            y=categories,
+            orientation="h",
+            marker_color="rgba(0,160,68,0.55)",
+            marker_line_color="rgba(0,80,30,0.9)",
+            marker_line_width=2,
+        )
+    )
+    fig.update_layout(
+        paper_bgcolor="#020602",
+        plot_bgcolor="#010401",
+        font=dict(family=_MONO, color="#00ff66"),
+        height=320,
+        margin=dict(l=140, r=40, t=20, b=40),
+        yaxis=dict(
+            automargin=True,
+            ticklabelstandoff=20,
+            gridcolor="rgba(0,170,68,0.15)",
+            tickcolor="#00ff66",
+            fixedrange=True,
+        ),
+        xaxis=dict(
+            title="Number of applications",
+            showgrid=True,
+            gridcolor="rgba(0,170,68,0.35)",
+            gridwidth=1,
+            zerolinecolor="rgba(0,170,68,0.5)",
+            tickcolor="#00ff66",
+            fixedrange=True,
+        ),
+    )
+    return fig
+
+
+def _build_concentration_figure(
+    total_providers: int,
+    cumulative_pcts: list[float],
+) -> go.Figure:
+    fig = go.Figure()
+
+    if total_providers > 0:
+        fig.add_trace(
+            go.Scatter(
+                x=list(range(1, total_providers + 1)),
+                y=cumulative_pcts,
+                mode="lines",
+                line=dict(color="rgba(0,220,88,0.90)", width=2),
+                fill="tozeroy",
+                fillcolor="rgba(0,160,68,0.12)",
+                hovertemplate="Top %{x} providers: %{y:.0f}%<extra></extra>",
+                showlegend=False,
+            )
+        )
+
+    fig.update_layout(
+        paper_bgcolor="#020602",
+        plot_bgcolor="#010401",
+        font=dict(family=_MONO, color="#00ff66"),
+        height=220,
+        margin=dict(l=60, r=20, t=10, b=50),
+        showlegend=False,
+        shapes=[
+            dict(
+                type="line",
+                x0=0,
+                x1=max(total_providers, 1),
+                y0=80,
+                y1=80,
+                line=dict(color="rgba(0,200,80,0.75)", width=1.5, dash="dot"),
+            )
+        ],
+        annotations=[
+            dict(
+                x=1,
+                y=80,
+                xref="paper",
+                yref="y",
+                text="80%",
+                showarrow=False,
+                xanchor="right",
+                yanchor="bottom",
+                xshift=-12,
+                font=dict(size=9, color="rgba(0,210,84,0.88)", family=_MONO),
+            )
+        ],
+        xaxis=dict(
+            title=dict(text="Providers (sorted by activity)", font=dict(color="#00ff66")),
+            showgrid=True,
+            gridcolor="rgba(0,170,68,0.35)",
+            gridwidth=1,
+            showline=True,
+            linecolor="rgba(0,170,68,0.5)",
+            tickcolor="#00ff66",
+            tickfont=dict(color="#00ff66"),
+            zeroline=False,
+            fixedrange=True,
+        ),
+        yaxis=dict(
+            title=dict(text="Activity covered", font=dict(color="#00ff66")),
+            range=[0, 100],
+            showgrid=True,
+            gridcolor="rgba(0,170,68,0.35)",
+            gridwidth=1,
+            showline=True,
+            linecolor="rgba(0,170,68,0.5)",
+            tickcolor="#00ff66",
+            tickfont=dict(color="#00ff66"),
+            zeroline=False,
+            ticksuffix="%",
+            fixedrange=True,
+        ),
+    )
+    return fig
+
+
+def _build_countries_figure(
+    country_map_points: list[dict[str, Any]],
+) -> go.Figure:
+    def _scale(active_days: int) -> float:
+        return 40 * (active_days / HISTORY_WINDOW_DAYS) ** 0.5
+
+    lats = [p["lat"] for p in country_map_points]
+    lons = [p["lon"] for p in country_map_points]
+    days = [p["active_days"] for p in country_map_points]
+    codes = [p["code"] for p in country_map_points]
+
+    fig = go.Figure(
+        go.Scattergeo(
+            lat=lats,
+            lon=lons,
+            mode="markers",
+            marker=dict(
+                size=[_scale(d) for d in days],
+                color="#00cc52",
+                opacity=0.75,
+                line=dict(width=1.5, color="rgba(0,60,20,0.85)"),
+            ),
+            hovertemplate="<b>%{customdata[0]}</b>: %{customdata[1]}d<extra></extra>",
+            customdata=list(zip(codes, days, strict=True)),
+        )
+    )
+    fig.update_layout(
+        paper_bgcolor="#010201",
+        height=420,
+        margin=dict(l=0, r=0, t=10, b=0),
+        showlegend=False,
+        geo=dict(
+            bgcolor="#010201",
+            showframe=False,
+            showcoastlines=True,
+            coastlinecolor="#145214",
+            showland=True,
+            landcolor="#0f4a0f",
+            showocean=True,
+            oceancolor="#010201",
+            showlakes=False,
+            showcountries=False,
+            projection_type="natural earth",
+            lataxis_range=[-60, 85],
+        ),
+        dragmode=False,
+    )
+    return fig
+
+
+def _render_recurrence_examples(
+    recurrence_examples: list[Any],
+    recurrence_labels: dict[str, str],
+    history_days: int,
+) -> list[Any]:
+    if history_days < MIN_APPENDIX_HISTORY_DAYS:
+        return [
+            html.P(
+                f"Recurrence grouping and patterns are shown once "
+                f"{MIN_APPENDIX_HISTORY_DAYS} days of connection history are available.",
+                style={
+                    "fontSize": "11px",
+                    "color": "rgba(0,220,88,0.55)",
+                    "marginLeft": "140px",
+                    "fontStyle": "italic",
+                },
+            )
+        ]
+
+    rows = []
+    for cat, name, days in recurrence_examples:
+        label_span = html.Span(
+            recurrence_labels.get(cat, cat),
+            className="rpt-cat-label",
+        )
+        if name is not None:
+            detail: list[Any] = [
+                html.Span(
+                    name,
+                    style={"color": "rgba(0,220,88,0.85)", "fontSize": "11px"},
+                ),
+                html.Div(
+                    [
+                        html.Span(
+                            "\u25a0" if active else "\u25a1",
+                            className="rpt-day--on" if active else "rpt-day--off",
+                        )
+                        for active in days
+                    ],
+                    className="rpt-day-strip",
+                ),
+            ]
+        else:
+            detail = [
+                html.Span(
+                    "no examples yet",
+                    style={
+                        "color": "rgba(0,180,70,0.45)",
+                        "fontSize": "11px",
+                        "fontStyle": "italic",
+                    },
+                )
+            ]
+
+        rows.append(
+            html.Div([label_span, *detail], style={"marginBottom": "6px"})
+        )
+
     return [
-        html.H1("Daily Activity Report"),
-        html.P("Daily activity report is not yet available.", className="mx-note"),
+        html.Div(
+            [
+                html.P(
+                    "Example recurrence patterns",
+                    style={
+                        "fontSize": "12px",
+                        "fontWeight": "600",
+                        "color": "rgba(0,220,88,0.90)",
+                        "margin": "0 0 10px 0",
+                        "letterSpacing": "0.02em",
+                    },
+                ),
+                *rows,
+                html.P(
+                    "Each square represents one day, with today on the right. "
+                    "Filled squares show days where activity was recorded.",
+                    style={
+                        "fontSize": "11px",
+                        "color": "rgba(0,220,88,0.85)",
+                        "margin": "14px 0 0 0",
+                        "lineHeight": "1.35",
+                    },
+                ),
+            ],
+            className="rpt-recurrence",
+        )
     ]
+
+
+def render_daily_activity_report(
+    report: DailyReportData,
+    *,
+    log_path: Path | None = None,
+) -> list[Any]:
+    """Render the Daily Activity Report modal content from pre-computed data."""
+    history_days = report["history_days"]
+    concentration = report["provider_concentration"]
+
+    applications_figure = _build_applications_figure(report["application_counts"])
+    concentration_figure = _build_concentration_figure(
+        concentration["total_providers"],
+        concentration["cumulative_pcts"],
+    )
+    countries_figure = _build_countries_figure(report["country_map_points"])
+
+    children: list[Any] = [
+        html.H1("Daily Activity Report"),
+        html.P(report["intro_text"]),
+        html.P(report["today_text"]),
+    ]
+
+    if report["activity_pattern_text"]:
+        children.append(html.P(report["activity_pattern_text"]))
+
+    children += [
+        html.H2("Applications", className="rpt-h2"),
+        html.P(report["applications_summary"]),
+        dcc.Graph(figure=applications_figure, config={"displayModeBar": False}),
+        *_render_recurrence_examples(
+            report["recurrence_examples"],
+            report["recurrence_labels"],
+            history_days,
+        ),
+        html.H2("Providers", className="rpt-h2"),
+        html.P(report["providers_summary"]),
+        dcc.Graph(
+            figure=concentration_figure,
+            config={"displayModeBar": False},
+        ),
+        html.H2("Countries", className="rpt-h2"),
+        html.P(report["countries_summary"]),
+        dcc.Graph(figure=countries_figure, config={"displayModeBar": False}),
+        html.P(
+            "Dot size reflects how many days each country was observed in the "
+            "connection history.",
+            className="modal-subtitle",
+        ),
+    ]
+
+    if log_path is not None:
+        children += [
+            html.H2("Log", className="rpt-h2"),
+            html.P(
+                "The detailed log includes complete activity timelines for "
+                "applications, providers, countries and ports."
+            ),
+            html.A(
+                "Open generated log",
+                href="/open-log",
+                target="_blank",
+                rel="opener",
+                className="mx-btn mx-btn--primary mx-btn--nowrap",
+            ),
+        ]
+
+    return children

--- a/src/tapmap/ui/layout_view.py
+++ b/src/tapmap/ui/layout_view.py
@@ -42,11 +42,14 @@ def render_layout(
             dcc.Store(id="ui_view", data={"points": [], "summaries": {}, "details": {}}),
             dcc.Store(id="modal_state", data=initial_modal_state),
             dcc.Store(id="open_ports_prefs", data={"show_system": False}),
-            dcc.Input(
-                id="key_capture",
-                type="text",
-                value="",
-                autoFocus=False,
+            html.Div(
+                dcc.Input(
+                    id="key_capture",
+                    type="text",
+                    value="",
+                    autoFocus=False,
+                ),
+                style={"display": "none"},
             ),
             dcc.Interval(id="tick_model", interval=poll_interval_ms, n_intervals=0),
             dcc.Graph(

--- a/src/tapmap/ui/layout_view.py
+++ b/src/tapmap/ui/layout_view.py
@@ -47,16 +47,6 @@ def render_layout(
                 type="text",
                 value="",
                 autoFocus=False,
-                style={
-                    "position": "fixed",
-                    "left": "0",
-                    "top": "0",
-                    "width": "1px",
-                    "height": "1px",
-                    "opacity": "0",
-                    "zIndex": "1000",
-                    "pointerEvents": "none",
-                },
             ),
             dcc.Interval(id="tick_model", interval=poll_interval_ms, n_intervals=0),
             dcc.Graph(

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -11,7 +11,6 @@ from typing import Any
 from dash import dcc, html
 
 from .about_view import render_about
-from .daily_activity_report_view import render_daily_activity_report
 from .formatting import (
     port_from_local,
     pretty_bind_ip,
@@ -65,9 +64,6 @@ class ModalTextBuilder:
         Returns:
             Dash components for the modal body.
         """
-        if action == "menu_daily_report":
-            return render_daily_activity_report()
-
         if action == "menu_unmapped":
             return self._render_unmapped(snapshot)
 

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -1,0 +1,572 @@
+"""Unit tests for state.daily_report pure analytics functions."""
+
+from __future__ import annotations
+
+from tapmap.state.daily_report import (
+    HISTORY_WINDOW_DAYS,
+    MIN_RELIABLE_HISTORY_DAYS,
+    ProviderConcentration,
+    build_activity_pattern,
+    build_applications_summary,
+    build_countries_summary,
+    build_intro_text,
+    build_provider_concentration,
+    build_providers_concentration_narrative,
+    build_providers_summary,
+    build_recurrence_counts,
+    build_recurrence_examples,
+    build_recurrence_labels,
+    build_report_data,
+    build_today_text,
+    classify_recurrence,
+    compute_activity_days_fraction,
+    count_history_days,
+    count_new_today,
+    format_count,
+    get_max_history_days,
+)
+
+# --- format_count ---
+
+
+def test_format_count_returns_word_for_values_in_dict() -> None:
+    """Return English words for values 0 through 10."""
+    assert format_count(0) == "zero"
+    assert format_count(1) == "one"
+    assert format_count(10) == "ten"
+
+
+def test_format_count_returns_string_for_values_outside_dict() -> None:
+    """Return the numeric string for values above ten."""
+    assert format_count(11) == "11"
+    assert format_count(100) == "100"
+
+
+# --- count_history_days ---
+
+
+def test_count_history_days_returns_bit_length_of_bitmask() -> None:
+    """Return the bit length of the supplied bitmask."""
+    assert count_history_days(1) == 1
+    assert count_history_days(0b11111) == 5
+    assert count_history_days((1 << 30) - 1) == 30
+
+
+# --- get_max_history_days ---
+
+
+def test_get_max_history_days_returns_zero_for_empty_insights() -> None:
+    """Return 0 when the insights dict has no entries."""
+    assert get_max_history_days({}) == 0
+
+
+def test_get_max_history_days_finds_maximum_across_all_categories() -> None:
+    """Return the longest bitmask length across all four categories."""
+    insights = {
+        "applications": {"App": {"m": (1 << 20) - 1}},   # bit_length=20
+        "countries":    {"US":  {"m": (1 << 30) - 1}},   # bit_length=30
+        "providers":    {"P1":  {"m": (1 << 10) - 1}},   # bit_length=10
+        "ports":        {"443": {"m": (1 << 15) - 1}},   # bit_length=15
+    }
+    assert get_max_history_days(insights) == 30
+
+
+def test_get_max_history_days_skips_missing_and_non_int_bitmask() -> None:
+    """Skip entries with no 'm' key or a non-integer bitmask."""
+    insights = {
+        "applications": {
+            "AppA": {},               # no 'm' key
+            "AppB": {"m": "bad"},     # non-int
+            "AppC": {"m": (1 << 7) - 1},  # valid, bit_length=7
+        }
+    }
+    assert get_max_history_days(insights) == 7
+
+
+# --- count_new_today ---
+
+
+def test_count_new_today_returns_zero_for_empty_state() -> None:
+    """Return 0 for an empty state dict."""
+    assert count_new_today({}) == 0
+
+
+def test_count_new_today_counts_only_entries_with_m_equal_to_one() -> None:
+    """Count only items first observed today (m == 1)."""
+    state = {
+        "new1": {"m": 1},
+        "new2": {"m": 1},
+        "old1": {"m": 0b11},   # active 2 days, not new
+        "old2": {"m": 0},      # zeroed
+    }
+    assert count_new_today(state) == 2
+
+
+# --- classify_recurrence ---
+
+
+def test_classify_recurrence_returns_seen_once_for_single_active_day() -> None:
+    """Return 'Seen once' when active_days is 1, regardless of history length."""
+    assert classify_recurrence(1, 1) == "Seen once"
+    assert classify_recurrence(1, 30) == "Seen once"
+
+
+def test_classify_recurrence_occasional_below_lower_boundary() -> None:
+    """Return 'Occasional' when the ratio is strictly below OCCASIONAL_RATIO."""
+    # 7/30 < 8/30 → Occasional; 2/30 < 8/30 → Occasional
+    assert classify_recurrence(7, 30) == "Occasional"
+    assert classify_recurrence(2, 30) == "Occasional"
+
+
+def test_classify_recurrence_recurring_at_lower_boundary() -> None:
+    """Return 'Recurring' when the ratio exactly equals OCCASIONAL_RATIO."""
+    # 8/30 == OCCASIONAL_RATIO, not strictly less → Recurring
+    assert classify_recurrence(8, 30) == "Recurring"
+
+
+def test_classify_recurrence_recurring_below_stable_boundary() -> None:
+    """Return 'Recurring' when the ratio is below STABLE_RATIO."""
+    assert classify_recurrence(20, 30) == "Recurring"
+
+
+def test_classify_recurrence_stable_at_lower_boundary() -> None:
+    """Return 'Stable' when the ratio exactly equals STABLE_RATIO."""
+    # 21/30 == STABLE_RATIO, not strictly less → Stable
+    assert classify_recurrence(21, 30) == "Stable"
+
+
+def test_classify_recurrence_stable_at_full_history() -> None:
+    """Return 'Stable' when active for the full history window."""
+    assert classify_recurrence(30, 30) == "Stable"
+
+
+# --- build_recurrence_labels ---
+
+
+def test_build_recurrence_labels_full_history_produces_bounded_labels() -> None:
+    """Return labels with exact day ranges for all four categories."""
+    labels = build_recurrence_labels(HISTORY_WINDOW_DAYS)
+
+    assert labels["Stable"] == "Stable (21\u201330 days)"
+    assert labels["Recurring"] == "Recurring (8\u201320 days)"
+    assert labels["Occasional"] == "Occasional (2\u20137 days)"
+    assert labels["Seen once"] == "Seen once (1 day)"
+
+
+def test_build_recurrence_labels_short_history_empty_bins_use_category_name() -> None:
+    """Use the plain category name for bins that have no values."""
+    # With history_days=1, only 'Seen once' is reachable.
+    labels = build_recurrence_labels(1)
+
+    assert labels["Seen once"] == "Seen once (1 day)"
+    assert labels["Stable"] == "Stable"
+    assert labels["Recurring"] == "Recurring"
+    assert labels["Occasional"] == "Occasional"
+
+
+# --- build_recurrence_counts ---
+
+
+def test_build_recurrence_counts_returns_all_zeros_for_empty_state() -> None:
+    """Return zero counts when the state is empty."""
+    counts = build_recurrence_counts({})
+    assert counts == {"Stable": 0, "Recurring": 0, "Occasional": 0, "Seen once": 0}
+
+
+def test_build_recurrence_counts_skips_zero_and_non_int_bitmasks() -> None:
+    """Skip entries with a zero bitmask, missing key, or non-integer value."""
+    state = {
+        "a": {"m": 0},
+        "b": {"m": "bad"},
+        "c": {},
+    }
+    assert sum(build_recurrence_counts(state, history_days=30).values()) == 0
+
+
+def test_build_recurrence_counts_classifies_items_correctly() -> None:
+    """Place each item into the correct recurrence bucket."""
+    # With history_days=30: 1→Seen once, 4→Occasional, 12→Recurring, 25→Stable
+    state = {
+        "seen_once":  {"m": 1},
+        "occasional": {"m": (1 << 4) - 1},    # bit_count=4
+        "recurring":  {"m": (1 << 12) - 1},   # bit_count=12
+        "stable":     {"m": (1 << 25) - 1},   # bit_count=25
+    }
+    counts = build_recurrence_counts(state, history_days=30)
+
+    assert counts["Seen once"] == 1
+    assert counts["Occasional"] == 1
+    assert counts["Recurring"] == 1
+    assert counts["Stable"] == 1
+
+
+# --- build_recurrence_examples ---
+
+
+def test_build_recurrence_examples_returns_none_tuple_for_missing_category() -> None:
+    """Return (category, None, None) for categories with no matching items."""
+    state = {"AppStable": {"m": (1 << 25) - 1}}   # 25 active days → Stable
+    examples = build_recurrence_examples(state, history_days=30)
+
+    by_cat = {cat: (name, days) for cat, name, days in examples}
+
+    assert by_cat["Stable"][0] == "AppStable"
+    assert by_cat["Stable"][1] is not None
+    assert by_cat["Recurring"] == (None, None)
+    assert by_cat["Occasional"] == (None, None)
+    assert by_cat["Seen once"] == (None, None)
+
+
+def test_build_recurrence_examples_day_strip_matches_bitmask() -> None:
+    """Verify the day-strip boolean list mirrors the bitmask bit pattern."""
+    # m=0b111: bits 0, 1, 2 set → last three positions active
+    state = {"App": {"m": 0b111}}   # bit_count=3 → Occasional with history=30
+    examples = build_recurrence_examples(state, history_days=30)
+
+    by_cat = {cat: days for cat, _, days in examples}
+    strip = by_cat["Occasional"]
+
+    assert strip is not None
+    assert len(strip) == HISTORY_WINDOW_DAYS
+    assert strip[:27] == [False] * 27
+    assert strip[27:] == [True, True, True]
+
+
+# --- compute_activity_days_fraction ---
+
+
+def test_compute_activity_days_fraction_returns_zero_for_empty_state() -> None:
+    """Return 0.0 when the state is empty."""
+    assert compute_activity_days_fraction({}, history_days=30) == 0.0
+
+
+def test_compute_activity_days_fraction_all_stable_returns_one() -> None:
+    """Return 1.0 when all entity-days come from Stable items."""
+    state = {"App": {"m": (1 << 25) - 1}}   # 25 active days, Stable with history=30
+    assert compute_activity_days_fraction(state, history_days=30) == 1.0
+
+
+def test_compute_activity_days_fraction_all_transient_returns_zero() -> None:
+    """Return 0.0 when all entity-days come from Occasional or Seen-once items."""
+    state = {
+        "a": {"m": 1},              # Seen once
+        "b": {"m": (1 << 4) - 1},  # Occasional (4 active days, history=30)
+    }
+    assert compute_activity_days_fraction(state, history_days=30) == 0.0
+
+
+# --- build_activity_pattern ---
+
+
+def test_build_activity_pattern_returns_empty_below_min_history() -> None:
+    """Return an empty string when history is below the reliability threshold."""
+    result = build_activity_pattern({}, {}, history_days=MIN_RELIABLE_HISTORY_DAYS - 1)
+    assert result == ""
+
+
+def test_build_activity_pattern_stable_narrative() -> None:
+    """Return the stable narrative when most activity is recurring."""
+    # All-Stable apps and countries → core_fraction = 1.0 ≥ STABLE_ACTIVITY_THRESHOLD
+    stable_state = {"a": {"m": (1 << 25) - 1}}
+    result = build_activity_pattern(stable_state, stable_state, history_days=30)
+    assert "stable" in result.lower()
+
+
+def test_build_activity_pattern_variable_narrative() -> None:
+    """Return the variable narrative when most activity is intermittent."""
+    # All-Seen-once → core_fraction = 0.0 < VARIABLE_ACTIVITY_THRESHOLD
+    transient_state = {"a": {"m": 1}}
+    result = build_activity_pattern(transient_state, transient_state, history_days=30)
+    assert "varied" in result.lower()
+
+
+def test_build_activity_pattern_mixed_narrative() -> None:
+    """Return the mixed narrative when activity is between the two thresholds."""
+    # All-Stable apps, empty country state → core_fraction = 0.5, in [0.45, 0.70)
+    stable_state = {"a": {"m": (1 << 25) - 1}}
+    result = build_activity_pattern(stable_state, {}, history_days=30)
+    assert "mix" in result.lower()
+
+
+# --- build_intro_text ---
+
+
+def test_build_intro_text_single_day() -> None:
+    """Use the 'one day' phrasing for exactly one day of history."""
+    result = build_intro_text(1)
+    assert "one day" in result
+    assert "reliable" in result
+
+
+def test_build_intro_text_sparse_history() -> None:
+    """Report the word-form count for sparse history below the threshold."""
+    result = build_intro_text(3)
+    assert "three" in result
+    assert "reliable" in result
+
+
+def test_build_intro_text_partial_window() -> None:
+    """Report the numeric day count when history is a partial window."""
+    result = build_intro_text(15)
+    assert "15" in result   # NUMBER_WORDS only covers 0-10
+    assert "rolling" not in result
+
+
+def test_build_intro_text_full_window() -> None:
+    """Report the rolling window when at the full 30-day limit."""
+    result = build_intro_text(HISTORY_WINDOW_DAYS)
+    assert "rolling" in result
+    assert "30-day" in result
+
+
+# --- build_applications_summary ---
+
+
+def test_build_applications_summary_mostly_transient() -> None:
+    """Use the 'briefly' phrasing when most apps are occasional."""
+    counts = {"Stable": 0, "Recurring": 0, "Occasional": 3, "Seen once": 1}
+    result = build_applications_summary(4, counts)
+    assert "briefly" in result
+
+
+def test_build_applications_summary_mixed() -> None:
+    """Use the 'Some apps' phrasing for an even split."""
+    counts = {"Stable": 1, "Recurring": 0, "Occasional": 1, "Seen once": 0}
+    result = build_applications_summary(2, counts)
+    assert "Some" in result
+
+
+def test_build_applications_summary_mostly_recurring() -> None:
+    """Use the 'Many apps' phrasing when most apps are recurring."""
+    counts = {"Stable": 3, "Recurring": 0, "Occasional": 1, "Seen once": 0}
+    result = build_applications_summary(4, counts)
+    assert "Many" in result
+
+
+def test_build_applications_summary_uses_singular_label_for_one_app() -> None:
+    """Use 'application' (singular) before 'used' when total is one."""
+    counts = {"Stable": 1, "Recurring": 0, "Occasional": 0, "Seen once": 0}
+    result = build_applications_summary(1, counts)
+    assert "One application used" in result
+
+
+# --- build_provider_concentration ---
+
+
+def test_build_provider_concentration_empty_state() -> None:
+    """Return zero total and empty percentages for an empty state."""
+    result = build_provider_concentration({})
+    assert result["total_providers"] == 0
+    assert result["cumulative_pcts"] == []
+
+
+def test_build_provider_concentration_single_provider_is_100_percent() -> None:
+    """Return 100% for a single provider."""
+    state = {"p1": {"m": (1 << 15) - 1}}
+    result = build_provider_concentration(state)
+    assert result["total_providers"] == 1
+    assert result["cumulative_pcts"] == [100.0]
+
+
+def test_build_provider_concentration_cumulative_percentages_descending_order() -> None:
+    """Sort by activity descending and compute correct cumulative percentages."""
+    # p1=20 active days, p2=10 active days → total=30
+    state = {
+        "p1": {"m": (1 << 20) - 1},   # bit_count=20
+        "p2": {"m": (1 << 10) - 1},   # bit_count=10
+    }
+    result = build_provider_concentration(state)
+    pcts = result["cumulative_pcts"]
+
+    assert result["total_providers"] == 2
+    assert abs(pcts[0] - 200 / 3) < 0.01   # 20/30 * 100 ≈ 66.67
+    assert pcts[1] == 100.0
+
+
+def test_build_provider_concentration_skips_zero_activity_entries() -> None:
+    """Exclude providers with a zero bitmask."""
+    state = {
+        "active":   {"m": (1 << 10) - 1},
+        "inactive": {"m": 0},
+    }
+    result = build_provider_concentration(state)
+    assert result["total_providers"] == 1
+
+
+# --- build_providers_summary ---
+
+
+def test_build_providers_summary_no_providers() -> None:
+    """Return a 'no activity' message when there are no providers."""
+    result = build_providers_summary(
+        ProviderConcentration(total_providers=0, cumulative_pcts=[])
+    )
+    assert "No provider activity" in result
+
+
+def test_build_providers_summary_uses_singular_for_one_provider() -> None:
+    """Use 'provider' (singular) when total is one."""
+    result = build_providers_summary(
+        ProviderConcentration(total_providers=1, cumulative_pcts=[100.0])
+    )
+    assert " provider " in result
+    assert "providers" not in result
+
+
+def test_build_providers_summary_uses_plural_for_multiple_providers() -> None:
+    """Use 'providers' (plural) when total is more than one."""
+    result = build_providers_summary(
+        ProviderConcentration(total_providers=5, cumulative_pcts=[20.0] * 5)
+    )
+    assert "providers" in result
+
+
+# --- build_providers_concentration_narrative ---
+
+
+def test_concentration_narrative_returns_empty_for_no_providers() -> None:
+    """Return an empty string when there are no providers."""
+    result = build_providers_concentration_narrative(
+        ProviderConcentration(total_providers=0, cumulative_pcts=[])
+    )
+    assert result == ""
+
+
+def test_concentration_narrative_high_concentration() -> None:
+    """Return the small-group narrative when one provider covers >50% of activity."""
+    # top_50_count=1, total=10 → 1/10=0.10 ≤ HIGH_THRESHOLD
+    result = build_providers_concentration_narrative(
+        ProviderConcentration(
+            total_providers=10,
+            cumulative_pcts=[60.0] + [100.0] * 9,
+        )
+    )
+    assert "small" in result.lower()
+
+
+def test_concentration_narrative_moderate_concentration() -> None:
+    """Return the established-group narrative when a small set covers >50%."""
+    # top_50_count=2, total=10 → 2/10=0.20, in (HIGH, MODERATE]
+    result = build_providers_concentration_narrative(
+        ProviderConcentration(
+            total_providers=10,
+            cumulative_pcts=[40.0, 70.0] + [100.0] * 8,
+        )
+    )
+    assert "established" in result.lower()
+
+
+def test_concentration_narrative_distributed() -> None:
+    """Return the broad-range narrative when many providers share activity."""
+    # top_50_count=4, total=10 → 4/10=0.40 > MODERATE_THRESHOLD
+    result = build_providers_concentration_narrative(
+        ProviderConcentration(
+            total_providers=10,
+            cumulative_pcts=[20.0, 35.0, 45.0, 60.0] + [100.0] * 6,
+        )
+    )
+    assert "broad" in result.lower()
+
+
+# --- build_countries_summary ---
+
+
+def test_build_countries_summary_singular() -> None:
+    """Use the word 'one' for a single country."""
+    result = build_countries_summary(1)
+    assert "one" in result
+    assert "countries" in result
+
+
+def test_build_countries_summary_plural() -> None:
+    """Use the numeric count when total is more than one."""
+    result = build_countries_summary(5)
+    assert "five" in result
+    assert "countries" in result
+
+
+# --- build_today_text ---
+
+
+def test_build_today_text_no_new_activity() -> None:
+    """Return a 'no new' message when all category counts are zero."""
+    result = build_today_text({})
+    assert "No new" in result
+
+
+def test_build_today_text_single_category_new() -> None:
+    """Format the message correctly for one category with new entries."""
+    insights = {"applications": {"App": {"m": 1}}}
+    result = build_today_text(insights)
+    assert "One new app" in result
+    assert "appeared today" in result
+
+
+def test_build_today_text_two_categories_joined_with_and() -> None:
+    """Join two active categories with 'and'."""
+    insights = {
+        "applications": {"App": {"m": 1}},
+        "providers":    {"P1": {"m": 1}, "P2": {"m": 1}},
+    }
+    result = build_today_text(insights)
+    assert "One new app" in result
+    assert "two new providers" in result
+    assert " and " in result
+    assert "," not in result.split("appeared")[0]
+
+
+def test_build_today_text_three_categories_uses_comma_and() -> None:
+    """Join three active categories with commas and 'and' before the last."""
+    insights = {
+        "applications": {"App": {"m": 1}},
+        "providers":    {"P1":  {"m": 1}},
+        "countries":    {"US":  {"m": 1}},
+    }
+    result = build_today_text(insights)
+    assert "One new app" in result
+    assert "one new provider" in result
+    assert "one new country" in result
+    assert ", " in result
+
+
+# --- build_report_data (integration) ---
+
+
+def test_build_report_data_returns_all_required_keys() -> None:
+    """Verify build_report_data returns a complete DailyReportData structure."""
+    report = build_report_data({})
+    required = {
+        "history_days", "intro_text", "today_text", "activity_pattern_text",
+        "application_total", "application_counts", "recurrence_labels",
+        "recurrence_examples", "applications_summary",
+        "provider_concentration", "providers_summary",
+        "country_total", "countries_summary", "country_map_points",
+    }
+    assert required <= set(report.keys())
+
+
+def test_build_report_data_history_days_reflects_max_bitmask_length() -> None:
+    """Derive history_days from the highest bit_length across all categories."""
+    insights = {
+        "applications": {"App": {"m": (1 << 20) - 1}},   # bit_length=20
+        "providers":    {"P1":  {"m": (1 << 30) - 1}},   # bit_length=30
+        "countries":    {},
+        "ports":        {"443": {"m": (1 << 15) - 1}},   # bit_length=15
+    }
+    report = build_report_data(insights)
+    assert report["history_days"] == 30
+
+
+def test_build_report_data_application_total_matches_sum_of_counts() -> None:
+    """Verify application_total equals the sum of all recurrence bucket counts."""
+    insights = {
+        "applications": {
+            "App1": {"m": (1 << 25) - 1},   # Stable
+            "App2": {"m": 1},               # Seen once
+        },
+        "countries": {},
+    }
+    report = build_report_data(insights)
+    counts = report["application_counts"]
+    assert report["application_total"] == sum(counts.values())
+    assert report["application_total"] == 2

--- a/tests/test_insights_log.py
+++ b/tests/test_insights_log.py
@@ -1,0 +1,126 @@
+"""Unit tests for deterministic helpers in state.insights_log."""
+
+from __future__ import annotations
+
+from tapmap.state.insights_log import (
+    BOX_EMPTY,
+    BOX_FILLED,
+    HISTORY_WINDOW_DAYS,
+    MAX_LABEL_WIDTH,
+    _coverage_boundary,
+    _entry_line,
+    _timeline,
+)
+
+
+# --- _timeline ---
+
+
+def test_timeline_today_only() -> None:
+    """Produce a timeline with only today's position filled."""
+    # m=1: bit 0 (today) is the only set bit.
+    result = _timeline(1)
+    expected = "[" + BOX_EMPTY * 29 + BOX_FILLED + "]"
+    assert result == expected
+
+
+def test_timeline_all_30_days_active() -> None:
+    """Produce a fully-filled timeline when all 30 bits are set."""
+    result = _timeline((1 << 30) - 1)
+    expected = "[" + BOX_FILLED * 30 + "]"
+    assert result == expected
+
+
+def test_timeline_specific_bit_positions() -> None:
+    """Reflect the exact bitmask pattern in character positions."""
+    # m=0b101: bits 0 and 2 set → positions 27 and 29 filled (oldest-left layout)
+    result = _timeline(0b101)
+    chars = result[1:-1]   # strip surrounding brackets
+    assert len(chars) == HISTORY_WINDOW_DAYS
+    # Positions 0..26 (indices for bits 29..3): all empty
+    assert all(c == BOX_EMPTY for c in chars[:27])
+    # Position 27 (bit 2): filled
+    assert chars[27] == BOX_FILLED
+    # Position 28 (bit 1): empty
+    assert chars[28] == BOX_EMPTY
+    # Position 29 (bit 0, today): filled
+    assert chars[29] == BOX_FILLED
+
+
+# --- _entry_line ---
+
+
+def test_entry_line_short_label_not_truncated() -> None:
+    """Include the full label when it fits within MAX_LABEL_WIDTH."""
+    label = "Firefox"
+    result = _entry_line(label, 1)
+    assert label in result
+    assert "\u2026" not in result
+
+
+def test_entry_line_label_at_exact_max_width_not_truncated() -> None:
+    """Do not truncate a label that is exactly MAX_LABEL_WIDTH characters."""
+    label = "A" * MAX_LABEL_WIDTH
+    result = _entry_line(label, 1)
+    assert label in result
+    assert "\u2026" not in result
+
+
+def test_entry_line_long_label_truncated_with_ellipsis() -> None:
+    """Truncate labels longer than MAX_LABEL_WIDTH and append an ellipsis."""
+    label = "A" * (MAX_LABEL_WIDTH + 4)
+    result = _entry_line(label, 1)
+    assert "\u2026" in result
+    assert label not in result
+
+
+def test_entry_line_day_count_format() -> None:
+    """Show active_days/HISTORY_WINDOW_DAYS in the entry line."""
+    # 30 active days: bit_count of (1<<30)-1 = 30
+    result = _entry_line("App", (1 << 30) - 1)
+    assert "30/30 days" in result
+
+
+def test_entry_line_single_day_count_right_aligned() -> None:
+    """Right-align single-digit active day count."""
+    # m=1: bit_count=1
+    result = _entry_line("App", 1)
+    assert " 1/30 days" in result
+
+
+# --- _coverage_boundary ---
+
+
+def test_coverage_boundary_empty_list_returns_zero() -> None:
+    """Return 0 for an empty input list."""
+    assert _coverage_boundary([], 0.5) == 0
+
+
+def test_coverage_boundary_single_element_always_covers_threshold() -> None:
+    """Return 1 when a single element covers the threshold."""
+    assert _coverage_boundary([10], 0.5) == 1
+    assert _coverage_boundary([10], 0.99) == 1
+
+
+def test_coverage_boundary_50_percent_threshold() -> None:
+    """Return the index where cumulative sum first meets 50% of the total."""
+    # Total=10, target=5; after element 1: 3<5; after element 2: 5>=5 → 2
+    assert _coverage_boundary([3, 2, 2, 1, 1, 1], 0.5) == 2
+
+
+def test_coverage_boundary_80_percent_threshold() -> None:
+    """Return the correct index for an 80% threshold."""
+    # Total=20, target=16; after 1: 10<16; after 2: 15<16; after 3: 20>=16 → 3
+    assert _coverage_boundary([10, 5, 5], 0.8) == 3
+
+
+def test_coverage_boundary_threshold_met_at_first_element() -> None:
+    """Return 1 when the first element already meets the threshold."""
+    # Total=10, target=5; after element 1: 5>=5 → 1
+    assert _coverage_boundary([5, 5], 0.5) == 1
+
+
+def test_coverage_boundary_all_equal_elements() -> None:
+    """Return the correct midpoint for uniformly distributed activity."""
+    # 4 equal elements, threshold=0.5: need 2 of 4 → index 2
+    assert _coverage_boundary([10, 10, 10, 10], 0.5) == 2


### PR DESCRIPTION
## Title

feat: add Daily Activity Report and insights log

## Description

## Summary

Add a Daily Activity Report modal with recurring activity analysis, provider concentration analysis, country activity visualization, and generated insights logs.

Changes:
- Add `state/daily_report.py`
- Add `state/insights_log.py`
- Add Daily Activity Report UI and visualizations
- Add "Open generated log" support
- Add unit tests for report and log logic
- Remove dead CSS rules
- Disable Plotly toolbars in report figures

## Testing
- Verified locally on Windows
- Verified Daily Activity Report modal and generated log
- `pytest` → 167 passed
- `gh pr checks` → all successful
