### PR TITLE
docs: update help and historical insights documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 ## Unreleased
 
+## 1.7.0 (2026-05-20)
+
+### Features
+- Add Daily Activity Report
+  - Summarize recent network activity
+  - Show recurring activity patterns
+  - Show provider concentration analysis
+  - Show country activity visualization
+  - Add generated activity log view
+- Add generated insights log
+  - Include detailed timelines for applications, providers, countries and ports
+  - Add "Open generated log" support
+- Add accordion-style grouped menu
+  - Group actions and views into expandable sections
+  - Add keyboard shortcut for Daily Activity Report
+- Add globe logo to application header
+
+### Improvements
+- Improve insights persistence robustness
+  - Save `insights.json` atomically
+  - Recover safely from corrupt or invalid insights data
+  - Prevent concurrent writers with single-instance PID lock handling
+  - Handle stale lock files safely
+
+### Refactor
+- Extract insights persistence orchestration from `app.py`
+- Remove dead established-state filtering logic
+- Remove dead CSS rules
+
+### Testing
+- Add persistence regression tests
+- Add tests for insights save/load handling and lock handling
+- Expand Daily Activity Report and insights log test coverage
+
+### Documentation
+- Update README and Help for Daily Activity Report and historical insights
+
 ## 1.6.3 (2026-05-04)
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -47,17 +47,24 @@ See below for how to allow the application.
 
 ---
 
-## New: Insights
+## Insights and Daily Activity Report
 
-TapMap tracks activity over the last 30 days and highlights what is unusual and what is most frequent.
+TapMap builds a rolling 30-day history of network activity and helps you understand what is normal, new, recurring, or unusual.
 
-- New apps, services (ASN), countries, and ports
+The Insights panel highlights:
+- New apps, providers (ASN), countries, and ports
 - Frequent activity (Top 5+, including ties)
 - Click countries to zoom and inspect on the map
 
-While the map is limited to connections in the current session, insights are based on activity observed over time.
+The Daily Activity Report provides a broader summary of recent activity:
+- Application recurrence patterns (seen once, occasional, recurring, and stable)
+- Provider concentration analysis
+- Country activity visualization
+- Generated activity logs with detailed timelines
 
-To build a complete 30-day history, keep TapMap running while your system is in use. Running it at startup is recommended.
+The map only shows live connections from the current session, while Insights and the Daily Activity Report use historical activity collected during the last 30 days.
+
+To build a complete activity history, keep TapMap running while your system is in use. Running it at startup is recommended.
 
 ---
 

