### PR TITLE
feat(runtime): add browser launch and cache retention options

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,3 +375,4 @@ Thanks to @TechnVision for raising the configurable port use case.
 Thanks to @desrod for suggesting a solution for configurable port support.  
 Thanks to @hugalafutro for suggesting optional SYS_PTRACE support for process visibility on Linux.
 
+Thanks to @mad-tunes for suggesting optional browser launch control when running TapMap as a service, and configurable cache retention to reduce map clutter on busy systems.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -104,3 +104,55 @@ If both values are present and valid, TapMap uses the specified coordinates for 
 If either value is missing or invalid, TapMap falls back to the configured location behavior.
 
 This setting is useful when automatic location detection is inaccurate or when you prefer not to use public-IP based location detection.
+
+## TAPMAP_LAUNCH_BROWSER
+
+Control whether TapMap automatically opens the default web browser at startup.
+
+Default:
+
+```text
+true
+```
+
+Values:
+
+```text
+true
+false
+```
+
+Example:
+
+```bash
+TAPMAP_LAUNCH_BROWSER=false tapmap
+```
+
+This setting is useful when running TapMap as a service or starting it automatically without user interaction.
+
+## TAPMAP_CACHE_RETENTION_MIN
+
+Control how long inactive services remain visible on the map.
+
+Default:
+
+```text
+0
+```
+
+Values:
+
+```text
+0     Keep cached services until Clear cache is used.
+>0    Remove cached services not seen for the specified number of minutes.
+```
+
+Example:
+
+```bash
+TAPMAP_CACHE_RETENTION_MIN=15 tapmap
+```
+
+This setting affects only the map cache.
+
+It does not affect the current network snapshot, Open Ports, LAN/LOCAL Services, Unmapped Services, or the 30-day Insights history.

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -141,6 +141,7 @@ class TapMap:
             coord_precision=COORD_PRECISION,
             debug=self.DEBUG_COORDS,
             is_docker=self.runtime.is_docker,
