### PR TITLE
Capture connections from other container namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Features
+- Add opt-in cross-namespace capture (`TAPMAP_CAPTURE_ALL_NETNS=1`, Linux + `pid: host`): aggregate connections from every other container's network namespace via `/proc/<pid>/net/*`, labeled by container (friendly names resolved through a mounted Docker socket, falling back to short ids). Default-off; degrades to host-only on error.
+
 ### Daily Activity Report
 - Refine narrative wording and report tone
 - Improve alignment between wording, recurrence visuals, and provider concentration curves

--- a/README.md
+++ b/README.md
@@ -434,6 +434,25 @@ In this setup, process names became available with:
 
 Behavior may vary across systems.
 
+### Capturing other containers' connections
+
+By default TapMap only sees the network namespace it runs in (the host namespace,
+when started with `--network host`). Connections inside *other* bridged containers
+live in their own namespaces and are not visible.
+
+Set `TAPMAP_CAPTURE_ALL_NETNS=1` (Linux only, requires `--pid host`) to also
+capture connections from every other container. TapMap reads each namespace's
+socket table from `/proc/<pid>/net/*` and labels the connections by container.
+
+    environment:
+      TAPMAP_CAPTURE_ALL_NETNS: "1"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro   # optional: friendly names
+
+The Docker socket is only used to resolve container ids to friendly names; without
+it, connections are labeled `docker:<short-id>`. The feature is opt-in and falls
+back to host-only capture on any error.
+
 ---
 
 ## Docker Hub

--- a/compose.linux.yaml
+++ b/compose.linux.yaml
@@ -14,8 +14,12 @@ services:
       TAPMAP_PORT: "8050"
       TAPMAP_HOST: "0.0.0.0"
       TAPMAP_DATA_DIR: /data
+      # Opt-in: also capture connections from other containers' namespaces.
+      # TAPMAP_CAPTURE_ALL_NETNS: "1"
 
     volumes:
       - ./docker-data:/data
+      # Optional, only with TAPMAP_CAPTURE_ALL_NETNS=1: resolve friendly names.
+      # - /var/run/docker.sock:/var/run/docker.sock:ro
 
     restart: unless-stopped

--- a/docs/backend-testing.md
+++ b/docs/backend-testing.md
@@ -176,6 +176,25 @@ Conclusion:
 - psutil is sufficient in Docker on Linux
 - ss does not provide a practical advantage in this environment
 
+### Cross-namespace capture (Docker, Linux)
+
+With `--network host`, psutil only sees the host network namespace, so connections
+inside *other* bridged containers are invisible (each has its own namespace).
+
+Tested with `TAPMAP_CAPTURE_ALL_NETNS=1` + `--pid host`:
+
+- network namespaces enumerated by grouping host PIDs by their `/proc/<pid>/ns/net`
+  inode; the host namespace (already covered by psutil) is skipped
+- each other namespace's socket table read directly from `/proc/<pid>/net/{tcp,tcp6,udp,udp6}`
+- container connections (e.g. jellyfin `217.131.67.82:443`, transmission peers)
+  appeared on the map, labeled by container
+- friendly container names resolved via a read-only mounted Docker socket; without
+  it, labels fall back to `docker:<short-id>`
+
+Conclusion:
+- cross-namespace capture makes other containers' connections visible
+- opt-in only; on any scan error it degrades to the host-only psutil result
+
 ---
 
 ## Docker (macOS host)

--- a/src/tapmap/model/netinfo.py
+++ b/src/tapmap/model/netinfo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -42,6 +43,11 @@ class NetInfo:
 
     def _select_backend(self) -> NetInfoBackend:
         system = platform.system()
+
+        if system == "Linux" and os.environ.get("TAPMAP_CAPTURE_ALL_NETNS") == "1":
+            from .netinfo_netns import NetNsNetInfo
+
+            return NetNsNetInfo(allowed_statuses=self.allowed_statuses)
 
         if system in {"Linux", "Windows"}:
             from .netinfo_psutil import PsutilNetInfo

