### PR TITLE
build: integrate SignPath test signing and simplify release pipelines

### DIFF
--- a/.github/workflows/pipeline-linux.yaml
+++ b/.github/workflows/pipeline-linux.yaml
@@ -2,8 +2,20 @@ name: Linux Pipeline
 
 on:
   workflow_dispatch:
+    inputs:
+      package:
+        description: Build Debian package
+        required: false
+        type: boolean
+        default: false
 
   workflow_call:
+    inputs:
+      package:
+        description: Build Debian package
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -33,14 +45,19 @@ jobs:
       - name: Build (same as local)
         shell: bash
         run: |
-          python tools/build.py
+          if [ "${{ inputs.package }}" = "true" ]; then
+            python tools/build.py --package
+          else
+            python tools/build.py
+          fi
 
       - name: Show build output
         shell: bash
         run: |
-          ls -la dist
+          find dist -maxdepth 2
 
-      - name: Upload artifact
+      - name: Upload Debian package
+        if: inputs.package
         uses: actions/upload-artifact@v7
         with:
           name: tapmap-linux-deb

--- a/.github/workflows/pipeline-macos.yaml
+++ b/.github/workflows/pipeline-macos.yaml
@@ -10,6 +10,10 @@ on:
           - arm64
           - x86_64
         default: arm64
+      package:
+        description: Create release package
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -17,6 +21,11 @@ on:
         description: Target architecture
         required: true
         type: string
+      package:
+        description: Create release package
+        required: false
+        type: boolean
+        default: false
 
 env:
   TARGET_ARCH: ${{ inputs.architecture }}
@@ -104,14 +113,19 @@ jobs:
           echo "Target architecture: $TARGET_ARCH"
           echo "Using interpreter: $PYTHON"
 
-          $PYTHON tools/build.py --sign
+          if [ "${{ inputs.package }}" = "true" ]; then
+            $PYTHON tools/build.py --package
+          else
+            $PYTHON tools/build.py
+          fi
 
       - name: Show build output
         shell: bash
         run: |
-          ls -la dist
+          find dist -maxdepth 2
 
       - name: Upload artifact
+        if: inputs.package
         uses: actions/upload-artifact@v7
         with:
           name: tapmap-macos-${{ env.TARGET_ARCH }}

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Show build output
         shell: pwsh
         run: |
-          Get-ChildItem -Recurse dist
+          Get-ChildItem dist
 
       - name: Upload installer
         if: inputs.package

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -65,6 +65,7 @@ jobs:
           github-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: signed
+          skip-decompress: true
 
       - name: Show build and signed output
         if: inputs.sign

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -85,5 +85,6 @@ jobs:
           name: tapmap-windows-setup-signed
           path: signed/TapMap-*-windows-x64-Setup.exe
           archive: false
+          overwrite: true
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -3,14 +3,14 @@ name: Windows Pipeline
 on:
   workflow_dispatch:
     inputs:
-      sign:
-        description: "Submit installer to SignPath"
+      package:
+        description: "Create a release package"
         type: boolean
         default: false
 
   workflow_call:
     inputs:
-      sign:
+      package:
         type: boolean
         default: false
 
@@ -34,63 +34,29 @@ jobs:
           pip install -r requirements-tests.txt
           pip install pyinstaller
 
-      - name: Build (same as local)
+      - name: Build
         shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
         run: |
-          python tools/build.py
+          if ("${{ inputs.package }}" -eq "true") {
+            python tools/build.py --package
+          }
+          else {
+            python tools/build.py
+          }
 
       - name: Show build output
         shell: pwsh
         run: |
-          Get-ChildItem dist
+          Get-ChildItem -Recurse dist
 
-      - name: Upload unsigned artifact
-        id: upload-unsigned-artifact
+      - name: Upload installer
+        if: inputs.package
         uses: actions/upload-artifact@v7
         with:
           name: tapmap-windows-setup
           path: dist/TapMap-*-windows-x64-Setup.exe