--- a/src/tapmap/ui/about_view.py
+++ b/src/tapmap/ui/about_view.py
@@ -98,8 +98,13 @@ def render_about(
     return [
         html.H1(f"About {app_name}"),
         html.P(
-            "TapMap inspects local socket data, enriches IP addresses with "
-            "geolocation, and shows them on an interactive map."
+            "TapMap inspects local socket activity, enriches IP addresses with "
+            "geolocation, visualizes connections on an interactive map, and "
+            "builds insights from the most recent 30 days of activity."
+        ),
+        html.P(
+            "Historical insights include recurring activity patterns, provider "
+            "distribution, country activity and generated activity logs."
         ),
         html.P(
             "It reads active socket data using a platform-specific backend, "

--- a/src/tapmap/ui/help_view.py
+++ b/src/tapmap/ui/help_view.py
@@ -175,6 +175,52 @@ def render_help() -> list[Any]:
                 "coordinates are shown as one marker.",
             ]
         ),
+        html.H2("Menu"),
+        html.P(
+            "The menu is organized into expandable sections for insights, network "
+            "views, actions, and information."
+        ),
+        html.Table(
+            className="mx-table mx-kv",
+            children=[
+                html.Tbody(
+                    [
+                        html.Tr(
+                            [
+                                html.Td("INSIGHTS"),
+                                html.Td(
+                                    "Daily Activity Report and Insights panel."
+                                ),
+                            ]
+                        ),
+                        html.Tr(
+                            [
+                                html.Td("NETWORK"),
+                                html.Td(
+                                    "Unmapped services, LAN/LOCAL services, and open ports."
+                                ),
+                            ]
+                        ),
+                        html.Tr(
+                            [
+                                html.Td("ACTIONS"),
+                                html.Td(
+                                    "Cache actions and GeoIP database checks."
+                                ),
+                            ]
+                        ),
+                        html.Tr(
+                            [
+                                html.Td("INFO"),
+                                html.Td(
+                                    "Help and About windows."
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+        ),
         html.H2("Controls"),
         html.Table(
             className="mx-table",
@@ -197,6 +243,13 @@ def render_help() -> list[Any]:
                 ),
                 html.Tbody(
                     [
+                        html.Tr(
+                            [
+                                html.Td("D"),
+                                html.Td("Show Daily Activity Report"),
+                                html.Td("Window"),
+                            ]
+                        ),
                         html.Tr(
                             [
                                 html.Td("I"),
@@ -241,26 +294,54 @@ def render_help() -> list[Any]:
         ),
         html.H2("Insights"),
         html.P(
-            "Shows activity observed over the last 30 days and highlights what is "
-            "unusual and what is most frequent."
+            "Insights track activity observed during the last 30 days."
+        ),
+        html.P(
+            "The Insights panel includes:"
         ),
         html.Ul(
             [
-                html.Li("Today: Items seen today that were not observed in the last 30 days."),
-                html.Li("Top 5: Most frequently observed items over the last 30 days."),
-                html.Li("Categories include apps, providers, countries, and ports."),
+                html.Li(
+                    "New apps, providers (ASN), countries, and ports observed today."
+                ),
+                html.Li(
+                    "Top 5+ most frequently observed items over the last 30 days."
+                ),
+                html.Li(
+                    "Click countries to zoom to their locations on the map."
+                ),
             ]
         ),
         html.P(
-            "Click a country to zoom to its location on the map."
+            "Insights may include activity that is not currently visible on the map."
         ),
         html.P(
+            "The map is limited to activity observed during the current session, "
+            "while Insights use activity observed during the last 30 days."
+        ),
+        html.H2("Daily Activity Report"),
+        html.P(
+            "The Daily Activity Report analyzes historical activity observed during "
+            "the last 30 days."
+        ),
+        html.Ul(
             [
-                "Entries may appear even if they are not currently visible on the map.",
-                html.Br(),
-                "Insights include activity observed over the last 30 days, while the "
-                "map shows only recent data (see CACHE).",
+                html.Li(
+                    "Application recurrence patterns (seen once, occasional, "
+                    "recurring, and stable)."
+                ),
+                html.Li("Provider concentration analysis."),
+                html.Li("Country activity visualization."),
+                html.Li(
+                    "Open the generated activity log from the Log section at the "
+                    "end of the report to inspect detailed timelines for apps, "
+                    "providers, countries, and ports."
+                ),
             ]
+        ),
+        html.P(
+            "To build a complete 30-day history, keep TapMap running while your "
+            "system is in use. Running it at startup is recommended."
         ),
         html.H2("Unmapped public services"),
         html.P(


### PR DESCRIPTION
## Summary
Update README, Help, and About descriptions for historical insights and the Daily Activity Report.

Changes:
- Replace the old Insights section in README
- Document Daily Activity Report functionality
- Document generated insights logs
- Clarify the difference between current-session map activity and 30-day historical insights
- Document the new accordion-style menu structure
- Add Daily Activity Report keyboard shortcut
- Update About view text for historical insights

## Notes
- Documentation and UI text changes only
- No functional changes

## Testing
- Verified locally on Windows
- Verified Help and About views
- Verified README and CHANGELOG preview in VS Code
- `ruff check .`
- `pytest` → 174 passed