### PR TITLE
fix: make insights saving safer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.8.30
 dash==4.0.0
+Flask==3.1.3
 maxminddb==3.0.0
 plotly==6.3.1
 psutil==7.0.0
 pycountry==26.2.16
-tomli==2.3.0

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -24,6 +24,7 @@ import argparse
 import contextlib
 import json
 import logging
+import os
 import platform
 import sys
 import threading
@@ -32,6 +33,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, ClassVar, Final
 
+import psutil
 from dash import ALL, Dash, Input, Output, State, ctx, html, no_update
 
 from tapmap import __version__
@@ -96,6 +98,8 @@ class TapMap:
     def __init__(self, runtime_ctx: RuntimeContext) -> None:
         self.runtime = runtime_ctx
         self.logger = logging.getLogger(__name__)
+        self._lock_path = self.runtime.app_data_dir / "tapmap.lock"
+        self._acquire_lock()
 
         self.app = Dash(
             __name__,
@@ -144,12 +148,11 @@ class TapMap:
             ],
         }
 
-        self.insights = {
-            "state": {},
-            "meta": {},
-            "ui": {
-                "expanded_ip": None,
-            },
+        self.insights: dict[str, Any] = {
+            "countries": {},
+            "providers": {},
+            "ports": {},
+            "applications": {},
         }
 
         self.insights_path = self.runtime.app_data_dir / "insights.json"
@@ -913,26 +916,39 @@ class TapMap:
             use_reloader=False,
         )
     
