### PR TITLE
feat: add runtime location override support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,22 @@
-## Unreleased
+## 1.7.2 (2026-05-26)
+
+### Features
+- Add runtime location override using `TAPMAP_LON` and `TAPMAP_LAT`
+- Skip external public-IP lookup when runtime coordinates are provided
+- Add ENV local-location mode to status line and About view
 
 ### Testing
+- Add focused regression tests for runtime location override parsing
+- Add boundary and validation coverage for runtime coordinate parsing
 - Add comprehensive regression coverage for rolling 30-day insights bitmaps
 - Add boundary tests for bitmap aging, pruning, and re-observation semantics
 - Clarify internal `anchor_day` bitmap semantics without changing persistence format
 
 ### Documentation
+- Document runtime location override environment variables
+- Document privacy behavior for automatic public-IP detection
 - Document Daily Activity Report keyboard shortcut in README
+- Update Help and About semantics for ENV location mode
 
 ### CI
 - Clarify macOS build naming in artifact workflow

--- a/README.md
+++ b/README.md
@@ -297,10 +297,11 @@ Redistribution is subject to the MaxMind license terms.
 
 ## Privacy
 
-- TapMap runs locally.  
+- TapMap runs locally.
 - No connection data is sent anywhere.
 - Geolocation uses local MaxMind databases.
-- If `MY_LOCATION = "auto"`, TapMap makes a small request to detect your public IP.
+- If automatic local geolocation is enabled, TapMap may make a small request to detect your public IP.
+- External public-IP lookup can be avoided by using fixed local coordinates in `config.py` or through runtime environment variables.
 
 ---
 
@@ -310,15 +311,20 @@ TapMap reads settings from `config.py`.
 
 Common settings:
 
-- `SERVER_PORT`  
-- `MY_LOCATION`  
-- `POLL_INTERVAL_MS`  
-- `COORD_PRECISION`  
+- `SERVER_PORT`
+- `MY_LOCATION`
+- `POLL_INTERVAL_MS`
+- `COORD_PRECISION`
 - `ZOOM_NEAR_KM`
 
-`SERVER_PORT` defines the default port used by the local Dash server.
+Some settings can also be overridden at runtime using environment variables:
 
-The port can be overridden at runtime using the environment variable `TAPMAP_PORT`.
+- `TAPMAP_HOST`
+- `TAPMAP_PORT`
+- `TAPMAP_LON`
+- `TAPMAP_LAT`
+
+If both `TAPMAP_LON` and `TAPMAP_LAT` are provided, TapMap uses those coordinates for the local map marker instead of automatic public-IP geolocation.
 
 ---
 
@@ -456,10 +462,14 @@ Place the GeoLite2 database files in that folder:
 
 The server binds to 0.0.0.0 by default in Docker.
 
-To override the bind address or port:
+To override the bind address, port, or local map location:
 
     -e TAPMAP_HOST=127.0.0.1
     -e TAPMAP_PORT=8060
+    -e TAPMAP_LON=10.7522
+    -e TAPMAP_LAT=59.9139
+
+If `TAPMAP_LON` and `TAPMAP_LAT` are provided, TapMap uses those coordinates for the local map marker and skips automatic public-IP geolocation.
 
 Open in browser on the host:
 
@@ -508,3 +518,4 @@ Thanks to @khadanja for suggesting a Docker-based workaround.
 Thanks to @TechnVision for raising the configurable port use case.  
 Thanks to @desrod for suggesting a solution for configurable port support.  
 Thanks to @hugalafutro for suggesting optional SYS_PTRACE support for process visibility on Linux.
+

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -250,6 +250,8 @@ class TapMap:
         return {"message": message, "until": (datetime.now().timestamp() + float(seconds))}
 
     def _myloc_label(self) -> str:
+        if self.runtime.location_override is not None:
+            return "ENV"
         if isinstance(MY_LOCATION, tuple):
             return "FIXED"
         if MY_LOCATION == "none":
@@ -259,6 +261,9 @@ class TapMap:
         return "OFF"
 
     def _resolve_my_location(self) -> list[LonLat]:
+        if self.runtime.location_override is not None:
+            return [self.runtime.location_override]
+
         if isinstance(MY_LOCATION, tuple):
             return [MY_LOCATION]
 
@@ -300,7 +305,11 @@ class TapMap:
             "run_dir": str(self.runtime.run_dir),
             "is_frozen": bool(self.runtime.is_frozen),
             "myloc_mode": self._myloc_label(),
-            "my_location": MY_LOCATION,
+            "my_location": (
+                self.runtime.location_override
+                if self.runtime.location_override is not None
+                else MY_LOCATION
+            ),
             "public_ip_cached": self._public_ip_cached,
             "auto_geo_cached": self._auto_geo_cached,
             "os": f"{platform.system()} {platform.release()}",

--- a/src/tapmap/runtime.py
+++ b/src/tapmap/runtime.py
@@ -41,6 +41,7 @@ class RuntimeContext:
     server_host: str
     server_port: int
     is_docker: bool
+    location_override: tuple[float, float] | None
 
     @property
     def geo_data_dir(self) -> Path:
