### PR TITLE
docs: remove accidental changelog text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-git 
+
 ### Maintenance
 - Ignore full Docker runtime directory
 - Fix MkDocs README list rendering


### PR DESCRIPTION
Remove accidental text entered into CHANGELOG.md after merge.

No functional changes.
