### PR TITLE
Refactor build and release workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,25 +20,26 @@ on:
 jobs:
   docker:
     name: Docker Tests
-    uses: ./.github/workflows/pipeline-docker.yaml
-    with:
-      mode: build
+    uses: ./.github/workflows/validate-docker.yaml
 
   linux:
     name: Linux Build
     uses: ./.github/workflows/pipeline-linux.yaml
-    with:
-      mode: build
 
   windows:
     name: Windows Build
     uses: ./.github/workflows/pipeline-windows.yaml
-    with:
-      mode: build
 
-  macos:
-    name: macOS Build
+  macos-arm64:
+    name: macOS (Apple Silicon)
     uses: ./.github/workflows/pipeline-macos.yaml
     with:
-      mode: build
+      architecture: arm64
+    secrets: inherit
+
+  macos-x86_64:
+    name: macOS (Intel)
+    uses: ./.github/workflows/pipeline-macos.yaml
+    with:
+      architecture: x86_64
     secrets: inherit

--- a/.github/workflows/pipeline-linux.yaml
+++ b/.github/workflows/pipeline-linux.yaml
@@ -2,22 +2,8 @@ name: Linux Pipeline
 
 on:
   workflow_dispatch:
-    inputs:
-      mode:
-        description: Build or release
-        type: choice
-        options:
-          - build
-          - release
-        default: build
 
   workflow_call:
-    inputs:
-      mode:
-        description: Build or release
-        required: false
-        type: string
-        default: build
 
 jobs:
   build:

--- a/.github/workflows/pipeline-macos.yaml
+++ b/.github/workflows/pipeline-macos.yaml
@@ -30,34 +30,108 @@ jobs:
       - id: matrix
         shell: bash
         run: |
-          echo "Mode is: ${{ inputs.mode }}"
-
           if [ "${{ inputs.mode }}" = "release" ]; then
             echo 'matrix={"include":[{"arch":"arm64"},{"arch":"x86_64"}]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"include":[{"arch":"arm64"}]}' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Show generated matrix
-        run: |
-          echo '${{ steps.matrix.outputs.matrix }}'
-
   build:
     needs: prepare
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     runs-on: macos-latest
 
     steps:
-      - name: Show matrix values
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Select Python interpreter
         shell: bash
         run: |
-          echo "Mode : ${{ inputs.mode }}"
-          echo "Arch : ${{ matrix.arch }}"
-          echo "Runner architecture:"
-          uname -m
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            echo "PYTHON=arch -x86_64 python" >> "$GITHUB_ENV"
+          else
+            echo "PYTHON=python" >> "$GITHUB_ENV"
+          fi
 
-      - name: Done
-        run: echo "Dynamic matrix test completed."
+      - name: Install dependencies
+        shell: bash
+        run: |
+          echo "Using: $PYTHON"
+          $PYTHON --version
+
+          $PYTHON -m pip install --upgrade pip
+          $PYTHON -m pip install -r requirements-tests.txt
+          $PYTHON -m pip install pyinstaller
+
+          brew install create-dmg
+
+      - name: Import signing certificate
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
+
+          security create-keychain -p runner build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p runner build.keychain
+
+          security import certificate.p12 \
+            -k build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k runner \
+            build.keychain
+
+      - name: Create notary profile
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          xcrun notarytool store-credentials tapmap-notary \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD"
+
+      - name: Show signing identities
+        shell: bash
+        run: |
+          security find-identity -v -p codesigning
+
+      - name: Build (same as local)
+        shell: bash
+        run: |
+          echo "Using: $PYTHON"
+
+          $PYTHON tools/build.py --sign
+
+      - name: Show build output
+        shell: bash
+        run: |
+          ls -la dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: tapmap-macos-${{ matrix.arch }}
+          path: dist/TapMap-*-macos-${{ matrix.arch }}.dmg
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/pipeline-macos.yaml
+++ b/.github/workflows/pipeline-macos.yaml
@@ -20,81 +20,44 @@ on:
         default: build
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - id: matrix
+        shell: bash
+        run: |
+          echo "Mode is: ${{ inputs.mode }}"
+
+          if [ "${{ inputs.mode }}" = "release" ]; then
+            echo 'matrix={"include":[{"arch":"arm64"},{"arch":"x86_64"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"arch":"arm64"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show generated matrix
+        run: |
+          echo '${{ steps.matrix.outputs.matrix }}'
+
   build:
+    needs: prepare
+
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
     runs-on: macos-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
+      - name: Show matrix values
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-tests.txt
-          pip install pyinstaller
-          brew install create-dmg
+          echo "Mode : ${{ inputs.mode }}"
+          echo "Arch : ${{ matrix.arch }}"
+          echo "Runner architecture:"
+          uname -m
 
