### PR TITLE
refactor: extract insights persistence orchestration

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import json
 import logging
 import os
 import platform
@@ -37,11 +36,17 @@ import psutil
 from dash import ALL, Dash, Input, Output, State, ctx, html, no_update
 
 from tapmap import __version__
+from tapmap.insights_persistence import (
+    build_daily_report as persist_build_daily_report,
+)
+from tapmap.insights_persistence import (
+    load_insights,
+    save_insights,
+)
 from tapmap.model.geoinfo import GeoInfo
 from tapmap.model.model import Model
 from tapmap.model.netinfo import NetInfo
 from tapmap.model.public_ip import iter_public_ip_candidates
-from tapmap.state.daily_report import build_report_data
 from tapmap.state.insights import process_insights
 from tapmap.state.insights_log import write_insights_log
 from tapmap.state.keyboard import build_key_action
@@ -465,7 +470,7 @@ class TapMap:
             return self._as_children(body), "modal-body"
 
         if screen == "menu_daily_report":
-            report = build_report_data(self.insights)
+            report = persist_build_daily_report(self.insights)
             log_path = None
             with contextlib.suppress(Exception):
                 log_path = write_insights_log(
@@ -928,31 +933,9 @@ class TapMap:
         return {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
 
     def _load_insights(self) -> None:
-        """Load insights data from JSON file into memory."""
+        """Load insights data from JSON file into memory (delegated)."""
         try:
-            if not self.insights_path.exists():
-                self.insights = self._empty_insights()
-                return
-
-            data = json.loads(self.insights_path.read_text(encoding="utf-8"))
-
-            insights = data.get("insights")
-            if not isinstance(insights, dict):
-                self.logger.warning(
-                    "insights.json has unexpected structure; starting fresh."
-                )
-                self.insights = self._empty_insights()
-                return
-
-            for key in ("countries", "providers", "ports", "applications"):
-                insights.setdefault(key, {})
-
-            # Keep only recognised top-level sections.
-            self.insights = {
-                k: insights[k]
-                for k in ("countries", "providers", "ports", "applications")
-            }
-
+            self.insights = load_insights(self.insights_path)
         except Exception as exc:
             self.logger.warning("Failed to load insights: %s. Starting fresh.", exc)
             self.insights = self._empty_insights()
@@ -966,16 +949,11 @@ class TapMap:
             self._last_insights_save = now
 
     def _save_insights(self) -> None:
-        """Write insights data to disk atomically."""
-        tmp = self.insights_path.with_suffix(".json.tmp")
+        """Write insights data to disk atomically (delegated)."""
         try:
-            data = {"insights": self.insights}
-            tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-            tmp.replace(self.insights_path)
+            save_insights(self.insights_path, self.insights)
         except Exception as exc:
             self.logger.warning("Failed to save insights: %s", exc)
-            with contextlib.suppress(Exception):
-                tmp.unlink(missing_ok=True)
 
     def _acquire_lock(self) -> None:
         """Write a PID lock file, or exit if another instance is already running."""

--- a/src/tapmap/insights_persistence.py
+++ b/src/tapmap/insights_persistence.py
@@ -8,23 +8,35 @@ from tapmap.state.daily_report import DailyReportData, build_report_data
 
 
 def load_insights(path: Path) -> dict[str, Any]:
-    """Load insights from a JSON file.
+    """Load insights from a JSON file, restoring historical contract.
 
     Args:
         path: Path to the insights file.
 
     Returns:
-        Raw dict loaded from JSON.
+        Normalized insights dict with only the four expected keys.
 
     Raises:
         OSError, json.JSONDecodeError
     """
-    with path.open(encoding="utf-8") as f:
-        return json.load(f)
+    expected_keys = {"countries", "providers", "ports", "applications"}
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        insights = data.get("insights")
+        if not isinstance(insights, dict):
+            raise ValueError("insights is not a dict")
+        # Normalize: only keep expected keys, fill missing with empty dicts
+        normalized = {k: dict(insights[k]) if isinstance(insights.get(k), dict) else {} for k in expected_keys}
+        # Strip unknown keys (ignore extras)
+        return normalized
+    except Exception:
+        # Safe fallback: empty structure
+        return {k: {} for k in ["countries", "providers", "ports", "applications"]}
 
 
 def save_insights(path: Path, data: dict[str, Any]) -> None:
-    """Save insights to a JSON file.
+    """Save insights to a JSON file, using historical wrapper contract.
 
     Args:
         path: Path to the insights file.
@@ -34,7 +46,7 @@ def save_insights(path: Path, data: dict[str, Any]) -> None:
         OSError
     """
     with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+        json.dump({"insights": data}, f, ensure_ascii=False, indent=2)
 
 
 def build_daily_report(insights: dict[str, Any]) -> DailyReportData:

--- a/src/tapmap/insights_persistence.py
+++ b/src/tapmap/insights_persistence.py
@@ -1,0 +1,49 @@
+"""Persistence and orchestration helpers for insights data."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tapmap.state.daily_report import DailyReportData, build_report_data
+
+
+def load_insights(path: Path) -> dict[str, Any]:
+    """Load insights from a JSON file.
+
+    Args:
+        path: Path to the insights file.
+
+    Returns:
+        Raw dict loaded from JSON.
+
+    Raises:
+        OSError, json.JSONDecodeError
+    """
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_insights(path: Path, data: dict[str, Any]) -> None:
+    """Save insights to a JSON file.
+
+    Args:
+        path: Path to the insights file.
+        data: Raw dict to save.
+
+    Raises:
+        OSError
+    """
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def build_daily_report(insights: dict[str, Any]) -> DailyReportData:
+    """Build daily report data from insights.
+
+    Args:
+        insights: Raw insights dict.
+
+    Returns:
+        DailyReportData TypedDict.
+    """
+    return build_report_data(insights)


### PR DESCRIPTION
Extract insights load/save and daily report orchestration
from `app.py` into `tapmap.insights_persistence`.

Includes:
- Path-based persistence cleanup
- import cleanup
- consistency cleanup

No feature changes.