-          archive: false
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Submit signing request
-        if: inputs.sign
-        uses: signpath/github-action-submit-signing-request@v2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: 95d3450c-5444-470c-a16f-9e990aacf813
-          project-slug: tapmap
-          signing-policy-slug: test-signing
-          github-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
-          wait-for-completion: true
-          output-artifact-directory: signed
-          skip-decompress: true
-
-      - name: Show build and signed output
-        if: inputs.sign
-        shell: pwsh
-        run: |
-          Write-Host "=== dist ==="
-          Get-ChildItem -Recurse dist
-
-          Write-Host ""
-          Write-Host "=== signed ==="
-          Get-ChildItem -Recurse signed
-
-      - name: Prepare signed installer artifact
-        if: inputs.sign
-        shell: pwsh
-        run: |
-          $file = Get-ChildItem signed\*-Setup.exe
-          Copy-Item $file.FullName ($file.FullName -replace '\.exe$', '-signed.exe')
-
-      - name: Upload signed installer
-        if: inputs.sign
-        uses: actions/upload-artifact@v7
-        with:
-          name: tapmap-windows-setup-signed
-          path: signed/*-Setup-signed.exe
           archive: false
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -78,13 +78,19 @@ jobs:
           Write-Host "=== signed ==="
           Get-ChildItem -Recurse signed
 
+      - name: Prepare signed installer artifact
+        if: inputs.sign
+        shell: pwsh
+        run: |
+          $file = Get-ChildItem signed\*-Setup.exe
+          Copy-Item $file.FullName ($file.FullName -replace '\.exe$', '-signed.exe')
+
       - name: Upload signed installer
         if: inputs.sign
         uses: actions/upload-artifact@v7
         with:
           name: tapmap-windows-setup-signed
-          path: signed/TapMap-*-windows-x64-Setup.exe
+          path: signed/*-Setup-signed.exe
           archive: false
-          overwrite: true
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -2,8 +2,17 @@ name: Windows Pipeline
 
 on:
   workflow_dispatch:
+    inputs:
+      sign:
+        description: "Submit installer to SignPath"
+        type: boolean
+        default: false
 
   workflow_call:
+    inputs:
+      sign:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -35,10 +44,35 @@ jobs:
         run: |
           Get-ChildItem dist
 
-      - name: Upload artifact
+      - name: Upload unsigned artifact
+        id: upload-unsigned-artifact
         uses: actions/upload-artifact@v7
         with:
           name: tapmap-windows-setup
           path: dist/TapMap-*-windows-x64-Setup.exe
+          archive: false
           if-no-files-found: error
           retention-days: 7
+
+      - name: Submit signing request
+        if: inputs.sign
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: 95d3450c-5444-470c-a16f-9e990aacf813
+          project-slug: tapmap
+          signing-policy-slug: test-signing
+          github-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Show build and signed output
+        if: inputs.sign
+        shell: pwsh
+        run: |
+          Write-Host "=== dist ==="
+          Get-ChildItem -Recurse dist
+
+          Write-Host ""
+          Write-Host "=== signed ==="
+          Get-ChildItem -Recurse signed

--- a/.github/workflows/pipeline-windows.yaml
+++ b/.github/workflows/pipeline-windows.yaml
@@ -77,3 +77,13 @@ jobs:
           Write-Host ""
           Write-Host "=== signed ==="
           Get-ChildItem -Recurse signed
+
+      - name: Upload signed installer
+        if: inputs.sign
+        uses: actions/upload-artifact@v7
+        with:
+          name: tapmap-windows-setup-signed
+          path: signed/TapMap-*-windows-x64-Setup.exe
+          archive: false
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Windows Build
     uses: ./.github/workflows/pipeline-windows.yaml
     with:
-      sign: true
+      package: true
 
   macos-arm64:
     name: macOS (Apple Silicon)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
   linux:
     name: Linux Build
     uses: ./.github/workflows/pipeline-linux.yaml
+    with:
+      package: true
 
   windows:
     name: Windows Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
   windows:
     name: Windows Build
     uses: ./.github/workflows/pipeline-windows.yaml
+    with:
+      sign: true
 
   macos-arm64:
     name: macOS (Apple Silicon)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
     uses: ./.github/workflows/pipeline-macos.yaml
     with:
       architecture: arm64
+      package: true
     secrets: inherit
 
   macos-x86_64:
@@ -39,6 +40,7 @@ jobs:
     uses: ./.github/workflows/pipeline-macos.yaml
     with:
       architecture: x86_64
+      package: true
     secrets: inherit
 
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 # Build output (PyInstaller)
 build/
 dist/
+tools/windows/file_version_info.txt
 
 # IDE / OS
 .vscode/*

--- a/tapmap.spec
+++ b/tapmap.spec
@@ -1,7 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
 import sys
+from pathlib import Path
 
 from tools.build_common import get_signing_identity, project_metadata
+
+VERSION_FILE = Path("tools") / "windows" / "file_version_info.txt"
 
 project = project_metadata()
 version = project["version"]
@@ -32,6 +35,9 @@ else:
     app_icon = "src/tapmap/assets/tapmap.ico"
 
 exe_kwargs = {}
+
+if sys.platform == "win32":
+    exe_kwargs["version"] = str(VERSION_FILE)
 
 if sys.platform == "darwin":
     if signing_identity := get_signing_identity():

--- a/tools/build.py
+++ b/tools/build.py
@@ -13,18 +13,18 @@ def main() -> None:
     """Run the build pipeline for the current operating system."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--sign",
+        "--package",
         action="store_true",
-        help="Enable local code signing (macOS only).",
+        help="Create a release package.",
     )
     args = parser.parse_args()
 
-    if sys.platform.startswith("linux"):
-        build_linux.pipeline()
-    elif sys.platform == "win32":
-        build_windows.pipeline()
+    if sys.platform == "win32":
+        build_windows.pipeline(package=args.package)
     elif sys.platform == "darwin":
-        build_macos.pipeline(sign=args.sign)
+        build_macos.pipeline(sign=args.package)
+    elif sys.platform.startswith("linux"):
+        build_linux.pipeline()
     else:
         raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -24,7 +24,7 @@ def main() -> None:
     elif sys.platform == "darwin":
         build_macos.pipeline(sign=args.package)
     elif sys.platform.startswith("linux"):
-        build_linux.pipeline()
+        build_linux.pipeline(package=args.package)
     else:
         raise RuntimeError(f"Unsupported platform: {sys.platform}")
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -15,14 +15,14 @@ def main() -> None:
     parser.add_argument(
         "--sign",
         action="store_true",
-        help="Sign build artifacts when supported.",
+        help="Enable local code signing (macOS only).",
     )
     args = parser.parse_args()
 
     if sys.platform.startswith("linux"):
-        build_linux.pipeline(sign=args.sign)
+        build_linux.pipeline()
     elif sys.platform == "win32":
-        build_windows.pipeline(sign=args.sign)
+        build_windows.pipeline()
     elif sys.platform == "darwin":
         build_macos.pipeline(sign=args.sign)
     else:

--- a/tools/build.py
+++ b/tools/build.py
@@ -22,7 +22,7 @@ def main() -> None:
     if sys.platform == "win32":
         build_windows.pipeline(package=args.package)
     elif sys.platform == "darwin":
-        build_macos.pipeline(sign=args.package)
+        build_macos.pipeline(package=args.package)
     elif sys.platform.startswith("linux"):
         build_linux.pipeline(package=args.package)
     else:

--- a/tools/build_common.py
+++ b/tools/build_common.py
@@ -65,6 +65,11 @@ def require_tool(name: str) -> None:
         raise RuntimeError(f"Required tool '{name}' is not installed.")
 
 
+def powershell() -> str:
+    """Return the preferred PowerShell executable."""
+    return shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+
+
 # File helpers
 def _on_rm_error(func, path: str, _exc) -> None:
     """Retry removal of read-only files."""

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -11,7 +11,7 @@ Pipeline
 
 Implementation
 --------------
-- Entry point: python tools/build.py [--sign]
+- Entry point: python tools/build.py
 - Application is built as a PyInstaller onedir distribution.
 - Packaging follows the Debian filesystem hierarchy.
 - Shared-library dependencies are determined automatically using
@@ -323,10 +323,8 @@ def verify_package(sign: bool = False) -> None:
     print(f"[OK] Verified package ({package.name})")
 
 
-def pipeline(sign: bool = False) -> None:
-    """Build the release package."""
-    _ = sign  # Reserved for future package signing.
-
+def pipeline() -> None:
+    """Build the Linux release package."""
     setup()
     run_tests()
     build_application()

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -6,12 +6,12 @@ Pipeline
 2. Run automated tests.
 3. Build the application with PyInstaller.
 4. Verify the application build.
-5. Package the application as a Debian package.
-6. Verify the packaged release.
+5. (Optional) Package the application as a Debian package.
+6. (Optional) Verify the packaged release.
 
 Implementation
 --------------
-- Entry point: python tools/build.py
+- Entry point: python tools/build.py [--package]
 - Application is built as a PyInstaller onedir distribution.
 - Packaging follows the Debian filesystem hierarchy.
 - Shared-library dependencies are determined automatically using
@@ -208,7 +208,7 @@ def deb_name(version: str) -> str:
     return f"TapMap-{version}-linux-amd64.deb"
 
 
-def package() -> None:
+def package_release() -> None:
     """Create the release package.
 
     - Build DEB.
@@ -218,8 +218,9 @@ def package() -> None:
     - Build RPM.
     """
     project = project_metadata()
-    package_name = deb_name(project["version"])
-    print(f"Packaging {project['name']} {project['version']}")
+    version = project["version"]
+    package_name = deb_name(version)
+    print(f"Packaging {project['name']} {version}")
 
     rm_tree(PACKAGE_DIR)
     PACKAGE_DIR.mkdir(exist_ok=True)
@@ -230,11 +231,11 @@ def package() -> None:
     (PACKAGE_DIR / "usr" / "share" / "metainfo").mkdir(parents=True)
     (PACKAGE_DIR / "usr" / "share" / "doc" / project["name"]).mkdir(parents=True)
     (PACKAGE_DIR / "usr" / "share" / "icons" / "hicolor" / "256x256" / "apps").mkdir(parents=True)
-    ICONS_DIR = PROJECT_ROOT / "src" / "tapmap" / "assets" / "icons"
-    LINUX_ASSETS_DIR = PROJECT_ROOT / "src" / "tapmap" / "assets" / "linux"
-    DOC_DIR = PACKAGE_DIR / "usr" / "share" / "doc" / project["name"]
+    icons_dir = PROJECT_ROOT / "src" / "tapmap" / "assets" / "icons"
+    linux_assets_dir = PROJECT_ROOT / "src" / "tapmap" / "assets" / "linux"
+    doc_dir = PACKAGE_DIR / "usr" / "share" / "doc" / project["name"]
 
-    copy_linux_icons(PACKAGE_DIR, ICONS_DIR)
+    copy_linux_icons(PACKAGE_DIR, icons_dir)
 
     # Install the application under /usr/lib and expose it via /usr/bin.
     # This follows the Debian filesystem hierarchy.
@@ -248,21 +249,21 @@ def package() -> None:
 
     # Install AppStream metadata used by software centers.
     shutil.copy2(
-        LINUX_ASSETS_DIR / "no.tip.tapmap.metainfo.xml",
+        linux_assets_dir / "no.tip.tapmap.metainfo.xml",
         PACKAGE_DIR / "usr" / "share" / "metainfo" / "no.tip.tapmap.metainfo.xml",
     )
 
     # Install Debian package documentation required by policy.
-    write_debian_changelog(DOC_DIR, project)
+    write_debian_changelog(doc_dir, project)
 
     install_manual_page(
         PACKAGE_DIR,
-        LINUX_ASSETS_DIR,
+        linux_assets_dir,
     )
 
     shutil.copy2(
         PROJECT_ROOT / "LICENSE",
-        DOC_DIR / "copyright",
+        doc_dir / "copyright",
     )
 
     executable = PACKAGE_DIR / "usr" / "lib" / "tapmap" / EXECUTABLE_NAME
@@ -312,7 +313,7 @@ def package() -> None:
     print(f"[OK] Package Linux release ({deb_file.name})")
 
 
-def verify_package(sign: bool = False) -> None:
+def verify_package() -> None:
     """Verify the release package."""
     project = project_metadata()
     package = DIST_DIR / deb_name(project["version"])
@@ -323,11 +324,13 @@ def verify_package(sign: bool = False) -> None:
     print(f"[OK] Verified package ({package.name})")
 
 
-def pipeline() -> None:
-    """Build the Linux release package."""
+def pipeline(package: bool = False) -> None:
+    """Build the Linux application and package."""
     setup()
     run_tests()
     build_application()
     verify_application()
-    package()
-    verify_package()
+
+    if package:
+        package_release()
+        verify_package()

--- a/tools/build_macos.py
+++ b/tools/build_macos.py
@@ -4,15 +4,15 @@ Pipeline
 --------
 1. Clean previous build artifacts.
 2. Run automated tests.
-3. Build and sign the application with PyInstaller.
-4. Verify the application signature.
-5. Package the application as a DMG.
-6. Sign, notarize and staple the DMG during packaging.
-7. Verify the packaged release.
+3. Build the application with PyInstaller.
+4. Verify the application.
+5. (Optional) Package the application as a DMG.
+6. (Optional) Sign, notarize and staple the DMG during packaging.
+7. (Optional) Verify the packaged release.
 
 Implementation
 --------------
-- Entry point: python tools/build.py [--sign]
+- Entry point: python tools/build.py [--package]
 - Application signing is performed by PyInstaller using the signing
   identity provided to tapmap.spec at build time.
 - DMG signing, notarization and stapling are performed by create-dmg
@@ -119,7 +119,7 @@ def dmg_name(version: str) -> str:
     return f"TapMap-{version}-macos-{current_arch()}.dmg"
 
 
-def package() -> None:
+def package_release() -> None:
     """Create macOS release artifacts."""
     rm_tree(PACKAGE_DIR)
     PACKAGE_DIR.mkdir(exist_ok=True)
@@ -178,7 +178,7 @@ def package() -> None:
     print(f"[OK] Package macOS release ({dmg_file.name})")
 
 
-def verify_package(sign: bool = False) -> None:
+def verify_package() -> None:
     """Verify the release package."""
     project = project_metadata()
     package = DIST_DIR / dmg_name(project["version"])
@@ -186,24 +186,25 @@ def verify_package(sign: bool = False) -> None:
     if not package.exists():
         raise FileNotFoundError(f"Expected package not found: {package}")
 
-    if sign:
-        run(
-            [
-                "xcrun",
-                "stapler",
-                "validate",
-                str(package),
-            ]
-        )
+    run(
+        [
+            "xcrun",
+            "stapler",
+            "validate",
+            str(package),
+        ]
+    )
 
     print(f"[OK] Verified package ({package.name})")
 
 
-def pipeline(sign: bool = False) -> None:
-    """Build the release package."""
+def pipeline(package: bool = False) -> None:
+    """Build the macOS application and optionally package it."""
     setup()
     run_tests()
     build_application()
-    verify_application(sign=sign)
-    package()
-    verify_package(sign=sign)
+    verify_application()
+
+    if package:
+        package_release()
+        verify_package()

--- a/tools/build_windows.py
+++ b/tools/build_windows.py
@@ -19,6 +19,7 @@ Implementation
 - Packaging requires the SIGNPATH_API_TOKEN environment variable.
 """
 
+from datetime import date
 from pathlib import Path
 
 from build_common import (
@@ -35,6 +36,10 @@ from build_common import (
     run_tests,
 )
 
+WINDOWS_DIR = PROJECT_ROOT / "tools" / "windows"
+VERSION_TEMPLATE = WINDOWS_DIR / "file_version_info.template"
+VERSION_FILE = WINDOWS_DIR / "file_version_info.txt"
+
 
 def clean() -> None:
     """Remove previous build artifacts."""
@@ -48,6 +53,35 @@ def setup() -> None:
     """Prepare the build environment."""
     clean()
     require_tool("iscc")
+
+
+def update_version_info() -> None:
+    """Generate the PyInstaller VERSIONINFO file from the project metadata template."""
+    project = project_metadata()
+    version = project["version"]
+
+    parts = version.split(".")
+    parts.extend(["0"] * (4 - len(parts)))
+    version_tuple = ", ".join(parts[:4])
+
+    current_year = date.today().year
+    copyright_years = "2026" if current_year == 2026 else f"2026-{current_year}"
+
+    legal_copyright = f"© {copyright_years} TIP Teknologi i Praksis AS"
+
+    template = VERSION_TEMPLATE.read_text(encoding="utf-8")
+
+    content = template.format(
+        FILE_VERSION_TUPLE=version_tuple,
+        PRODUCT_VERSION_TUPLE=version_tuple,
+        FILE_VERSION=version,
+        PRODUCT_VERSION=version,
+        LEGAL_COPYRIGHT=legal_copyright,
+    )
+
+    VERSION_FILE.write_text(content, encoding="utf-8")
+
+    print(f"[OK] Generated {VERSION_FILE.name}")
 
 
 def expected_output_file() -> Path:
@@ -138,6 +172,7 @@ def pipeline(package: bool = False) -> None:
     """Build the Windows application and installer."""
     setup()
     run_tests()
+    update_version_info()
     build_application()
     verify_application()
     if package:

--- a/tools/build_windows.py
+++ b/tools/build_windows.py
@@ -12,11 +12,12 @@ Pipeline
 
 Implementation
 --------------
-- Entry point: python tools/build.py [--sign]
+- Entry point: python tools/build.py
 - Application is built as a PyInstaller onedir distribution.
 - The installer is created with Inno Setup (TapMap.iss).
-- Code signing is not yet implemented and will be added when a
-  suitable signing solution is available.
+- Official release signing is performed by the GitHub Actions
+  pipeline using SignPath.
+- Local builds are not code signed.
 """
 
 from pathlib import Path
@@ -102,13 +103,11 @@ def verify_package(sign: bool = False) -> None:
     print(f"[OK] Verified package ({package.name})")
 
 
-def pipeline(sign: bool = False) -> None:
-    """Build the release package."""
+def pipeline() -> None:
+    """Build the Windows application and installer."""
     setup()
     run_tests()
     build_application()
-    # TODO: Add code signing once a signing solution is available.
     verify_application()
     package()
-    # TODO: Add code signing once a signing solution is available.
     verify_package()

--- a/tools/build_windows.py
+++ b/tools/build_windows.py
@@ -7,17 +7,16 @@ Pipeline
 3. Run automated tests.
 4. Build the application with PyInstaller.
 5. Verify the application build.
-6. Package the application as an Inno Setup installer.
-7. Verify the packaged release.
+6. (Optional) Package the application as an Inno Setup installer.
+7. (Optional) Verify the packaged release.
 
 Implementation
 --------------
-- Entry point: python tools/build.py
+- Entry point: python tools/build.py [--package]
 - Application is built as a PyInstaller onedir distribution.
 - The installer is created with Inno Setup (TapMap.iss).
-- Official release signing is performed by the GitHub Actions
-  pipeline using SignPath.
-- Local builds are not code signed.
+- Release packages are code signed using SignPath.
+- Packaging requires the SIGNPATH_API_TOKEN environment variable.
 """
 
 from pathlib import Path
@@ -28,6 +27,7 @@ from build_common import (
     PACKAGE_DIR,
     PROJECT_ROOT,
     build_application,
+    powershell,
     project_metadata,
     require_tool,
     rm_tree,
@@ -65,22 +65,51 @@ def verify_application() -> None:
     print(f"[OK] Verify build ({app.name})")
 
 
+def sign_application() -> None:
+    """Sign the application executable."""
+    ps = powershell()
+    require_tool(ps)
+
+    exe = expected_output_file()
+
+    run(
+        [
+            ps,
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(PROJECT_ROOT / "tools" / "signtool.ps1"),
+            "-File",
+            str(exe),
+        ],
+        capture_output=True,
+    )
+
+    print(f"[OK] Signed application ({exe.name})")
+
+
 def setup_name(version: str) -> str:
     """Return the Windows installer filename."""
     return f"TapMap-{version}-windows-x64-Setup"
 
 
-def package() -> None:
+def package_release() -> None:
     """Create the release package."""
     project = project_metadata()
     version = project["version"]
     output = setup_name(version)
     exe = expected_output_file()
     icon = PROJECT_ROOT / "src" / "tapmap" / "assets" / "tapmap.ico"
+    sign_script = PROJECT_ROOT / "tools" / "signtool.ps1"
+
+    ps = powershell()
+    require_tool(ps)
+    require_tool("iscc")
 
     run(
         [
             "iscc",
+            f"/Ssigntool={ps} -ExecutionPolicy Bypass -File $q{sign_script}$q $f",
             f"/DMyAppVersion={version}",
             f"/DMyAppExePath={exe}",
             f"/DMySetupIcon={icon}",
@@ -91,8 +120,10 @@ def package() -> None:
         capture_output=True,
     )
 
+    print(f"[OK] Package release ({output}.exe)")
 
-def verify_package(sign: bool = False) -> None:
+
+def verify_package() -> None:
     """Verify the release package."""
     project = project_metadata()
     package = DIST_DIR / f"{setup_name(project['version'])}.exe"
@@ -103,11 +134,13 @@ def verify_package(sign: bool = False) -> None:
     print(f"[OK] Verified package ({package.name})")
 
 
-def pipeline() -> None:
+def pipeline(package: bool = False) -> None:
     """Build the Windows application and installer."""
     setup()
     run_tests()
     build_application()
     verify_application()
-    package()
-    verify_package()
+    if package:
+        sign_application()
+        package_release()
+        verify_package()

--- a/tools/signtool.ps1
+++ b/tools/signtool.ps1
@@ -1,0 +1,60 @@
+# Sign a single executable using SignPath.
+#
+# This script is used:
+#   - directly by build_windows.py to sign TapMap.exe
+#   - by Inno Setup to sign the generated uninstaller and installer
+#
+# Required environment variable:
+#   SIGNPATH_API_TOKEN
+#
+# If the SignPath PowerShell module is missing, it is installed
+# automatically for the current user.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$File
+)
+
+$ErrorActionPreference = "Stop"
+
+# SignPath project configuration.
+$organizationId = "95d3450c-5444-470c-a16f-9e990aacf813"
+$projectSlug = "tapmap"
+$signingPolicy = "test-signing"
+$apiToken = $env:SIGNPATH_API_TOKEN
+
+if ([string]::IsNullOrWhiteSpace($apiToken)) {
+    throw "SIGNPATH_API_TOKEN environment variable is not set."
+}
+
+Write-Host "Signing: $File"
+
+try {
+
+    if (-not (Get-Module -ListAvailable SignPath)) {
+        Write-Host "Installing SignPath PowerShell module..."
+        Install-Module SignPath `
+            -Scope CurrentUser `
+            -Force `
+            -AllowClobber
+    }
+
+    Import-Module SignPath -ErrorAction Stop
+
+    Submit-SigningRequest `
+        -ApiToken $apiToken `
+        -OrganizationId $organizationId `
+        -ProjectSlug $projectSlug `
+        -SigningPolicySlug $signingPolicy `
+        -InputArtifactPath $File `
+        -WaitForCompletion `
+        -OutputArtifactPath $File `
+        -Force
+
+    Write-Host "Signing completed."
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/tools/windows/TapMap.iss
+++ b/tools/windows/TapMap.iss
@@ -52,6 +52,8 @@ OutputBaseFilename={#MyOutputBaseFilename}
 SolidCompression=yes
 WizardStyle=modern dynamic
 SetupIconFile={#MySetupIcon}
+SignTool=signtool
+SignedUninstaller=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/tools/windows/file_version_info.template
+++ b/tools/windows/file_version_info.template
@@ -1,0 +1,44 @@
+# UTF-8
+#
+# For more details about fixed file info 'ffi' see:
+# http://msdn.microsoft.com/en-us/library/ms646997.aspx
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
+    # Set not needed items to zero 0.
+    filevers=({FILE_VERSION_TUPLE}),
+    prodvers=({PRODUCT_VERSION_TUPLE}),
+    # Contains a bitmask that specifies the valid bits 'flags'r
+    mask=0x3f,
+    # Contains a bitmask that specifies the Boolean attributes of the file.
+    flags=0x0,
+    # The operating system for which this file was designed.
+    # 0x4 - NT and there is no need to change it.
+    OS=0x40004,
+    # The general type of file.
+    # 0x1 - the file is an application.
+    fileType=0x1,
+    # The function of the file.
+    # 0x0 - the function is not defined for this fileType
+    subtype=0x0,
+    # Creation date and time stamp.
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        '040904B0',
+        [StringStruct('CompanyName', 'TIP Teknologi i Praksis AS'),
+        StringStruct('FileDescription', 'Network connection monitor'),
+        StringStruct('FileVersion', '{FILE_VERSION}'),
+        StringStruct('InternalName', 'tapmap'),
+        StringStruct('LegalCopyright', '{LEGAL_COPYRIGHT}'),
+        StringStruct('OriginalFilename', 'tapmap.exe'),
+        StringStruct('ProductName', 'TapMap'),
+        StringStruct('ProductVersion', '{PRODUCT_VERSION}'),
+        ]),
+      ]), 
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)


### PR DESCRIPTION
## Summary

- integrate SignPath test signing into the Windows build and packaging pipeline
- sign the Windows application, generated uninstaller, and installer through the same SignPath signing script
- simplify and align the Windows, Linux, and macOS build pipelines around the `--package` option
- generate Windows VERSIONINFO from project metadata

## SignPath

Windows signing has been tested using the SignPath self-signed test certificate.

The signing policy remains `test-signing`. Production signing is intentionally not enabled by this PR.

SignPath Foundation production signing requires manual approval of signing requests. The production signing workflow will therefore be finalized separately when the production certificate is available.

## Validation

- `ruff check .`
- `pytest` — 309 passed
- Windows, Linux, and macOS pipelines have been tested successfully during development
