### PR TITLE
Fix: refine daily report narrative wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Daily Activity Report
+- Refine narrative wording and report tone
+- Improve alignment between wording, recurrence visuals, and provider concentration curves
+- Simplify provider concentration summaries
+
 ## 1.7.2 (2026-05-26)
 
 ### Features

--- a/src/tapmap/state/daily_report.py
+++ b/src/tapmap/state/daily_report.py
@@ -260,7 +260,22 @@ def build_activity_pattern(
         return ""
     app_fraction = compute_activity_days_fraction(app_state, history_days)
     country_fraction = compute_activity_days_fraction(country_state, history_days)
-    core_fraction = (app_fraction + country_fraction) / 2
+    app_has_activity = any(
+        isinstance(item.get("m"), int) and item["m"].bit_count() > 0
+        for item in app_state.values()
+    )
+    country_has_activity = any(
+        isinstance(item.get("m"), int) and item["m"].bit_count() > 0
+        for item in country_state.values()
+    )
+    if app_has_activity and country_has_activity:
+        core_fraction = (app_fraction + country_fraction) / 2
+    elif app_has_activity:
+        core_fraction = app_fraction
+    elif country_has_activity:
+        core_fraction = country_fraction
+    else:
+        core_fraction = 0.0
     if core_fraction >= STABLE_ACTIVITY_THRESHOLD:
         return (
             "Most recurring internet activity remained centered "
@@ -300,13 +315,21 @@ def build_applications_summary(
     counts: dict[str, int],
 ) -> str:
     """Return applications summary text."""
+    if application_total == 0:
+        return "No applications used the internet during this period."
+
     application_label = "application" if application_total == 1 else "applications"
     application_total_text = format_count(application_total)
     frequent = counts["Stable"] + counts["Recurring"]
-    total = frequent + counts["Occasional"] + counts["Seen once"]
+    transient = counts["Occasional"] + counts["Seen once"]
+    total = frequent + transient
     fraction = frequent / total if total > 0 else 0.0
 
-    if fraction < 0.33:
+    if frequent == 0:
+        distribution_text = "Most appeared only briefly or for the first time."
+    elif transient == 0:
+        distribution_text = "Apps ran consistently throughout the period."
+    elif fraction < 0.33:
         distribution_text = (
             "Most appeared only briefly or for the first time. "
             "Some ran consistently throughout the period."
@@ -376,6 +399,11 @@ def build_providers_concentration_narrative(concentration: ProviderConcentration
     total = concentration["total_providers"]
     if total == 0:
         return ""
+    if total == 1:
+        return (
+            "Most observed activity was handled by "
+            "a relatively small group of providers."
+        )
     cumulative_pcts = concentration["cumulative_pcts"]
     top_50_count = next(
         (i + 1 for i, pct in enumerate(cumulative_pcts) if pct >= 50.0),

--- a/src/tapmap/state/daily_report.py
+++ b/src/tapmap/state/daily_report.py
@@ -278,17 +278,14 @@ def build_activity_pattern(
         core_fraction = 0.0
     if core_fraction >= STABLE_ACTIVITY_THRESHOLD:
         return (
-            "Most recurring internet activity remained centered "
-            "around a stable everyday pattern."
+            "Most activity-days came from recurring connections."
         )
     if core_fraction < VARIABLE_ACTIVITY_THRESHOLD:
         return (
-            "Internet activity varied considerably over time, "
-            "with many connections appearing only intermittently."
+            "Short-lived connections made up a larger share across the period."
         )
     return (
-        "Internet activity showed a steady mix of recurring "
-        "and occasional patterns throughout the observed history."
+        "Recurring and short-lived connections appeared throughout the period."
     )
 
 
@@ -322,27 +319,38 @@ def build_applications_summary(
     application_total_text = format_count(application_total)
     frequent = counts["Stable"] + counts["Recurring"]
     transient = counts["Occasional"] + counts["Seen once"]
+    seen_once = counts["Seen once"]
     total = frequent + transient
     fraction = frequent / total if total > 0 else 0.0
 
+    once_phrase = ""
+    if 2 <= seen_once <= 5:
+        once_phrase = ", and some only once"
+    elif seen_once >= 6:
+        once_phrase = ", and many only once"
+
     if frequent == 0:
-        distribution_text = "Most appeared only briefly or for the first time."
+        distribution_text = (
+            f"Most apps appeared briefly{once_phrase}."
+        )
     elif transient == 0:
-        distribution_text = "Apps ran consistently throughout the period."
+        distribution_text = (
+            "Apps appeared repeatedly during the period."
+        )
     elif fraction < 0.33:
         distribution_text = (
-            "Most appeared only briefly or for the first time. "
-            "Some ran consistently throughout the period."
+            f"Most apps appeared briefly{once_phrase}. "
+            "Some appeared repeatedly during the period."
         )
     elif fraction <= 0.66:
         distribution_text = (
-            "Some apps ran consistently throughout the period. "
-            "Many others appeared only occasionally or briefly."
+            "Some apps appeared repeatedly during the period. "
+            "Many others appeared briefly."
         )
     else:
         distribution_text = (
-            "Many apps ran consistently throughout the period. "
-            "Others appeared only occasionally or briefly."
+            "Many apps appeared repeatedly during the period. "
+            "Others appeared briefly."
         )
 
     return (
@@ -412,16 +420,13 @@ def build_providers_concentration_narrative(concentration: ProviderConcentration
     provider_50_fraction = top_50_count / total
     if provider_50_fraction <= PROVIDER_HIGH_CONCENTRATION_THRESHOLD:
         return (
-            "Most observed activity was handled by "
-            "a relatively small group of providers."
+            "Most activity came through a few providers."
         )
     if provider_50_fraction <= PROVIDER_MODERATE_CONCENTRATION_THRESHOLD:
         return (
-            "Much of the observed activity was handled by a smaller "
-            "established group of providers, alongside a broader set "
-            "of occasional ones."
+            "At least half of the activity came through a few providers."
         )
-    return "Observed activity was distributed across a broad range of providers."
+    return "Activity was spread across many providers."
 
 
 def build_countries_summary(country_total: int) -> str:

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -269,7 +269,7 @@ def test_build_activity_pattern_stable_narrative() -> None:
     # All-Stable apps and countries → core_fraction = 1.0 ≥ STABLE_ACTIVITY_THRESHOLD
     stable_state = {"a": {"m": (1 << 25) - 1}}
     result = build_activity_pattern(stable_state, stable_state, history_days=30)
-    assert "stable" in result.lower()
+    assert "recurring connections" in result.lower()
 
 
 def test_build_activity_pattern_variable_narrative() -> None:
@@ -277,7 +277,7 @@ def test_build_activity_pattern_variable_narrative() -> None:
     # All-Seen-once → core_fraction = 0.0 < VARIABLE_ACTIVITY_THRESHOLD
     transient_state = {"a": {"m": 1}}
     result = build_activity_pattern(transient_state, transient_state, history_days=30)
-    assert "varied" in result.lower()
+    assert "short-lived" in result.lower()
 
 
 def test_build_activity_pattern_uses_non_empty_dimension_only() -> None:
@@ -285,7 +285,7 @@ def test_build_activity_pattern_uses_non_empty_dimension_only() -> None:
     # All-Stable apps, empty country state → core_fraction uses apps only.
     stable_state = {"a": {"m": (1 << 25) - 1}}
     result = build_activity_pattern(stable_state, {}, history_days=30)
-    assert "stable" in result.lower()
+    assert "recurring connections" in result.lower()
 
 
 # --- build_intro_text ---
@@ -462,7 +462,7 @@ def test_concentration_narrative_high_concentration() -> None:
             cumulative_pcts=[60.0] + [100.0] * 9,
         )
     )
-    assert "small" in result.lower()
+    assert "few providers" in result.lower()
 
 
 def test_concentration_narrative_single_provider_not_broad() -> None:
@@ -482,7 +482,7 @@ def test_concentration_narrative_moderate_concentration() -> None:
             cumulative_pcts=[40.0, 70.0] + [100.0] * 8,
         )
     )
-    assert "established" in result.lower()
+    assert "at least half" in result.lower()
 
 
 def test_concentration_narrative_distributed() -> None:
@@ -494,7 +494,7 @@ def test_concentration_narrative_distributed() -> None:
             cumulative_pcts=[20.0, 35.0, 45.0, 60.0] + [100.0] * 6,
         )
     )
-    assert "broad" in result.lower()
+    assert "many providers" in result.lower()
 
 
 # --- build_countries_summary ---

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -280,12 +280,12 @@ def test_build_activity_pattern_variable_narrative() -> None:
     assert "varied" in result.lower()
 
 
-def test_build_activity_pattern_mixed_narrative() -> None:
-    """Return the mixed narrative when activity is between the two thresholds."""
-    # All-Stable apps, empty country state → core_fraction = 0.5, in [0.45, 0.70)
+def test_build_activity_pattern_uses_non_empty_dimension_only() -> None:
+    """Use the available dimension when the other has no active entities."""
+    # All-Stable apps, empty country state → core_fraction uses apps only.
     stable_state = {"a": {"m": (1 << 25) - 1}}
     result = build_activity_pattern(stable_state, {}, history_days=30)
-    assert "mix" in result.lower()
+    assert "stable" in result.lower()
 
 
 # --- build_intro_text ---
@@ -327,6 +327,27 @@ def test_build_applications_summary_mostly_transient() -> None:
     counts = {"Stable": 0, "Recurring": 0, "Occasional": 3, "Seen once": 1}
     result = build_applications_summary(4, counts)
     assert "briefly" in result
+
+
+def test_build_applications_summary_no_consistent_phrase_when_no_frequent() -> None:
+    """Do not mention consistent usage when Stable+Recurring is zero."""
+    counts = {"Stable": 0, "Recurring": 0, "Occasional": 2, "Seen once": 3}
+    result = build_applications_summary(5, counts)
+    assert "ran consistently throughout the period" not in result
+
+
+def test_build_applications_summary_no_transient_phrase_when_no_transient() -> None:
+    """Do not mention occasional/brief usage when transient categories are zero."""
+    counts = {"Stable": 2, "Recurring": 1, "Occasional": 0, "Seen once": 0}
+    result = build_applications_summary(3, counts)
+    assert "occasionally or briefly" not in result
+
+
+def test_build_applications_summary_zero_total_has_dedicated_message() -> None:
+    """Use a neutral message when no applications were observed."""
+    counts = {"Stable": 0, "Recurring": 0, "Occasional": 0, "Seen once": 0}
+    result = build_applications_summary(0, counts)
+    assert result == "No applications used the internet during this period."
 
 
 def test_build_applications_summary_mixed() -> None:
@@ -442,6 +463,14 @@ def test_concentration_narrative_high_concentration() -> None:
         )
     )
     assert "small" in result.lower()
+
+
+def test_concentration_narrative_single_provider_not_broad() -> None:
+    """Avoid broad-range wording when only one provider is present."""
+    result = build_providers_concentration_narrative(
+        ProviderConcentration(total_providers=1, cumulative_pcts=[100.0])
+    )
+    assert "broad" not in result.lower()
 
 
 def test_concentration_narrative_moderate_concentration() -> None:


### PR DESCRIPTION
## Summary

Refine Daily Activity Report wording and narrative tone.

Improve alignment with:
- recurrence visuals
- provider concentration curves
- underlying report metrics

## Testing

- `pytest`
- 269 passed