@@ -76,6 +77,31 @@ def _detect_docker() -> bool:
     """Return True when running in Docker."""
     return os.environ.get("TAPMAP_IN_DOCKER") == "1"
 
+
+def _get_location_override() -> tuple[float, float] | None:
+    """Parse TAPMAP_LON and TAPMAP_LAT env vars; return override or None.
+
+    Both vars must exist together. Both must parse as float.
+    lon must be -180 <= lon <= 180. lat must be -90 <= lat <= 90.
+    On any validation failure: return None (silent fallback to config.py).
+    """
+    lon_str = os.environ.get("TAPMAP_LON", "")
+    lat_str = os.environ.get("TAPMAP_LAT", "")
+
+    if not lon_str or not lat_str:
+        return None
+
+    try:
+        lon = float(lon_str)
+        lat = float(lat_str)
+    except ValueError:
+        return None
+
+    if -180 <= lon <= 180 and -90 <= lat <= 90:
+        return (lon, lat)
+
+    return None
+
 def build_runtime(meta: AppMeta) -> RuntimeContext:
     """Build the runtime context for the current OS and execution mode."""
     is_frozen = bool(getattr(sys, "frozen", False))
@@ -88,6 +114,7 @@ def build_runtime(meta: AppMeta) -> RuntimeContext:
     is_docker = _detect_docker()
     server_host = _get_server_host(is_docker)
     server_port = _get_server_port()
+    location_override = _get_location_override()
 
     return RuntimeContext(
         meta=meta,
@@ -99,6 +126,7 @@ def build_runtime(meta: AppMeta) -> RuntimeContext:
         server_host=server_host,
         server_port=server_port,
         is_docker=is_docker,
+        location_override=location_override,
     )
 
 def _detect_network_backend() -> tuple[str, str]:

