### PR TITLE
test: strengthen persistence regression coverage

### DIFF
--- a/src/tapmap/insights_persistence.py
+++ b/src/tapmap/insights_persistence.py
@@ -27,7 +27,10 @@ def load_insights(path: Path) -> dict[str, Any]:
         if not isinstance(insights, dict):
             raise ValueError("insights is not a dict")
         # Normalize: only keep expected keys, fill missing with empty dicts
-        normalized = {k: dict(insights[k]) if isinstance(insights.get(k), dict) else {} for k in expected_keys}
+        normalized = {
+            k: dict(insights[k]) if isinstance(insights.get(k), dict) else {}
+            for k in expected_keys
+        }
         # Strip unknown keys (ignore extras)
         return normalized
     except Exception:

--- a/tests/test_insights_persistence.py
+++ b/tests/test_insights_persistence.py
@@ -1,15 +1,42 @@
 """Tests for insights persistence robustness and the single-instance lock guard."""
+
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
+import unittest.mock
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from tapmap.app import TapMap
+
+
+def test_failed_save_does_not_corrupt_state(tmp_path: Path) -> None:
+    """A failed save does not corrupt or clear in-memory state."""
+    app = _bare_app(tmp_path)
+    app.insights = {
+        "countries": {"NO": 1},
+        "providers": {},
+        "ports": {},
+        "applications": {},
+    }
+    # Simulate save failure by patching Path.open to raise OSError
+    with (
+        unittest.mock.patch.object(Path, "open", side_effect=OSError("disk full")),
+        contextlib.suppress(OSError),
+    ):
+        app._save_insights()
+    # State should be unchanged
+    assert app.insights == {
+        "countries": {"NO": 1},
+        "providers": {},
+        "ports": {},
+        "applications": {},
+    }
+
 
 _EMPTY: dict = {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
 
@@ -41,9 +68,7 @@ def test_load_insights_corrupt_json_fallback(tmp_path: Path) -> None:
 def test_load_insights_wrong_structure_fallback(tmp_path: Path) -> None:
     """A non-dict 'insights' value must fall back to the empty structure."""
     app = _bare_app(tmp_path)
-    app.insights_path.write_text(
-        json.dumps({"insights": ["not", "a", "dict"]}), encoding="utf-8"
-    )
+    app.insights_path.write_text(json.dumps({"insights": ["not", "a", "dict"]}), encoding="utf-8")
     app._load_insights()
     assert app.insights == _EMPTY
 
@@ -102,7 +127,7 @@ def test_acquire_lock_blocks_when_pid_running(tmp_path: Path) -> None:
     fake_pid = 99999
     app._lock_path.write_text(str(fake_pid), encoding="utf-8")
     with (
-        patch("tapmap.app.psutil.pid_exists", return_value=True),
+        unittest.mock.patch("tapmap.app.psutil.pid_exists", return_value=True),
         pytest.raises(SystemExit) as exc_info,
     ):
         app._acquire_lock()
@@ -116,6 +141,6 @@ def test_acquire_lock_replaces_stale_lock(tmp_path: Path) -> None:
     """A lock file whose PID is no longer running must be overwritten silently."""
     app = _bare_app(tmp_path)
     app._lock_path.write_text("99999", encoding="utf-8")
-    with patch("tapmap.app.psutil.pid_exists", return_value=False):
+    with unittest.mock.patch("tapmap.app.psutil.pid_exists", return_value=False):
         app._acquire_lock()  # must not raise
     assert app._lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())


### PR DESCRIPTION
## Summary
Add regression tests for insights persistence and fallback behavior.

## Tests
- corrupted insights JSON falls back safely
- invalid insights structure falls back safely
- unknown insight keys are discarded
- save/load roundtrip preserves data
- failed save does not corrupt in-memory state
- stale and active lock handling remains correct

## Notes
Tests verify the historical insights persistence contract introduced with the Insights panel.
