### PR TITLE
feat: add GitHub issue and discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yaml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yaml
@@ -1,0 +1,32 @@
+title: Feature request
+
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the problem or limitation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe your idea
+      description: Explain how you think TapMap could solve the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: How would this improve TapMap?
+      description: Explain how the proposed feature would benefit users.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: Include examples, screenshots, mockups, or anything else that may help explain the idea.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,47 @@
+name: I found a bug
+description: Report a bug in TapMap.
+
+body:
+  - type: checkboxes
+    attributes:
+      label: Search existing issues
+      options:
+        - label: I searched the existing issues.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Describe the problem and how to reproduce it.
+      placeholder: |
+        1. Start TapMap.
+        2. ...
+        3. ...
+        4. The problem occurs.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Docker
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: |
+        Include screenshots, error messages, or log output if relevant.
+
+        The log file is named tapmap.log.
+
+        To locate it, press G in TapMap, then click Open data folder.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Feature requests
+    url: https://github.com/olalie/tapmap/discussions
+    about: Suggest new features or improvements.
+
+  - name: Questions
+    url: https://github.com/olalie/tapmap/discussions
+    about: Ask questions about TapMap.


### PR DESCRIPTION
## Summary

Add GitHub templates to guide users toward the appropriate place for reporting bugs, requesting features, and asking questions.

## Changes

- Add bug report issue template
- Add issue configuration
- Add feature request discussion template

## Notes

- Bugs are reported through GitHub Issues.
- Feature requests and questions are directed to GitHub Discussions.
- Ongoing development continues to be tracked through GitHub Issues.