--- a/src/tapmap/model/netinfo_netns.py
+++ b/src/tapmap/model/netinfo_netns.py
@@ -1,0 +1,331 @@
+"""Aggregate socket records across all network namespaces (Linux).
+
+The default psutil backend only sees the network namespace tapmap runs in. When
+tapmap runs as a Docker container with ``pid: host``, every host PID is visible,
+including the main process of each *other* container. The connection table of a
+namespace can be read from ``/proc/<pid>/net/{tcp,tcp6,udp,udp6}`` for any pid in
+that namespace, so this backend:
+
+1. Delegates to :class:`PsutilNetInfo` for the host/default namespace (preserving
+   full process attribution there), then
+2. Parses ``/proc/<pid>/net/*`` for every *other* namespace, labeling those rows
+   by the owning container.
+
+Opt-in only (``TAPMAP_CAPTURE_ALL_NETNS=1``); on any failure it degrades to the
+plain host-only psutil result.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import struct
+from typing import Any
+
+from .netinfo_psutil import PsutilNetInfo
+
+# /proc/net/tcp "st" column (hex) -> psutil-compatible status string.
+_TCP_STATES = {
+    "01": "ESTABLISHED",
+    "02": "SYN_SENT",
+    "03": "SYN_RECV",
+    "04": "FIN_WAIT1",
+    "05": "FIN_WAIT2",
+    "06": "TIME_WAIT",
+    "07": "CLOSE",
+    "08": "CLOSE_WAIT",
+    "09": "LAST_ACK",
+    "0A": "LISTEN",
+    "0B": "CLOSING",
+}
+
+# Per-protocol /proc/net file -> (proto, family, socket type string).
+_PROC_NET_FILES = (
+    ("tcp", "IPv4", "1"),
+    ("tcp6", "IPv6", "1"),
+    ("udp", "IPv4", "2"),
+    ("udp6", "IPv6", "2"),
+)
+
+_CGROUP_DOCKER_RE = re.compile(r"docker[-/]([0-9a-f]{12,64})")
+
+
+class NetNsNetInfo:
+    """Collect socket records across the host plus every container namespace."""
+
+    def __init__(self, allowed_statuses: set[str] | None = None) -> None:
+        self.allowed_statuses = allowed_statuses
+        self._host = PsutilNetInfo(allowed_statuses=allowed_statuses)
+
+    def get_data(self) -> list[dict[str, Any]]:
+        """Return host records plus per-container records, or host-only on error."""
+        host_records = self._host.get_data()
+        try:
+            container_records = self._collect_container_records()
+        except Exception:
+            # Never let namespace scanning break the existing host capture.
+            return host_records
+        return host_records + container_records
+
+    # -- namespace discovery ------------------------------------------------
+
+    def _collect_container_records(self) -> list[dict[str, Any]]:
+        host_inode = self._netns_inode(os.getpid())
+        groups = self._group_pids_by_netns(skip_inode=host_inode)
+        if not groups:
+            return []
+
+        names = self._docker_names()
+        results: list[dict[str, Any]] = []
+
+        for inode, pids in groups.items():
+            for pid in pids:
+                records = self._read_netns(pid)
+                if records is None:
+                    continue  # unreadable pid; try the next one in this netns
+                label = self._label_for(pid, names, inode)
+                for rec in records:
+                    rec["process_label"] = label
+                    rec["process_name"] = label
+                results.extend(records)
+                break  # one readable pid per netns yields the whole table
+
+        return results
+
+    def _group_pids_by_netns(self, *, skip_inode: int | None) -> dict[int, list[int]]:
+        """Map netns inode -> sorted pids, excluding the host namespace."""
+        groups: dict[int, list[int]] = {}
+        try:
+            entries = os.scandir("/proc")
+        except OSError:
+            return groups
+
+        with entries:
+            for entry in entries:
+                if not entry.name.isdigit():
+                    continue
+                pid = int(entry.name)
+                inode = self._netns_inode(pid)
+                if inode is None or inode == skip_inode:
+                    continue
+                groups.setdefault(inode, []).append(pid)
+
+        for pids in groups.values():
+            pids.sort()  # lowest pid first -> cleanest cgroup for labeling
+        return groups
+
+    @staticmethod
+    def _netns_inode(pid: int) -> int | None:
+        """Return the network-namespace inode for a pid, or None if unreadable."""
+        try:
+            return os.stat(f"/proc/{pid}/ns/net").st_ino
+        except (PermissionError, FileNotFoundError, ProcessLookupError, OSError):
+            return None
+
+    # -- /proc/net parsing --------------------------------------------------
+
+    def _read_netns(self, pid: int) -> list[dict[str, Any]] | None:
+        """Parse a pid's four /proc/net files. None if the whole netns is unreadable."""
+        records: list[dict[str, Any]] = []
+        seen: set[tuple[Any, ...]] = set()
+        readable = False
+
+        for fname, family, sock_type in _PROC_NET_FILES:
+            try:
+                with open(f"/proc/{pid}/net/{fname}", encoding="ascii") as fh:
+                    lines = fh.readlines()
+            except (PermissionError, FileNotFoundError, ProcessLookupError, OSError):
+                continue
+            readable = True
+
+            proto = "tcp" if fname.startswith("tcp") else "udp"
+            for line in lines[1:]:
+                rec = self._parse_line(line, proto=proto, family=family, sock_type=sock_type)
+                if rec is None:
+                    continue
+                if not self._is_included(proto, rec["status"]):
+                    continue
+                key = (
+                    proto,
+                    family,
+                    rec["laddr_ip"],
+                    rec["laddr_port"],
+                    rec["raddr_ip"],
+                    rec["raddr_port"],
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                rec["pid"] = pid
+                records.append(rec)
+
+        return records if readable else None
+
+    def _parse_line(
+        self, line: str, *, proto: str, family: str, sock_type: str
+    ) -> dict[str, Any] | None:
+        parts = line.split()
+        if len(parts) < 4:
+            return None
+
+        l_ip, l_port = self._parse_addr(parts[1], family)
+        if l_port is None:
+            return None
+        r_ip, r_port = self._parse_addr(parts[2], family)
+
+        if proto == "tcp":
+            status = _TCP_STATES.get(parts[3].upper(), "NONE")
+        else:
+            status = "NONE"
+
+        out_family = family
+        # IPv4-mapped IPv6 (::ffff:a.b.c.d) -> report as plain IPv4 so it matches
+        # and dedups against psutil host rows.
+        if family == "IPv6":
+            l_ip, out_family = self._demap(l_ip, out_family)
+            r_ip, out_family = self._demap(r_ip, out_family)
+
+        return {
+            "pid": None,
+            "proto": proto,
+            "status": status,
+            "family": out_family,
+            "type": sock_type,
+            "laddr_ip": l_ip,
+            "laddr_port": l_port,
+            "raddr_ip": r_ip,
+            "raddr_port": r_port,
+            "process_status": "OK",
+            "process_label": None,  # filled in by the caller with the container label
+            "process_name": None,
+            "exe": None,
+            "cmdline": None,
+        }
+
+    @staticmethod
+    def _demap(ip: str | None, family: str) -> tuple[str | None, str]:
+        if ip and ip.startswith("::ffff:") and "." in ip:
+            return ip[len("::ffff:") :], "IPv4"
+        return ip, family
+
+    @staticmethod
+    def _parse_addr(token: str, family: str) -> tuple[str | None, int | None]:
+        """Decode a HEXIP:HEXPORT token from /proc/net into (ip, port)."""
+        if ":" not in token:
+            return None, None
+        hex_ip, _, hex_port = token.rpartition(":")
+        try:
+            port = int(hex_port, 16)
+        except ValueError:
+            return None, None
+
+        try:
+            if family == "IPv4":
+                raw = bytes.fromhex(hex_ip)[::-1]  # little-endian 32-bit word
+                ip = socket.inet_ntop(socket.AF_INET, raw)
+            else:
+                # Four little-endian 32-bit words; byte-reverse each word.
+                words = struct.unpack("<4I", bytes.fromhex(hex_ip))
+                raw = struct.pack(">4I", *words)
+                ip = socket.inet_ntop(socket.AF_INET6, raw)
+        except (ValueError, OSError):
+            return None, None
+
+        # All-zero address == unbound/no remote -> no endpoint.
+        if port == 0 and ip in ("0.0.0.0", "::"):
+            return None, None
+        if ip in ("0.0.0.0", "::"):
+            ip = None
+        return ip, port
+
+    # -- container labeling -------------------------------------------------
+
+    def _label_for(self, pid: int, names: dict[str, str], inode: int) -> str:
+        cid = self._container_id(pid)
+        if cid is None:
+            return f"netns:{inode}"
+        short = cid[:12]
+        return names.get(cid) or names.get(short) or f"docker:{short}"
+
+    @staticmethod
+    def _container_id(pid: int) -> str | None:
+        try:
+            with open(f"/proc/{pid}/cgroup", encoding="ascii") as fh:
+                text = fh.read()
+        except (PermissionError, FileNotFoundError, ProcessLookupError, OSError):
+            return None
+        match = _CGROUP_DOCKER_RE.search(text)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _docker_names() -> dict[str, str]:
+        """Map container id (full and 12-char) -> friendly name via the Docker UDS.
+
+        Returns an empty map (so labels fall back to short ids) if the socket is
+        absent or unreachable.
+        """
+        sock_path = "/var/run/docker.sock"
+        if not os.path.exists(sock_path):
+            return {}
+
+        try:
+            raw = _docker_get(sock_path, "/containers/json?all=1")
+        except (OSError, ValueError):
+            return {}
+
+        import json
+
+        try:
+            containers = json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+
+        names: dict[str, str] = {}
+        for c in containers:
+            cid = c.get("Id")
+            name_list = c.get("Names") or []
+            name = name_list[0].lstrip("/") if name_list else None
+            if cid and name:
+                names[cid] = name
+                names[cid[:12]] = name
+        return names
+
+    def _is_included(self, proto: str, status: str) -> bool:
+        """Mirror PsutilNetInfo: filter TCP by allowed_statuses; keep all UDP."""
+        return not (
+            proto == "tcp"
+            and self.allowed_statuses is not None
+            and status not in self.allowed_statuses
+        )
+
+
+def _docker_get(sock_path: str, path: str) -> str:
+    """Minimal HTTP/1.0 GET over the Docker Unix socket; returns the JSON body."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(2.0)
+    try:
+        sock.connect(sock_path)
+        request = (
+            f"GET {path} HTTP/1.0\r\n"
+            "Host: localhost\r\n"
+            "Accept: application/json\r\n"
+            "\r\n"
+        )
+        sock.sendall(request.encode("ascii"))
+
+        chunks: list[bytes] = []
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        sock.close()
+
+    data = b"".join(chunks)
+    header, _, body = data.partition(b"\r\n\r\n")
+    status_line = header.split(b"\r\n", 1)[0]
+    if b" 200 " not in status_line:
+        raise ValueError(f"docker socket returned: {status_line!r}")
+    return body.decode("utf-8", errors="replace")

--- a/src/tapmap/runtime.py
+++ b/src/tapmap/runtime.py
@@ -136,7 +136,10 @@ def _detect_network_backend() -> tuple[str, str]:
     if system in {"Windows", "Linux"}:
         import psutil
 
-        return "psutil", getattr(psutil, "__version__", "-")
+        version = getattr(psutil, "__version__", "-")
+        if system == "Linux" and os.environ.get("TAPMAP_CAPTURE_ALL_NETNS") == "1":
+            return "psutil+netns", version
+        return "psutil", version
 
     if system == "Darwin":
         try:

--- a/tests/test_netinfo_netns.py
+++ b/tests/test_netinfo_netns.py
@@ -1,0 +1,176 @@
+"""Tests for the cross-namespace backend's parsing and labeling."""
+from __future__ import annotations
+
+import pytest
+
+from tapmap.model.netinfo_netns import _TCP_STATES, NetNsNetInfo
+
+
+def _backend(allowed=None):
+    return NetNsNetInfo(allowed_statuses=allowed)
+
+
+# -- address parsing --------------------------------------------------------
+
+
+def test_parse_ipv4_address_little_endian():
+    # 0100007F:1F90 -> 127.0.0.1:8080 (bytes stored little-endian)
+    ip, port = _backend()._parse_addr("0100007F:1F90", "IPv4")
+    assert ip == "127.0.0.1"
+    assert port == 8080
+
+
+def test_parse_ipv4_remote():
+    # 52438352 little-endian -> 82.131.67.... actually decode generically.
+    ip, port = _backend()._parse_addr("0F02000A:01BB", "IPv4")
+    assert ip == "10.0.2.15"
+    assert port == 443
+
+
+def test_parse_unbound_returns_none():
+    ip, port = _backend()._parse_addr("00000000:0000", "IPv4")
+    assert ip is None
+    assert port is None
+
+
+def test_parse_ipv6():
+    # loopback ::1 in /proc form, port 0x1F90.
+    token = "00000000000000000000000001000000:1F90"
+    ip, port = _backend()._parse_addr(token, "IPv6")
+    assert ip == "::1"
+    assert port == 8080
+
+
+# -- line parsing -----------------------------------------------------------
+
+
+def test_parse_line_established_ipv4():
+    line = "  1: 0F02000A:E4D2 12345678:01BB 01 00000000:00000000 00:00000000 00000000  1000 0 99 1 0"
+    rec = _backend()._parse_line(line, proto="tcp", family="IPv4", sock_type="1")
+    assert rec["status"] == "ESTABLISHED"
+    assert rec["proto"] == "tcp"
+    assert rec["family"] == "IPv4"
+    assert rec["type"] == "1"
+    assert rec["laddr_ip"] == "10.0.2.15"
+    assert rec["raddr_port"] == 443
+    assert rec["process_status"] == "OK"
+    assert rec["exe"] is None and rec["cmdline"] is None
+
+
+def test_parse_line_listen_has_no_remote():
+    line = "  0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 1 1 0"
+    rec = _backend()._parse_line(line, proto="tcp", family="IPv4", sock_type="1")
+    assert rec["status"] == "LISTEN"
+    assert rec["raddr_ip"] is None
+    assert rec["raddr_port"] is None
+
+
+def test_udp_status_is_none():
+    line = "  0: 0100007F:1F90 0F02000A:01BB 01 00000000:00000000 00:00000000 00000000 1000 0 1 1 0"
+    rec = _backend()._parse_line(line, proto="udp", family="IPv4", sock_type="2")
+    assert rec["status"] == "NONE"
+    assert rec["type"] == "2"
+
+
+def test_ipv4_mapped_demapped_to_ipv4():
+    # ::ffff:217.131.67.82 in /proc tcp6 form. 0xD9834352 == 217.131.67.82.
+    token = "0000000000000000FFFF00005243 83D9".replace(" ", "")
+    token = token + ":01BB"
+    line = f"  3: 00000000000000000000000000000000:E4D2 {token} 01 0 0 0"
+    rec = _backend()._parse_line(line, proto="tcp", family="IPv6", sock_type="1")
+    assert rec["raddr_ip"] == "217.131.67.82"
+    assert rec["family"] == "IPv4"
+    assert rec["raddr_port"] == 443
+
+
+# -- state table ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("01", "ESTABLISHED"),
+        ("0A", "LISTEN"),
+        ("06", "TIME_WAIT"),
+        ("08", "CLOSE_WAIT"),
+    ],
+)
+def test_state_table(code, expected):
+    assert _TCP_STATES[code] == expected
+
+
+def test_unknown_state_falls_back_to_none():
+    line = "  0: 0100007F:1F90 0F02000A:01BB FF 0 0 0"
+    rec = _backend()._parse_line(line, proto="tcp", family="IPv4", sock_type="1")
+    assert rec["status"] == "NONE"
+
+
+# -- allowed_statuses filter ------------------------------------------------
+
+
+def test_allowed_statuses_filters_tcp():
+    b = _backend(allowed={"ESTABLISHED"})
+    assert b._is_included("tcp", "LISTEN") is False
+    assert b._is_included("tcp", "ESTABLISHED") is True
+    # UDP always kept regardless of filter.
+    assert b._is_included("udp", "NONE") is True
+
+
+# -- container labeling -----------------------------------------------------
+
+
+def test_label_resolves_friendly_name():
+    b = _backend()
+    names = {"5c543658a54d": "jellyfin"}
+    b._container_id = lambda pid: "5c543658a54dd9eb5651fcf71e160a00795a50c846b5"  # noqa: ARG005
+    label = b._label_for(412095, names, inode=4026531999)
+    assert label == "jellyfin"
+
+
+def test_label_falls_back_to_short_id_when_name_unknown():
+    b = _backend()
+    b._container_id = lambda pid: "abcdef0123456789" + "0" * 48  # noqa: ARG005
+    label = b._label_for(1, {}, inode=4026531999)
+    assert label == "docker:abcdef012345"
+
+
+def test_label_falls_back_to_netns_for_non_docker():
+    b = _backend()
+    b._container_id = lambda pid: None  # noqa: ARG005
+    label = b._label_for(1, {}, inode=4026531999)
+    assert label == "netns:4026531999"
+
+
+def test_container_id_parses_cgroup(tmp_path, monkeypatch):
+    cid = "5c543658a54dd9eb5651fcf71e160a00795a50c846b5101c6e4156dcdbf107b9"
+    proc = tmp_path / "proc" / "412095"
+    proc.mkdir(parents=True)
+    (proc / "cgroup").write_text(f"0::/system.slice/docker-{cid}.scope\n")
+    monkeypatch.chdir(tmp_path)
+
+    # Point the open() at our fake tree via a tiny wrapper.
+    import builtins
+
+    real_open = builtins.open
+
+    def fake_open(path, *a, **k):
+        if str(path) == "/proc/412095/cgroup":
+            return real_open(proc / "cgroup", *a, **k)
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert NetNsNetInfo._container_id(412095) == cid[:64]
+
+
+# -- graceful degradation ---------------------------------------------------
+
+
+def test_get_data_returns_host_only_on_scan_error(monkeypatch):
+    b = _backend()
+    monkeypatch.setattr(b._host, "get_data", lambda: [{"pid": 1, "proto": "tcp"}])
+
+    def boom():
+        raise RuntimeError("no /proc")
+
+    monkeypatch.setattr(b, "_collect_container_records", boom)
+    assert b.get_data() == [{"pid": 1, "proto": "tcp"}]