-      - name: Import signing certificate
-        shell: bash
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
-
-          security create-keychain -p runner build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p runner build.keychain
-
-          security import certificate.p12 \
-            -k build.keychain \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
-
-          security set-key-partition-list \
-            -S apple-tool:,apple: \
-            -s \
-            -k runner \
-            build.keychain
-
-      - name: Create notary profile
-        shell: bash
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        run: |
-          xcrun notarytool store-credentials tapmap-notary \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD"
-
-      - name: Show signing identities
-        shell: bash
-        run: |
-          security find-identity -v -p codesigning
-
-      - name: Build (same as local)
-        shell: bash
-        run: |
-          python tools/build.py --sign
-
-      - name: Show build output
-        shell: bash
-        run: |
-          ls -la dist
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: tapmap-macos-dmg
-          path: dist/TapMap-*-macos-arm64.dmg
-          if-no-files-found: error
-          retention-days: 7
+      - name: Done
+        run: echo "Dynamic matrix test completed."

--- a/.github/workflows/pipeline-macos.yaml
+++ b/.github/workflows/pipeline-macos.yaml
@@ -3,46 +3,26 @@ name: macOS Pipeline
 on:
   workflow_dispatch:
     inputs:
-      mode:
-        description: Build or release
+      architecture:
+        description: Target architecture
         type: choice
         options:
-          - build
-          - release
-        default: build
+          - arm64
+          - x86_64
+        default: arm64
 
   workflow_call:
     inputs:
-      mode:
-        description: Build or release
-        required: false
+      architecture:
+        description: Target architecture
+        required: true
         type: string
-        default: build
+
+env:
+  TARGET_ARCH: ${{ inputs.architecture }}
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-    steps:
-      - id: matrix
-        shell: bash
-        run: |
-          if [ "${{ inputs.mode }}" = "release" ]; then
-            echo 'matrix={"include":[{"arch":"arm64"},{"arch":"x86_64"}]}' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix={"include":[{"arch":"arm64"}]}' >> "$GITHUB_OUTPUT"
-          fi
-
   build:
-    needs: prepare
-
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-
     runs-on: macos-latest
 
     steps:
@@ -57,7 +37,7 @@ jobs:
       - name: Select Python interpreter
         shell: bash
         run: |
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+          if [[ "$TARGET_ARCH" == "x86_64" ]]; then
             echo "PYTHON=arch -x86_64 python" >> "$GITHUB_ENV"
           else
             echo "PYTHON=python" >> "$GITHUB_ENV"
@@ -66,7 +46,9 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          echo "Using: $PYTHON"
+          echo "Target architecture: $TARGET_ARCH"
+          echo "Using interpreter: $PYTHON"
+
           $PYTHON --version
 
           $PYTHON -m pip install --upgrade pip
@@ -119,7 +101,8 @@ jobs:
       - name: Build (same as local)
         shell: bash
         run: |
-          echo "Using: $PYTHON"
+          echo "Target architecture: $TARGET_ARCH"
+          echo "Using interpreter: $PYTHON"
 
           $PYTHON tools/build.py --sign
 
@@ -131,7 +114,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: tapmap-macos-${{ matrix.arch }}
-          path: dist/TapMap-*-macos-${{ matrix.arch }}.dmg
+          name: tapmap-macos-${{ env.TARGET_ARCH }}
+          path: dist/TapMap-*-macos-${{ env.TARGET_ARCH }}.dmg
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -2,22 +2,8 @@ name: Windows Pipeline
 
 on:
   workflow_dispatch:
-    inputs:
-      mode:
-        description: Build or release
-        type: choice
-        options:
-          - build
-          - release
-        default: build
 
   workflow_call:
-    inputs:
-      mode:
-        description: Build or release
-        required: false
-        type: string
-        default: build
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,34 +20,31 @@ jobs:
   # linux:
   #   name: Linux Build
   #   uses: ./.github/workflows/pipeline-linux.yaml
+
+  windows:
+    name: Windows Build
+    uses: ./.github/workflows/pipeline-windows.yaml
+
+  # macos-arm64:
+  #   name: macOS (Apple Silicon)
+  #   uses: ./.github/workflows/pipeline-macos.yaml
   #   with:
-  #     mode: release
+  #     architecture: arm64
+  #   secrets: inherit
 
-  # windows:
-  #   name: Windows Build
-  #   uses: ./.github/workflows/pipeline-windows.yaml
+  # macos-x86_64:
+  #   name: macOS (Intel)
+  #   uses: ./.github/workflows/pipeline-macos.yaml
   #   with:
-  #     mode: release
-
-  macos-arm64:
-    name: macOS (Apple Silicon)
-    uses: ./.github/workflows/pipeline-macos.yaml
-    with:
-      architecture: arm64
-    secrets: inherit
-
-  macos-x86_64:
-    name: macOS (Intel)
-    uses: ./.github/workflows/pipeline-macos.yaml
-    with:
-      architecture: x86_64
-    secrets: inherit
+  #     architecture: x86_64
+  #   secrets: inherit
 
   publish-test:
     name: Test artifact download
     needs:
