### PR TITLE
chore: polish docs and workflow naming

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Testing
+- Add comprehensive regression coverage for rolling 30-day insights bitmaps
+- Add boundary tests for bitmap aging, pruning, and re-observation semantics
+- Clarify internal `anchor_day` bitmap semantics without changing persistence format
+
+### Documentation
+- Document Daily Activity Report keyboard shortcut in README
+
+### CI
+- Clarify macOS build naming in artifact workflow
+
 ### Maintenance
 - Ignore full Docker runtime directory
 - Fix MkDocs README list rendering

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ It uses:
 
 ## How to use
 
-- Hover map markers for a summary  
-- Click map markers for detailed information  
+- Hover map markers for a summary
+- Click map markers for detailed information
+- Open the Daily Activity Report with D
 - Click countries in Insights to zoom to the location
 
 ---
@@ -280,6 +281,7 @@ Redistribution is subject to the MaxMind license terms.
 
 | Key | Action |
 |-----|--------|
+| D   | Daily Activity Report |
 | I   | Toggle Insights panel |
 | U   | Unmapped public services |
 | L   | Established LAN/LOCAL services |


### PR DESCRIPTION
## Summary

Polish documentation and workflow naming after recent insights and Daily Activity Report changes.

## Changes

- document Daily Activity Report keyboard shortcut in README
- update changelog for recent unreleased changes
- clarify macOS build naming in build workflows

## Notes

- no runtime behaviour changes
- no packaging changes
- no release changes

## Testing

- workflow naming change only
- no runtime code modified