+    @staticmethod
+    def _empty_insights() -> dict[str, Any]:
+        return {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
+
     def _load_insights(self) -> None:
         """Load insights data from JSON file into memory."""
         try:
             if not self.insights_path.exists():
-                self.insights = {}
+                self.insights = self._empty_insights()
                 return
 
             data = json.loads(self.insights_path.read_text(encoding="utf-8"))
 
             insights = data.get("insights")
             if not isinstance(insights, dict):
-                insights = {}
+                self.logger.warning(
+                    "insights.json has unexpected structure; starting fresh."
+                )
+                self.insights = self._empty_insights()
+                return
 
             for key in ("countries", "providers", "ports", "applications"):
                 insights.setdefault(key, {})
 
-            self.insights = insights
+            # Keep only recognised top-level sections.
+            self.insights = {
+                k: insights[k]
+                for k in ("countries", "providers", "ports", "applications")
+            }
 
         except Exception as exc:
-            self.logger.warning("Failed to load insights: %s", exc)
+            self.logger.warning("Failed to load insights: %s. Starting fresh.", exc)
+            self.insights = self._empty_insights()
 
     def _maybe_save_insights(self) -> None:
         """Save insights periodically to limit disk writes."""
@@ -943,23 +959,40 @@ class TapMap:
             self._last_insights_save = now
 
     def _save_insights(self) -> None:
-        """Save insights data to JSON file."""
+        """Write insights data to disk atomically."""
+        tmp = self.insights_path.with_suffix(".json.tmp")
         try:
-            data = {
-                "insights": self.insights
-            }
-
-            self.insights_path.write_text(
-                json.dumps(data, indent=2),
-                encoding="utf-8",
-            )
-
+            data = {"insights": self.insights}
+            tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            tmp.replace(self.insights_path)
         except Exception as exc:
             self.logger.warning("Failed to save insights: %s", exc)
+            with contextlib.suppress(Exception):
+                tmp.unlink(missing_ok=True)
+
+    def _acquire_lock(self) -> None:
+        """Write a PID lock file, or exit if another instance is already running."""
+        if self._lock_path.exists():
+            try:
+                pid = int(self._lock_path.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pid = None
+            if pid is not None and psutil.pid_exists(pid) and pid != os.getpid():
+                self.logger.warning(
+                    "Another TapMap instance is already running (PID %d). Exiting.", pid
+                )
+                sys.exit(1)
+        self._lock_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    def _release_lock(self) -> None:
+        """Remove the PID lock file."""
+        with contextlib.suppress(OSError):
+            self._lock_path.unlink(missing_ok=True)
 
     def close(self) -> None:
         """Close model resources."""
         self._save_insights()
+        self._release_lock()
         close_fn = getattr(self.model.geoinfo, "close", None)
         if callable(close_fn):
             close_fn()

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -81,7 +81,14 @@ class TapMap:
     """Coordinate Dash callbacks, model polling, and UI state."""
 
     MENU_SCREENS: ClassVar[frozenset[str]] = frozenset(
-        {"menu_unmapped", "menu_lan_local", "menu_open_ports", "menu_help", "menu_about", "menu_daily_report"}
+        {
+            "menu_unmapped",
+            "menu_lan_local",
+            "menu_open_ports",
+            "menu_help",
+            "menu_about",
+            "menu_daily_report",
+        }
     )
     MENU_COMMANDS: ClassVar[frozenset[str]] = frozenset(
         {"menu_clear_cache", "menu_cache_terminal", "menu_recheck_geoip"}

--- a/src/tapmap/state/daily_report.py
+++ b/src/tapmap/state/daily_report.py
@@ -38,11 +38,15 @@ RecurrenceExample = tuple[str, str | None, list[bool] | None]
 
 
 class ProviderConcentration(TypedDict):
+    """Provider concentration metrics."""
+
     total_providers: int
     cumulative_pcts: list[float]
 
 
 class CountryMapPoint(TypedDict):
+    """Geographical point for a country on the activity map."""
+
     lat: float
     lon: float
     active_days: int
@@ -50,6 +54,8 @@ class CountryMapPoint(TypedDict):
 
 
 class DailyReportData(TypedDict):
+    """Aggregated data for the daily activity report."""
+
     history_days: int
     intro_text: str
     today_text: str

--- a/src/tapmap/ui/layout_view.py
+++ b/src/tapmap/ui/layout_view.py
@@ -118,9 +118,15 @@ def render_layout(
                             html.Summary("Actions", className="mx-acc-header"),
                             html.Div(
                                 [
-                                    _menu_button("Show cache in terminal (T)", "menu_cache_terminal"),
+                                    _menu_button(
+                                        "Show cache in terminal (T)",
+                                        "menu_cache_terminal",
+                                    ),
                                     _menu_button("Clear cache (C)", "menu_clear_cache"),
-                                    _menu_button("Recheck GeoIP databases (R)", "menu_recheck_geoip"),
+                                    _menu_button(
+                                        "Recheck GeoIP databases (R)",
+                                        "menu_recheck_geoip",
+                                    ),
                                 ],
                                 className="mx-acc-body",
                             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration and session-wide stubs.
+
+pycountry is a runtime dependency that is not available in all test
+environments (e.g. when the system Python is used instead of the
+project venv).  None of the tests exercise pycountry directly, so a
+lightweight stub is sufficient to allow collection and import to succeed.
+"""
+import sys
+from unittest.mock import MagicMock
+
+if "pycountry" not in sys.modules:
+    sys.modules["pycountry"] = MagicMock()

--- a/tests/test_insights_log.py
+++ b/tests/test_insights_log.py
@@ -12,7 +12,6 @@ from tapmap.state.insights_log import (
     _timeline,
 )
 
-
 # --- _timeline ---
 
 

--- a/tests/test_insights_persistence.py
+++ b/tests/test_insights_persistence.py
@@ -1,0 +1,119 @@
+"""Tests for insights persistence robustness and the single-instance lock guard."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tapmap.app import TapMap
+
+_EMPTY: dict = {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
+
+
+def _bare_app(tmp_path: Path) -> TapMap:
+    """Return a TapMap instance with only the attributes needed for method-level tests."""
+    app = object.__new__(TapMap)
+    app.logger = logging.getLogger("test")
+    app.insights = {}
+    app.insights_path = tmp_path / "insights.json"
+    app._lock_path = tmp_path / "tapmap.lock"
+    return app
+
+
+# --- _load_insights: corrupt JSON ---
+
+
+def test_load_insights_corrupt_json_fallback(tmp_path: Path) -> None:
+    """Corrupt JSON must not crash; insights must become the empty structure."""
+    app = _bare_app(tmp_path)
+    app.insights_path.write_text("not valid json", encoding="utf-8")
+    app._load_insights()
+    assert app.insights == _EMPTY
+
+
+# --- _load_insights: unexpected structure ---
+
+
+def test_load_insights_wrong_structure_fallback(tmp_path: Path) -> None:
+    """A non-dict 'insights' value must fall back to the empty structure."""
+    app = _bare_app(tmp_path)
+    app.insights_path.write_text(
+        json.dumps({"insights": ["not", "a", "dict"]}), encoding="utf-8"
+    )
+    app._load_insights()
+    assert app.insights == _EMPTY
+
+
+# --- _load_insights: unknown top-level keys are discarded ---
+
+
+def test_load_insights_strips_unknown_keys(tmp_path: Path) -> None:
+    """Only the four recognised keys should be kept; unknown keys are discarded."""
+    app = _bare_app(tmp_path)
+    data = {
+        "insights": {
+            "countries": {"US": 1},
+            "providers": {},
+            "ports": {},
+            "applications": {},
+            "legacy_field": {"should": "be_removed"},
+        }
+    }
+    app.insights_path.write_text(json.dumps(data), encoding="utf-8")
+    app._load_insights()
+    assert set(app.insights.keys()) == {"countries", "providers", "ports", "applications"}
+    assert "legacy_field" not in app.insights
+    assert app.insights["countries"] == {"US": 1}
+
+
+# --- _save_insights / _load_insights: roundtrip ---
+
+
+def test_save_and_reload_preserves_data(tmp_path: Path) -> None:
+    """Saving and reloading insights must preserve all data exactly."""
+    app = _bare_app(tmp_path)
+    app.insights = {
+        "countries": {"DE": 3},
+        "providers": {"AS1234": 1},
+        "ports": {"443": 5},
+        "applications": {"curl": 2},
+    }
+    app._save_insights()
+    app.insights = {}
+    app._load_insights()
+    assert app.insights == {
+        "countries": {"DE": 3},
+        "providers": {"AS1234": 1},
+        "ports": {"443": 5},
+        "applications": {"curl": 2},
+    }
+
+
+# --- _acquire_lock: running PID blocks startup ---
+
+
+def test_acquire_lock_blocks_when_pid_running(tmp_path: Path) -> None:
+    """A lock file with a live foreign PID must cause sys.exit(1)."""
+    app = _bare_app(tmp_path)
+    fake_pid = 99999
+    app._lock_path.write_text(str(fake_pid), encoding="utf-8")
+    with patch("tapmap.app.psutil.pid_exists", return_value=True):
+        with pytest.raises(SystemExit) as exc_info:
+            app._acquire_lock()
+    assert exc_info.value.code == 1
+
+
+# --- _acquire_lock: stale lock is replaced ---
+
+
+def test_acquire_lock_replaces_stale_lock(tmp_path: Path) -> None:
+    """A lock file whose PID is no longer running must be overwritten silently."""
+    app = _bare_app(tmp_path)
+    app._lock_path.write_text("99999", encoding="utf-8")
+    with patch("tapmap.app.psutil.pid_exists", return_value=False):
+        app._acquire_lock()  # must not raise
+    assert app._lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())

--- a/tests/test_insights_persistence.py
+++ b/tests/test_insights_persistence.py
@@ -101,9 +101,11 @@ def test_acquire_lock_blocks_when_pid_running(tmp_path: Path) -> None:
     app = _bare_app(tmp_path)
     fake_pid = 99999
     app._lock_path.write_text(str(fake_pid), encoding="utf-8")
-    with patch("tapmap.app.psutil.pid_exists", return_value=True):
-        with pytest.raises(SystemExit) as exc_info:
-            app._acquire_lock()
+    with (
+        patch("tapmap.app.psutil.pid_exists", return_value=True),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app._acquire_lock()
     assert exc_info.value.code == 1
 
 


### PR DESCRIPTION
```markdown id="x4m8wr"
## Summary
Make insights saving safer and prevent problems caused by multiple TapMap instances running at the same time.

Changes:
- Save `insights.json` atomically
- Fall back safely if insights data is corrupt or invalid
- Keep only recognised insights sections
- Add a simple PID lock file to prevent concurrent writers
- Handle stale lock files safely
- Add tests for insights loading, saving and lock handling
- Add `Flask` explicitly to `requirements.txt`
- Remove unused `tomli` dependency

## Testing
- Verified locally on Windows
- Verified stale lock replacement
- Verified second instance exits cleanly
- Verified insights save/load roundtrip
- `pytest` → 173 passed