-      - macos-arm64
-      - macos-x86_64
+      - windows
+      # - macos-arm64
+      # - macos-x86_64
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,15 +11,13 @@ permissions:
   contents: write
 
 jobs:
-  # docker:
-  #   name: Docker Tests
-  #   uses: ./.github/workflows/pipeline-docker.yaml
-  #   with:
-  #     mode: release
+  docker:
+    name: Validate Docker
+    uses: ./.github/workflows/validate-docker.yaml
 
-  linux:
-    name: Linux Build
-    uses: ./.github/workflows/pipeline-linux.yaml
+  # linux:
+  #   name: Linux Build
+  #   uses: ./.github/workflows/pipeline-linux.yaml
 
   # windows:
   #   name: Windows Build
@@ -39,21 +37,22 @@ jobs:
   #     architecture: x86_64
   #   secrets: inherit
 
-  publish-test:
-    name: Test artifact download
-    needs:
-      - linux
-      # - windows
-      # - macos-arm64
-      # - macos-x86_64
-    runs-on: ubuntu-latest
+  # publish-test:
+  #   name: Test artifact download
+  #   needs:
+  #     - docker
+  #     # - linux
+  #     # - windows
+  #     # - macos-arm64
+  #     # - macos-x86_64
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v5
-        with:
-          path: artifacts
+  #   steps:
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         path: artifacts
 
-      - name: Show downloaded artifacts
-        run: |
-          find artifacts -type f
+  #     - name: Show downloaded artifacts
+  #       run: |
+  #         find artifacts -type f

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,44 +15,51 @@ jobs:
     name: Validate Docker
     uses: ./.github/workflows/validate-docker.yaml
 
-  # linux:
-  #   name: Linux Build
-  #   uses: ./.github/workflows/pipeline-linux.yaml
+  linux:
+    name: Linux Build
+    uses: ./.github/workflows/pipeline-linux.yaml
 
-  # windows:
-  #   name: Windows Build
-  #   uses: ./.github/workflows/pipeline-windows.yaml
+  windows:
+    name: Windows Build
+    uses: ./.github/workflows/pipeline-windows.yaml
 
-  # macos-arm64:
-  #   name: macOS (Apple Silicon)
-  #   uses: ./.github/workflows/pipeline-macos.yaml
-  #   with:
-  #     architecture: arm64
-  #   secrets: inherit
+  macos-arm64:
+    name: macOS (Apple Silicon)
+    uses: ./.github/workflows/pipeline-macos.yaml
+    with:
+      architecture: arm64
+    secrets: inherit
 
-  # macos-x86_64:
-  #   name: macOS (Intel)
-  #   uses: ./.github/workflows/pipeline-macos.yaml
-  #   with:
-  #     architecture: x86_64
-  #   secrets: inherit
+  macos-x86_64:
+    name: macOS (Intel)
+    uses: ./.github/workflows/pipeline-macos.yaml
+    with:
+      architecture: x86_64
+    secrets: inherit
 
-  # publish-test:
-  #   name: Test artifact download
-  #   needs:
-  #     - docker
-  #     # - linux
-  #     # - windows
-  #     # - macos-arm64
-  #     # - macos-x86_64
-  #   runs-on: ubuntu-latest
+  publish-test:
+    name: Test artifact download
+    needs:
+      - docker
+      - linux
+      - windows
+      - macos-arm64
+      - macos-x86_64
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         path: artifacts
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v5
+        with:
+          path: release-assets
+          merge-multiple: true
 
-  #     - name: Show downloaded artifacts
-  #       run: |
-  #         find artifacts -type f
+      - name: Show downloaded assets
+        shell: bash
+        run: |
+          echo "Directory tree:"
+          ls -lR release-assets
+
+          echo
+          echo "Files:"
+          find release-assets -type f | sort

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ jobs:
   #   with:
   #     mode: release
 
-  # linux:
-  #   name: Linux Build
-  #   uses: ./.github/workflows/pipeline-linux.yaml
+  linux:
+    name: Linux Build
+    uses: ./.github/workflows/pipeline-linux.yaml
 
-  windows:
-    name: Windows Build
-    uses: ./.github/workflows/pipeline-windows.yaml
+  # windows:
+  #   name: Windows Build
+  #   uses: ./.github/workflows/pipeline-windows.yaml
 
   # macos-arm64:
   #   name: macOS (Apple Silicon)
@@ -42,7 +42,8 @@ jobs:
   publish-test:
     name: Test artifact download
     needs:
-      - windows
+      - linux
+      # - windows
       # - macos-arm64
       # - macos-x86_64
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,27 +11,51 @@ permissions:
   contents: write
 
 jobs:
