### PR TITLE
fix: configure API documentation source path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths:
+            - src
           options:
             show_root_heading: true
             show_root_toc_entry: false


### PR DESCRIPTION
## Summary

- configure mkdocstrings to resolve TapMap modules from `src`
- fix API documentation builds in GitHub Actions

## Verification

- Docs `build-docs` job passes in GitHub Actions