+            cache_retention_min=self.runtime.cache_retention_min,
         )
 
         self.modal_text = ModalTextBuilder(
@@ -1107,7 +1108,8 @@ class TapMap:
         host = self.runtime.server_host
         port = self.runtime.server_port
         url = f"http://{host}:{port}/"
-        self._open_browser(url)
+        if self.runtime.launch_browser and not self.runtime.is_docker:
+            self._open_browser(url)
 
         self.app.run(
             host=host,

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -342,6 +342,8 @@ class TapMap:
             "net_backend_version": self.runtime.net_backend_version,
             "server_host": self.runtime.server_host,
             "server_port": self.runtime.server_port,
+            "launch_browser": self.runtime.launch_browser,
+            "cache_retention_min": self.runtime.cache_retention_min,
             "is_docker": self.runtime.is_docker,
             "geo_provider": geo_status["provider"],
             "geo_database_date": geo_status["local_display_date"]

--- a/src/tapmap/config.py
+++ b/src/tapmap/config.py
@@ -12,6 +12,15 @@ LocationMode = Literal["auto", "none"]
 SERVER_PORT: Final[int] = 8050
 """HTTP port used by the local Dash server."""
 
+LAUNCH_BROWSER: Final[bool] = True
+"""Open the default web browser automatically at startup."""
+
+CACHE_RETENTION_MIN: Final[int] = 0
+"""Keep cached connections until Clear cache.
+
+0 disables automatic cache expiration.
+"""
+
 MY_LOCATION: Final[tuple[float, float] | LocationMode] = "auto"
 """Local map marker options:
 - (lon, lat): fixed manual coordinates

--- a/src/tapmap/runtime.py
+++ b/src/tapmap/runtime.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .app_dirs import ensure_app_data_dir, ensure_native_app_data_dir
-from .config import SERVER_PORT
+from .config import (
+    CACHE_RETENTION_MIN,
+    LAUNCH_BROWSER,
+    SERVER_PORT,
+)
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,8 @@ class RuntimeContext:
     net_backend_version: str
     server_host: str
     server_port: int
+    launch_browser: bool
+    cache_retention_min: int
     is_docker: bool
     location_override: tuple[float, float] | None
 
@@ -72,6 +78,36 @@ def _get_server_host(is_docker: bool) -> str:
 def _get_server_port() -> int:
     """Return server port for the current runtime."""
     return int(os.environ.get("TAPMAP_PORT", str(SERVER_PORT)))
+
+def _get_launch_browser() -> bool:
+    """Return whether to launch the browser automatically."""
+    value = os.environ.get("TAPMAP_LAUNCH_BROWSER")
+
+    if value is None:
+        return LAUNCH_BROWSER
+
+    value = value.strip().lower()
+
+    if value in {"1", "true", "yes", "on"}:
+        return True
+
+    if value in {"0", "false", "no", "off"}:
+        return False
+
+    return LAUNCH_BROWSER
+
+
+def _get_cache_retention_min() -> int:
+    """Return UI cache retention time in minutes."""
+    value = os.environ.get("TAPMAP_CACHE_RETENTION_MIN")
+
+    if value is None:
+        return CACHE_RETENTION_MIN
+
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return CACHE_RETENTION_MIN
 
 def _detect_docker() -> bool:
     """Return True when running in Docker."""
@@ -114,6 +150,8 @@ def build_runtime(meta: AppMeta) -> RuntimeContext:
     is_docker = _detect_docker()
     server_host = _get_server_host(is_docker)
     server_port = _get_server_port()
+    launch_browser = _get_launch_browser()
+    cache_retention_min = _get_cache_retention_min()
     location_override = _get_location_override()
 
     return RuntimeContext(
@@ -125,6 +163,8 @@ def build_runtime(meta: AppMeta) -> RuntimeContext:
         net_backend_version=net_backend_version,
         server_host=server_host,
         server_port=server_port,
+        launch_browser=launch_browser,
+        cache_retention_min=cache_retention_min,
         is_docker=is_docker,
         location_override=location_override,
     )

--- a/src/tapmap/ui/about_view.py
+++ b/src/tapmap/ui/about_view.py
@@ -37,6 +37,11 @@ def render_about(
     poll_ms = app_info.get("poll_interval_ms")
     coord_precision = app_info.get("coord_precision")
     near_km = app_info.get("zoom_near_km")
+    launch_browser = bool(app_info.get("launch_browser", True))
+
+    cache_retention_min = app_info.get("cache_retention_min")
+    if not isinstance(cache_retention_min, int):
+        cache_retention_min = 0
 
     geoinfo_enabled = bool(app_info.get("geoinfo_enabled", False))
     geo_provider = str(app_info.get("geo_provider") or "-")
@@ -100,6 +105,13 @@ def render_about(
         ("Backend version", net_backend_version),
         ("Server host", server_host),
         ("Docker", "Yes" if is_docker else "No"),
+        ("Browser launch", "Enabled" if launch_browser else "Disabled"),
+        (
+            "Cache retention",
+            "Until Clear cache"
+            if cache_retention_min == 0
+            else f"{cache_retention_min} min",
+        ),
     ]
 
     return [

--- a/src/tapmap/ui/cache_view.py
+++ b/src/tapmap/ui/cache_view.py
@@ -22,10 +22,12 @@ class CacheViewBuilder:
         coord_precision: int = 3,
         debug: bool = False,
         is_docker: bool = False,
+        cache_retention_min: int = 0,
     ) -> None:
         self.coord_precision = int(coord_precision)
         self.debug = bool(debug)
         self.is_docker = bool(is_docker)
+        self.cache_retention_min = int(cache_retention_min)
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
@@ -75,6 +77,7 @@ class CacheViewBuilder:
         map_candidates: list[dict[str, Any]],
     ) -> dict[str, Any]:
         """Merge map candidates into a per-service cache."""
+        now = datetime.now().timestamp()
         cache = dict(ui_cache) if isinstance(ui_cache, dict) else {}
 
         for candidate in map_candidates:
@@ -100,6 +103,8 @@ class CacheViewBuilder:
                 entry = self._new_entry(candidate, ip=ip, port=port, proto=proto)
                 cache[key] = entry
 
+            entry["last_seen"] = now
+
             if process_name:
                 self._merge_process(entry, process_name=process_name, pid=pid)
             
@@ -109,7 +114,25 @@ class CacheViewBuilder:
                 attrs=("proto", "lon", "lat", "city", "country", "asn", "asn_org"),
             )
 
+        self._prune_cache(cache, now)
         return cache
+    
+    def _prune_cache(
+        self,
+        cache: dict[str, Any],
+        now: float,
+    ) -> None:
+        """Remove cache entries older than the configured retention period."""
+        retention_min = self.cache_retention_min
+
+        if retention_min <= 0:
+            return
+
+        cutoff = now - (retention_min * 60)
+
+        for key, entry in list(cache.items()):
+            if entry["last_seen"] < cutoff:
+                del cache[key]
 
     def _new_entry(
         self, candidate: dict[str, Any], *, ip: str, port: int, proto: str | None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from tapmap.runtime import _get_location_override
+from tapmap.runtime import (
+    _get_cache_retention_min,
+    _get_launch_browser,
+    _get_location_override,
+)
 
 
 class TestGetLocationOverride:
@@ -96,3 +100,54 @@ class TestGetLocationOverride:
             result = _get_location_override()
             assert result == (10.0, 50.0)
 
+
+class TestGetLaunchBrowser:
+    """Test _get_launch_browser() env var parser."""
+
+    def test_default_returns_config(self) -> None:
+        """Missing env var returns config default."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert _get_launch_browser() is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_true_values(self, value: str) -> None:
+        """Accepted true values return True."""
+        with patch.dict(os.environ, {"TAPMAP_LAUNCH_BROWSER": value}, clear=True):
+            assert _get_launch_browser() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+    def test_false_values(self, value: str) -> None:
+        """Accepted false values return False."""
+        with patch.dict(os.environ, {"TAPMAP_LAUNCH_BROWSER": value}, clear=True):
+            assert _get_launch_browser() is False
+
+    def test_invalid_value_returns_config_default(self) -> None:
+        """Invalid value falls back to config default."""
+        with patch.dict(os.environ, {"TAPMAP_LAUNCH_BROWSER": "banana"}, clear=True):
+            assert _get_launch_browser() is True
+
+
+class TestGetCacheRetentionMin:
+    """Test _get_cache_retention_min() env var parser."""
+
+    def test_default_returns_config(self) -> None:
+        """Missing env var returns config default."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert _get_cache_retention_min() == 0
+
+    def test_valid_value(self) -> None:
+        """Positive integer is accepted."""
+        with patch.dict(os.environ, {"TAPMAP_CACHE_RETENTION_MIN": "15"}, clear=True):
+            assert _get_cache_retention_min() == 15
+
+    @pytest.mark.parametrize("value", ["-1", "-15"])
+    def test_negative_values_return_zero(self, value: str) -> None:
+        """Negative values are clamped to zero."""
+        with patch.dict(os.environ, {"TAPMAP_CACHE_RETENTION_MIN": value}, clear=True):
+            assert _get_cache_retention_min() == 0
+
+    @pytest.mark.parametrize("value", ["abc", "1.5", ""])
+    def test_invalid_values_return_config_default(self, value: str) -> None:
+        """Invalid values fall back to config default."""
+        with patch.dict(os.environ, {"TAPMAP_CACHE_RETENTION_MIN": value}, clear=True):
+            assert _get_cache_retention_min() == 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -39,6 +39,8 @@ def _runtime_ctx(tmp_path: Path) -> RuntimeContext:
         net_backend_version="test",
         server_host="127.0.0.1",
         server_port=8050,
+        launch_browser=True,
+        cache_retention_min=0,
         is_docker=False,
         location_override=None,
     )


### PR DESCRIPTION
## Summary

Add two optional runtime environment variables:

- `TAPMAP_LAUNCH_BROWSER`
- `TAPMAP_CACHE_RETENTION_MIN`

`TAPMAP_LAUNCH_BROWSER` allows disabling automatic browser launch, making it easier to run TapMap as a background service or via scheduled startup.

`TAPMAP_CACHE_RETENTION_MIN` automatically removes inactive cached map connections after a configurable number of minutes, reducing map clutter on busy systems while leaving snapshots, reports and Insights unchanged.

## Changes

- add `LAUNCH_BROWSER` and `CACHE_RETENTION_MIN` configuration options
- add runtime environment variable parsing
- extend `RuntimeContext`
- make browser launch optional
- add automatic UI cache pruning
- document the new environment variables
- rename runtime test module
- add runtime parser tests
- acknowledge the feature suggestion in the README

## Testing

- Manual testing:
  - verified browser launch enabled/disabled
  - verified automatic cache expiration
- Automated:
  - Ruff passes
  - All tests pass (`297 passed`)