-  docker:
-    name: Docker Tests
-    uses: ./.github/workflows/pipeline-docker.yaml
-    with:
-      mode: release
+  # docker:
+  #   name: Docker Tests
+  #   uses: ./.github/workflows/pipeline-docker.yaml
+  #   with:
+  #     mode: release
 
-  linux:
-    name: Linux Build
-    uses: ./.github/workflows/pipeline-linux.yaml
-    with:
-      mode: release
+  # linux:
+  #   name: Linux Build
+  #   uses: ./.github/workflows/pipeline-linux.yaml
+  #   with:
+  #     mode: release
 
-  windows:
-    name: Windows Build
-    uses: ./.github/workflows/pipeline-windows.yaml
-    with:
-      mode: release
+  # windows:
+  #   name: Windows Build
+  #   uses: ./.github/workflows/pipeline-windows.yaml
+  #   with:
+  #     mode: release
 
-  macos:
-    name: macOS Build
+  macos-arm64:
+    name: macOS (Apple Silicon)
     uses: ./.github/workflows/pipeline-macos.yaml
     with:
-      mode: release
+      architecture: arm64
     secrets: inherit
+
+  macos-x86_64:
+    name: macOS (Intel)
+    uses: ./.github/workflows/pipeline-macos.yaml
+    with:
+      architecture: x86_64
+    secrets: inherit
+
+  publish-test:
+    name: Test artifact download
+    needs:
+      - macos-arm64
+      - macos-x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: artifacts
+
+      - name: Show downloaded artifacts
+        run: |
+          find artifacts -type f

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,19 +37,23 @@ jobs:
       architecture: x86_64
     secrets: inherit
 
-  publish-test:
-    name: Test artifact download
+  publish:
+    name: Publish Release
     needs:
       - docker
       - linux
       - windows
       - macos-arm64
       - macos-x86_64
+
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Download release assets
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: tapmap-*
           path: release-assets
@@ -64,3 +68,48 @@ jobs:
           echo
           echo "Files:"
           find release-assets -type f | sort
+
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS.txt
+
+          echo
+          echo "SHA256 checksums:"
+          cat SHA256SUMS.txt
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: olalie/tapmap
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: release-assets/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Download release assets
         uses: actions/download-artifact@v5
         with:
+          pattern: tapmap-*
           path: release-assets
           merge-multiple: true
 

--- a/.github/workflows/validate-docker.yaml
+++ b/.github/workflows/validate-docker.yaml
@@ -1,23 +1,9 @@
-name: Docker Pipeline
+name: Validate Docker
 
 on:
   workflow_dispatch:
-    inputs:
-      mode:
-        description: Build or release
-        type: choice
-        options:
-          - build
-          - release
-        default: build
 
   workflow_call:
-    inputs:
-      mode:
-        description: Build or release
-        required: false
-        type: string
-        default: build
 
 jobs:
   docker-smoke:
@@ -39,7 +25,7 @@ jobs:
           docker run --rm tapmap:test -v | grep -q "tapmap"
 
   docker-smoke-arm64:
-    name: Docker smoke test arm64
+    name: Docker smoke test (arm64)
     runs-on: ubuntu-latest
 
     steps:

--- a/tools/build_macos.py
+++ b/tools/build_macos.py
@@ -19,6 +19,7 @@ Implementation
   during packaging.
 """
 
+import platform
 from pathlib import Path
 
 from build_common import (
@@ -101,9 +102,21 @@ def verify_application(sign: bool = False) -> None:
     print(f"[OK] Verified application ({app.name})")
 
 
+def current_arch() -> str:
+    """Return normalized architecture name."""
+    arch = platform.machine().lower()
+
+    if arch == "amd64":
+        return "x86_64"
+    if arch == "aarch64":
+        return "arm64"
+
+    return arch
+
+
 def dmg_name(version: str) -> str:
     """Return the macOS package filename."""
-    return f"TapMap-{version}-macos-arm64.dmg"
+    return f"TapMap-{version}-macos-{current_arch()}.dmg"
 
 
 def package() -> None:


### PR DESCRIPTION
## Summary

Refactor the GitHub Actions build and release architecture.

### Changes

- replace `pipeline-docker.yaml` with `validate-docker.yaml`
- remove obsolete `mode` parameters
- split macOS builds into Apple Silicon and Intel workflows
- replace artifact test with the final publish pipeline
- upgrade to `actions/download-artifact@v8`
- generate `SHA256SUMS.txt`
- publish multi-architecture Docker images
- automatically create GitHub Releases

### Testing

- [x] CI
- [x] Docker validation
- [x] Linux artifact verified
- [x] Windows artifact verified
- [x] macOS Apple Silicon artifact verified
- [x] macOS Intel artifact verified