### PR DESCRIPTION
## Problem

TapMap's psutil backend only reads the **network namespace it runs in**. Run as a Docker container with `--network host --pid host`, it sees the host namespace (and host-network containers), but **bridged containers' connections are invisible** — each lives in its own netns.

## Change

New **opt-in** backend `NetNsNetInfo` (`TAPMAP_CAPTURE_ALL_NETNS=1`, Linux + `pid: host`) that aggregates connections across every namespace:

- Delegates to `PsutilNetInfo` for the **host** namespace (unchanged process attribution), then reads `/proc/<pid>/net/{tcp,tcp6,udp,udp6}` for each **other** namespace, discovered by grouping host PIDs by their `/proc/<pid>/ns/net` inode.
- **Skips the host namespace** (psutil owns it) to avoid double counting.
- Parses hex IPv4/IPv6 (incl. IPv4-mapped) addresses and TCP state codes into the **existing record shape**, so geo-enrichment, the map, and open-ports work unchanged.
- **Labels rows by container**: friendly names via a read-only mounted Docker socket, falling back to `docker:<short-id>`, then `netns:<inode>`.
- **Degrades to host-only** on any scan error. Default-off — existing behavior preserved when the env var is unset.

Backend reported as `psutil+netns`.

## Usage

```yaml
environment:
  TAPMAP_CAPTURE_ALL_NETNS: "1"
volumes:
  - /var/run/docker.sock:/var/run/docker.sock:ro   # optional: friendly names
```

## Testing

- New `tests/test_netinfo_netns.py` (19 tests): address/line parsing, IPv4-mapped demapping, state-code table, `allowed_statuses` filter, cgroup→name labeling + fallbacks, graceful degradation. Full netinfo suite (22) green.
- Verified live against a real multi-container host: host processes keep real names; container connections (conduwuit, nginx-proxy-manager, vpn-router, jellyfin, sonarr, transmission peers) captured and labeled by container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)