--- a/src/tapmap/ui/about_view.py
+++ b/src/tapmap/ui/about_view.py
@@ -218,6 +218,15 @@ def _build_location_rows(
             return [("MY_LOCATION", _fmt_coord(lon, lat))]
         return [("MY_LOCATION", "fixed (invalid value)")]
 
+    if myloc_mode == "ENV":
+        if isinstance(my_location, (list, tuple)) and len(my_location) == 2:
+            lon, lat = my_location[0], my_location[1]
+            return [
+                ("MY_LOCATION", "env override"),
+                ("Coordinate", _fmt_coord(lon, lat)),
+            ]
+        return [("MY_LOCATION", "env override")]
+
     rows: list[tuple[str, str]] = [("MY_LOCATION", "auto")]
     rows.append(("Public IP", public_ip_cached or "-"))
 

--- a/src/tapmap/ui/help_view.py
+++ b/src/tapmap/ui/help_view.py
@@ -490,8 +490,8 @@ def render_help() -> list[Any]:
         html.P("SERV is derived from SOCK by ignoring PID and process."),
         html.H3("UPDATED"),
         html.P("Time of the last snapshot."),
-        html.H3("MYLOC: FIXED | AUTO | AUTO (NO GEO) | OFF"),
-        html.P("Shows your local map location based on the MY_LOCATION setting in config.py."),
+        html.H3("MYLOC: FIXED | ENV | AUTO | AUTO (NO GEO) | OFF"),
+        html.P("Shows the active local map location mode."),
         html.Table(
             className="mx-table mx-kv",
             children=[
@@ -499,6 +499,14 @@ def render_help() -> list[Any]:
                     [
                         html.Tr(
                             [html.Td("FIXED"), html.Td("Uses fixed coordinates from config.py.")]
+                        ),
+                        html.Tr(
+                            [
+                                html.Td("ENV"),
+                                html.Td(
+                                    "Uses coordinates provided through TAPMAP_LON and TAPMAP_LAT."
+                                ),
+                            ]
                         ),
                         html.Tr(
                             [html.Td("AUTO"), html.Td("Location detected from your public IP.")]
@@ -567,7 +575,8 @@ def render_help() -> list[Any]:
                                 html.Td("MY_LOCATION"),
                                 html.Td(
                                     "'none' hides the local marker. Use (lon, lat) for fixed "
-                                    "coordinates, or 'auto' to detect from public IP."
+                                    "coordinates, or 'auto' to detect from public IP. "
+                                    "Runtime environment variables can override this setting."
                                 ),
                             ]
                         ),
@@ -611,6 +620,7 @@ def render_help() -> list[Any]:
         html.P("Geolocation lookups are performed locally using the mmdb files."),
         html.P(
             "If MY_LOCATION is set to 'auto', TapMap may query external services to detect the "
-            "public IP address. It stops after the first valid result."
+            "public IP address. It stops after the first valid result. "
+            "This lookup is skipped when TAPMAP_LON and TAPMAP_LAT are provided."
         ),
     ]

--- a/tests/test_runtime_location.py
+++ b/tests/test_runtime_location.py
@@ -1,0 +1,98 @@
+"""Tests for runtime location override parsing."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tapmap.runtime import _get_location_override
+
+
+class TestGetLocationOverride:
+    """Test _get_location_override() env var parser."""
+
+    def test_both_valid_coordinates(self) -> None:
+        """Valid positive coordinates return tuple."""
+        with patch.dict(os.environ, {"TAPMAP_LON": "10.5", "TAPMAP_LAT": "50.2"}, clear=True):
+            result = _get_location_override()
+            assert result == (10.5, 50.2)
+
+    def test_both_valid_negative_coordinates(self) -> None:
+        """Valid negative coordinates return tuple."""
+        with patch.dict(os.environ, {"TAPMAP_LON": "-74.0", "TAPMAP_LAT": "-33.9"}, clear=True):
+            result = _get_location_override()
+            assert result == (-74.0, -33.9)
+
+    @pytest.mark.parametrize("env", [
+        {"TAPMAP_LAT": "50.2"},
+        {"TAPMAP_LON": "10.5"},
+        {},
+    ])
+    def test_missing_pair_returns_none(self, env: dict[str, str]) -> None:
+        """Missing lon/lat pair returns None."""
+        with patch.dict(os.environ, env, clear=True):
+            result = _get_location_override()
+            assert result is None
+
+    @pytest.mark.parametrize("lon,lat", [
+        ("invalid", "50.2"),
+        ("abc", "50.2"),
+        ("12.34.56", "50.2"),
+        ("10.5", "invalid"),
+        ("10.5", "xyz"),
+        ("10.5", "90.1.2"),
+    ])
+    def test_invalid_float_returns_none(self, lon: str, lat: str) -> None:
+        """Invalid float input in either var returns None."""
+        with patch.dict(os.environ, {"TAPMAP_LON": lon, "TAPMAP_LAT": lat}, clear=True):
+            result = _get_location_override()
+            assert result is None
+
+    @pytest.mark.parametrize("lon,lat", [
+        ("-180.1", "50"),
+        ("-200", "50"),
+        ("180.1", "50"),
+        ("200", "50"),
+        ("10", "-90.1"),
+        ("10", "-100"),
+        ("10", "90.1"),
+        ("10", "100"),
+    ])
+    def test_out_of_range_returns_none(self, lon: str, lat: str) -> None:
+        """Out-of-range lon/lat returns None."""
+        with patch.dict(os.environ, {"TAPMAP_LON": lon, "TAPMAP_LAT": lat}, clear=True):
+            result = _get_location_override()
+            assert result is None
+
+    @pytest.mark.parametrize("lon,lat", [
+        ("-180", "0"),
+        ("180", "0"),
+        ("0", "-90"),
+        ("0", "90"),
+    ])
+    def test_boundary_values_return_tuple(self, lon: str, lat: str) -> None:
+        """Boundary lon/lat values are accepted."""
+        with patch.dict(os.environ, {"TAPMAP_LON": lon, "TAPMAP_LAT": lat}, clear=True):
+            result = _get_location_override()
+            assert result == (float(lon), float(lat))
+
+    @pytest.mark.parametrize("lon,lat", [
+        ("", "50"),
+        ("10", ""),
+        ("   ", "50"),
+        ("10", "   "),
+    ])
+    def test_empty_or_whitespace_returns_none(self, lon: str, lat: str) -> None:
+        """Empty or whitespace-only env vars return None."""
+        with patch.dict(os.environ, {"TAPMAP_LON": lon, "TAPMAP_LAT": lat}, clear=True):
+            result = _get_location_override()
+            assert result is None
+
+    def test_scientific_notation(self) -> None:
+        """Scientific notation accepted as valid float."""
+        with patch.dict(os.environ, {"TAPMAP_LON": "1e1", "TAPMAP_LAT": "5e1"}, clear=True):
+            result = _get_location_override()
+            assert result == (10.0, 50.0)
+


### PR DESCRIPTION
## Summary

Add runtime location override support using `TAPMAP_LON` and `TAPMAP_LAT`.

This allows:
- skipping external public-IP lookup
- overriding automatic local geolocation
- setting fixed runtime coordinates without editing `config.py`

The PR also expands regression coverage for rolling 30-day insights persistence semantics and improves workflow naming consistency.

## Changes

### Runtime
- Add `location_override` runtime context field
- Add runtime env parsing and validation for:
  - `TAPMAP_LON`
  - `TAPMAP_LAT`
- Apply runtime override precedence before config.py resolution

### UI
- Add `ENV` local-location mode to status line
- Add ENV semantics to About view
- Add ENV documentation to Help view

### Documentation
- Document runtime location override support in README
- Document privacy behavior for public-IP lookup
- Add Docker Hub examples for runtime location override
- Document Daily Activity Report keyboard shortcut

### Testing
- Add focused regression tests for runtime location override parsing
- Add validation and boundary coverage for runtime coordinate parsing
- Add comprehensive regression coverage for rolling 30-day insights bitmaps
- Add bitmap aging, pruning, and re-observation boundary tests
- Clarify and preserve internal `anchor_day` bitmap semantics

### CI
- Clarify macOS build naming in artifact workflows

### Maintenance
- Ignore full Docker runtime directory
- Fix MkDocs README list rendering
- Remove unused Flask dependency

## Validation

- `pytest`
- 265 passed