### PR TITLE
refactor: centralize connection state and analysis

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -55,6 +55,7 @@ from tapmap.model.model import Model
 from tapmap.model.netinfo import NetInfo
 from tapmap.model.public_ip import iter_public_ip_candidates
 from tapmap.settings_persistence import Settings, load_settings, save_settings
+from tapmap.state.connection_state import ConnectionState
 from tapmap.state.insights import process_insights
 from tapmap.state.insights_log import write_insights_log
 from tapmap.state.keyboard import build_key_action
@@ -146,9 +147,10 @@ class TapMap:
         self.view_builder = CacheViewBuilder(
             coord_precision=COORD_PRECISION,
             is_docker=self.runtime.is_docker,
-            cache_retention_min=self.runtime.cache_retention_min,
         )
-        self._ui_cache: dict[str, Any] = {}
+        self.connection_state = ConnectionState(
+            cache_retention_min=self.runtime.cache_retention_min
+        )
         self._status_cache = StatusCache()
         # Technical details setting the current ui_view was built with, so a
         # setting change can trigger an immediate rebuild instead of waiting for
@@ -462,37 +464,40 @@ class TapMap:
    
     def _handle_clear_cache(
         self, status_cache: StatusCache, technical_details_enabled: bool
-    ) -> tuple[Any, Any, Any, Any, Any]:
+    ) -> tuple[Any, Any, Any, Any]:
         """Reset the runtime cache without observing the monitored system."""
         status_cache.clear()
-        empty_cache: dict[str, Any] = {}
-        view = self.view_builder.build_view_from_cache(empty_cache, technical_details_enabled)
+        cache = self.connection_state.clear()
+        view = self.view_builder.build_view_from_cache(cache, technical_details_enabled)
         flash = self._flash("Clearing cache...", self.MIN_FLASH_S)
-        return no_update, empty_cache, status_cache.to_store(), view, flash
+        return no_update, status_cache.to_store(), view, flash
 
     def _handle_normal_poll(
         self,
         tick_n: int,
         status_cache: StatusCache,
-        ui_cache: dict[str, Any],
         technical_details_enabled: bool,
-    ) -> tuple[Any, Any, Any, Any, Any]:
+    ) -> tuple[Any, Any, Any, Any]:
         snap = self.model.snapshot()
         if not isinstance(snap, dict):
-            view = self.view_builder.build_view_from_cache(ui_cache, technical_details_enabled)
+            view = self.view_builder.build_view_from_cache(
+                self.connection_state.cache, technical_details_enabled
+            )
             flash = self._flash("Model snapshot is invalid. See terminal.", self.MIN_FLASH_S)
-            return {"error": True}, ui_cache, status_cache.to_store(), view, flash
+            return {"error": True}, status_cache.to_store(), view, flash
 
         snap["runtime_info"] = self._build_runtime_info()
 
         if snap.get("error"):
-            view = self.view_builder.build_view_from_cache(ui_cache, technical_details_enabled)
-            return snap, ui_cache, status_cache.to_store(), view, no_update
+            view = self.view_builder.build_view_from_cache(
+                self.connection_state.cache, technical_details_enabled
+            )
+            return snap, status_cache.to_store(), view, no_update
 
         candidates_any = snap.get("map_candidates")
         candidates = candidates_any if isinstance(candidates_any, list) else []
-        updated_cache = self.view_builder.merge_map_candidates(ui_cache, candidates)
-        self._refresh_pending_app_verifications(updated_cache)
+        updated_cache = self.connection_state.merge(candidates)
+        self._refresh_pending_app_verifications()
 
         items_any = snap.get("cache_items")
         items = items_any if isinstance(items_any, list) else []
@@ -500,15 +505,15 @@ class TapMap:
         view = self.view_builder.build_view_from_cache(updated_cache, technical_details_enabled)
         self._maybe_save_insights()
 
-        return snap, updated_cache, status_cache.to_store(), view, no_update
+        return snap, status_cache.to_store(), view, no_update
 
-    def _refresh_pending_app_verifications(self, ui_cache: dict[str, Any]) -> None:
+    def _refresh_pending_app_verifications(self) -> None:
         """Backfill AppInfo verification results that completed since the last poll.
 
-        Covers ui_cache entries whose connection has left the current
-        snapshot but are still retained. Never triggers new AppInfo work.
+        Covers connection-state entries whose connection has left the
+        current snapshot but are still retained. Never triggers new AppInfo work.
         """
-        pending = self.view_builder.pending_exe_paths(ui_cache)
+        pending = self.connection_state.pending_exe_paths()
         if not pending:
             return
 
@@ -529,7 +534,7 @@ class TapMap:
             }
             for exe, metadata in resolved.items()
         }
-        self.view_builder.refresh_resolved_applications(ui_cache, fields)
+        self.connection_state.refresh_resolved_applications(fields)
 
     def _open_browser(self, url: str, delay_s: float = 0.8) -> None:
         try:
@@ -722,7 +727,6 @@ class TapMap:
             model_snapshot_data: Any,
         ):
             status_cache = self._status_cache
-            ui_cache = self._ui_cache
             technical_details_enabled = bool(technical_details_data)
             trigger = ctx.triggered_id
             decision = decide_poll_action(
@@ -746,18 +750,16 @@ class TapMap:
                 decision = PollDecision(action=ACTION_REBUILD_VIEW)
 
             if decision.action == ACTION_CLEAR_CACHE:
-                snap, cache, sc_store, view, flash = self._handle_clear_cache(
+                snap, sc_store, view, flash = self._handle_clear_cache(
                     status_cache, technical_details_enabled
                 )
-                self._ui_cache = cache
                 self._last_built_technical_details = technical_details_enabled
                 return snap, sc_store, view, flash
 
             if decision.action == ACTION_NORMAL_POLL:
-                snap, cache, sc_store, view, _flash = self._handle_normal_poll(
-                    tick_n, status_cache, ui_cache, technical_details_enabled
+                snap, sc_store, view, _flash = self._handle_normal_poll(
+                    tick_n, status_cache, technical_details_enabled
                 )
-                self._ui_cache = cache
                 self._last_built_technical_details = technical_details_enabled
 
                 now = datetime.now().timestamp()
@@ -770,7 +772,7 @@ class TapMap:
 
             if decision.action == ACTION_REBUILD_VIEW:
                 view = self.view_builder.build_view_from_cache(
-                    self._ui_cache, technical_details_enabled
+                    self.connection_state.cache, technical_details_enabled
                 )
                 self._last_built_technical_details = technical_details_enabled
                 return no_update, no_update, view, no_update
@@ -1018,7 +1020,10 @@ class TapMap:
             filename = f"tapmap-cache-{now.strftime('%Y-%m-%d_%H-%M-%S')}.txt"
             header = f"TapMap Cache Export\nGenerated: {now.strftime('%Y-%m-%d %H:%M:%S')}"
             return dcc.send_string(
-                self._status_cache.format_ui_cache_text(self._ui_cache, header=header), filename
+                self._status_cache.format_ui_cache_text(
+                    self.connection_state.cache, header=header
+                ),
+                filename,
             )
 
         @self.app.callback(

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -55,8 +55,8 @@ from tapmap.model.model import Model
 from tapmap.model.netinfo import NetInfo
 from tapmap.model.public_ip import iter_public_ip_candidates
 from tapmap.settings_persistence import Settings, load_settings, save_settings
+from tapmap.state.connection_analyzer import ConnectionAnalyzer
 from tapmap.state.connection_state import ConnectionState
-from tapmap.state.insights import process_insights
 from tapmap.state.insights_log import write_insights_log
 from tapmap.state.keyboard import build_key_action
 from tapmap.state.menu import compute_menu_open_state
@@ -199,6 +199,9 @@ class TapMap:
         self.insights_path = self.runtime.app_data_dir / "insights.json"
         self._load_insights()
         self._last_insights_save = 0.0
+
+        # Construct after _load_insights() to reference the loaded Insights dict.
+        self.connection_analyzer = ConnectionAnalyzer(self.connection_state, self.insights)
 
         self.settings_path = self.runtime.app_data_dir / "settings.json"
         self.settings: Settings = load_settings(self.settings_path)
@@ -464,27 +467,27 @@ class TapMap:
    
     def _handle_clear_cache(
         self, status_cache: StatusCache, technical_details_enabled: bool
-    ) -> tuple[Any, Any, Any, Any]:
+    ) -> tuple[Any, Any, Any, Any, Any]:
         """Reset the runtime cache without observing the monitored system."""
         status_cache.clear()
         cache = self.connection_state.clear()
         view = self.view_builder.build_view_from_cache(cache, technical_details_enabled)
         flash = self._flash("Clearing cache...", self.MIN_FLASH_S)
-        return no_update, status_cache.to_store(), view, flash
+        return no_update, status_cache.to_store(), view, flash, no_update
 
     def _handle_normal_poll(
         self,
         tick_n: int,
         status_cache: StatusCache,
         technical_details_enabled: bool,
-    ) -> tuple[Any, Any, Any, Any]:
+    ) -> tuple[Any, Any, Any, Any, Any]:
         snap = self.model.snapshot()
         if not isinstance(snap, dict):
             view = self.view_builder.build_view_from_cache(
                 self.connection_state.cache, technical_details_enabled
             )
             flash = self._flash("Model snapshot is invalid. See terminal.", self.MIN_FLASH_S)
-            return {"error": True}, status_cache.to_store(), view, flash
+            return {"error": True}, status_cache.to_store(), view, flash, no_update
 
         snap["runtime_info"] = self._build_runtime_info()
 
@@ -492,20 +495,21 @@ class TapMap:
             view = self.view_builder.build_view_from_cache(
                 self.connection_state.cache, technical_details_enabled
             )
-            return snap, status_cache.to_store(), view, no_update
-
-        candidates_any = snap.get("map_candidates")
-        candidates = candidates_any if isinstance(candidates_any, list) else []
-        updated_cache = self.connection_state.merge(candidates)
-        self._refresh_pending_app_verifications()
+            return snap, status_cache.to_store(), view, no_update, no_update
 
         items_any = snap.get("cache_items")
         items = items_any if isinstance(items_any, list) else []
+
+        insights_data = self.connection_analyzer.analyze(items)
+        self._refresh_pending_app_verifications()
+
         status_cache.update(items)
-        view = self.view_builder.build_view_from_cache(updated_cache, technical_details_enabled)
+        view = self.view_builder.build_view_from_cache(
+            self.connection_state.cache, technical_details_enabled
+        )
         self._maybe_save_insights()
 
-        return snap, status_cache.to_store(), view, no_update
+        return snap, status_cache.to_store(), view, no_update, insights_data
 
     def _refresh_pending_app_verifications(self) -> None:
         """Backfill AppInfo verification results that completed since the last poll.
@@ -710,6 +714,7 @@ class TapMap:
             Output("status_cache", "data"),
             Output("ui_view", "data"),
             Output("status_flash", "data"),
+            Output("insights_cache", "data"),
             Input("tick_model", "n_intervals"),
             Input("key_action", "data"),
             Input("menu_clear_cache", "n_clicks"),
@@ -750,14 +755,14 @@ class TapMap:
                 decision = PollDecision(action=ACTION_REBUILD_VIEW)
 
             if decision.action == ACTION_CLEAR_CACHE:
-                snap, sc_store, view, flash = self._handle_clear_cache(
+                snap, sc_store, view, flash, insights_data = self._handle_clear_cache(
                     status_cache, technical_details_enabled
                 )
                 self._last_built_technical_details = technical_details_enabled
-                return snap, sc_store, view, flash
+                return snap, sc_store, view, flash, insights_data
 
             if decision.action == ACTION_NORMAL_POLL:
-                snap, sc_store, view, _flash = self._handle_normal_poll(
+                snap, sc_store, view, _flash, insights_data = self._handle_normal_poll(
                     tick_n, status_cache, technical_details_enabled
                 )
                 self._last_built_technical_details = technical_details_enabled
@@ -766,18 +771,18 @@ class TapMap:
                 if isinstance(status_flash_data, dict):
                     until = status_flash_data.get("until")
                     if isinstance(until, (int, float)) and now < until:
-                        return snap, sc_store, view, no_update
+                        return snap, sc_store, view, no_update, insights_data
 
-                return snap, sc_store, view, None
+                return snap, sc_store, view, None, insights_data
 
             if decision.action == ACTION_REBUILD_VIEW:
                 view = self.view_builder.build_view_from_cache(
                     self.connection_state.cache, technical_details_enabled
                 )
                 self._last_built_technical_details = technical_details_enabled
-                return no_update, no_update, view, no_update
+                return no_update, no_update, view, no_update, no_update
 
-            return no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update, no_update
 
     def _register_menu_callbacks(self) -> None:
         @self.app.callback(
@@ -1281,23 +1286,6 @@ class TapMap:
                 return []
 
             return render_insights_panel(data, selected_country=selected_country)
-
-        @self.app.callback(
-            Output("insights_cache", "data"),
-            Input("model_snapshot", "data"),
-        )
-        def update_insights_data(snapshot: Any) -> Any:
-
-            if not isinstance(snapshot, dict):
-                return {"new": {}, "top": {}}
-
-            now = datetime.now()
-
-            return process_insights(
-                snapshot.get("cache_items", []),
-                self.insights,
-                now,
-            )
 
     def run(self) -> None:
         """Start the Dash server and launch the local UI."""

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -55,9 +55,14 @@ from tapmap.model.model import Model
 from tapmap.model.netinfo import NetInfo
 from tapmap.model.public_ip import iter_public_ip_candidates
 from tapmap.settings_persistence import Settings, load_settings, save_settings
+from tapmap.significant_connections_persistence import (
+    load_significant_connections,
+    save_significant_connections,
+)
 from tapmap.state.connection_analyzer import ConnectionAnalyzer
 from tapmap.state.connection_state import ConnectionState
 from tapmap.state.insights_log import write_insights_log
+from tapmap.state.insights_state import CURRENT_SCHEMA_VERSION, InsightsState
 from tapmap.state.keyboard import build_key_action
 from tapmap.state.menu import compute_menu_open_state
 from tapmap.state.modal import decide_modal_route
@@ -70,6 +75,8 @@ from tapmap.state.poll import (
     PollDecision,
     decide_poll_action,
 )
+from tapmap.state.significance import SignificanceHistory
+from tapmap.state.significant_connections import SignificantConnections
 from tapmap.state.status_cache import StatusCache
 from tapmap.state.status_line import render_status_text
 from tapmap.ui.cache_view import CacheViewBuilder
@@ -187,21 +194,23 @@ class TapMap:
             ],
         }
 
-        self.insights: dict[str, Any] = {
-            "countries": {},
-            "providers": {},
-            "ports": {},
-
-
-            "applications": {},
-        }
-
         self.insights_path = self.runtime.app_data_dir / "insights.json"
-        self._load_insights()
-        self._last_insights_save = 0.0
+        self.significant_connections_path = (
+            self.runtime.app_data_dir / "significant_connections.json"
+        )
+        self._load_history()
+        self._last_history_save = 0.0
 
-        # Construct after _load_insights() to reference the loaded Insights dict.
-        self.connection_analyzer = ConnectionAnalyzer(self.connection_state, self.insights)
+        # Constructed after _load_history() so SignificanceHistory derives from
+        # the loaded InsightsState, and ConnectionAnalyzer references the
+        # already-loaded SignificantConnections.
+        self.significance_history = SignificanceHistory.from_insights_state(self.insights_state)
+        self.connection_analyzer = ConnectionAnalyzer(
+            self.connection_state,
+            self.insights_state.insights,
+            self.significant_connections,
+            self.significance_history,
+        )
 
         self.settings_path = self.runtime.app_data_dir / "settings.json"
         self.settings: Settings = load_settings(self.settings_path)
@@ -507,7 +516,7 @@ class TapMap:
         view = self.view_builder.build_view_from_cache(
             self.connection_state.cache, technical_details_enabled
         )
-        self._maybe_save_insights()
+        self._maybe_save_history()
 
         return snap, status_cache.to_store(), view, no_update, insights_data
 
@@ -638,7 +647,7 @@ class TapMap:
             return self._as_children(body), "modal-body"
 
         if screen == "menu_daily_report":
-            report = persist_build_daily_report(self.insights)
+            report = persist_build_daily_report(self.insights_state.insights)
             return (
                 render_daily_activity_report(report),
                 self._class_for_modal_screen(screen),
@@ -648,7 +657,7 @@ class TapMap:
             log_path = self.insights_path.with_suffix(".log")
             text = ""
             with contextlib.suppress(Exception):
-                write_insights_log(self.insights, log_path)
+                write_insights_log(self.insights_state.insights, log_path)
                 text = log_path.read_text(encoding="utf-8")
             return (
                 render_insights_log(text),
@@ -1313,24 +1322,40 @@ class TapMap:
     def _empty_insights() -> dict[str, Any]:
         return {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
 
-    def _load_insights(self) -> None:
-        """Load insights data from JSON file into memory (delegated)."""
+    def _load_history(self) -> None:
+        """Load Insights and Significant Connections history from disk (delegated)."""
         try:
-            self.insights = load_insights(self.insights_path)
+            self.insights_state = load_insights(self.insights_path)
         except Exception as exc:
             self.logger.warning(
                 "Unable to load insights. Starting with empty history. Reason: %s",
                 exc,
             )
-            self.insights = self._empty_insights()
+            self.insights_state = InsightsState(
+                version=CURRENT_SCHEMA_VERSION,
+                insights=self._empty_insights(),
+                verification_failed={},
+            )
 
-    def _maybe_save_insights(self) -> None:
-        """Save insights periodically to limit disk writes."""
+        try:
+            significant_connections_items = load_significant_connections(
+                self.significant_connections_path
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Unable to load Significant Connections history. Starting empty. Reason: %s",
+                exc,
+            )
+            significant_connections_items = []
+        self.significant_connections = SignificantConnections(significant_connections_items)
+
+    def _maybe_save_history(self) -> None:
+        """Save Insights and Significant Connections history periodically to limit disk writes."""
         now = datetime.now().timestamp()
 
-        if now - self._last_insights_save >= 60:
-            self._last_insights_save = now
-            self._save_insights()
+        if now - self._last_history_save >= 60:
+            self._last_history_save = now
+            self._save_history()
 
     def _save_settings(self) -> None:
         """Write settings data to disk atomically."""
@@ -1342,13 +1367,28 @@ class TapMap:
                 exc,
             )
 
-    def _save_insights(self) -> None:
-        """Write insights data to disk atomically (delegated)."""
+    def _save_history(self) -> None:
+        """Write Insights and Significant Connections history to disk atomically (delegated).
+
+        Each file's save failure is isolated so one failing write does not
+        prevent the other from being persisted.
+        """
         try:
-            save_insights(self.insights_path, self.insights)
+            save_insights(self.insights_path, self.insights_state)
         except Exception as exc:
             self.logger.warning(
                 "Unable to save insights. Changes will not be preserved. Reason: %s",
+                exc,
+            )
+
+        try:
+            save_significant_connections(
+                self.significant_connections_path, self.significant_connections.items
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Unable to save Significant Connections history. Changes will not be preserved."
+                " Reason: %s",
                 exc,
             )
 
@@ -1404,7 +1444,7 @@ class TapMap:
     def close(self) -> None:
         """Close model resources."""
         self.logger.info("Shutting down")
-        self._save_insights()
+        self._save_history()
         self._release_lock()
         close_fn = getattr(self.model.geoinfo, "close", None)
         if callable(close_fn):

--- a/src/tapmap/insights_persistence.py
+++ b/src/tapmap/insights_persistence.py
@@ -6,38 +6,74 @@ from pathlib import Path
 from typing import Any
 
 from tapmap.state.daily_report import DailyReportData, build_report_data
+from tapmap.state.insights_state import CURRENT_SCHEMA_VERSION, InsightsState
+
+_DIMENSION_KEYS = ("countries", "providers", "ports", "applications")
 
 
-def load_insights(path: Path) -> dict[str, Any]:
-    """Load insights from a JSON file, restoring historical contract.
+def _empty_insights_dict() -> dict[str, Any]:
+    return {k: {} for k in _DIMENSION_KEYS}
+
+
+def load_insights(path: Path) -> InsightsState:
+    """Load InsightsState from a JSON file, migrating older schema versions as needed.
+
+    A file with no version marker, or version < CURRENT_SCHEMA_VERSION, has
+    its applications history reset (process-name-keyed history cannot be
+    reliably converted to app_name-keyed history); countries, providers, and
+    ports are preserved.
 
     Args:
         path: Path to the insights file.
 
     Returns:
-        Normalized insights dict with only the four expected keys.
+        InsightsState at the current schema version. Empty on missing,
+        corrupt, or malformed input.
     """
-    expected_keys = {"countries", "providers", "ports", "applications"}
     try:
         with path.open(encoding="utf-8") as f:
             data = json.load(f)
-        insights = data.get("insights")
-        if not isinstance(insights, dict):
+
+        version = data.get("version")
+        version = version if isinstance(version, int) else 1
+
+        raw_insights = data.get("insights")
+        if not isinstance(raw_insights, dict):
             raise ValueError("insights is not a dict")
-        normalized = {
-            k: dict(insights[k]) if isinstance(insights.get(k), dict) else {} for k in expected_keys
+
+        insights = {
+            k: dict(raw_insights[k]) if isinstance(raw_insights.get(k), dict) else {}
+            for k in _DIMENSION_KEYS
         }
-        return normalized
+
+        raw_verification_failed = data.get("verification_failed")
+        verification_failed = (
+            dict(raw_verification_failed) if isinstance(raw_verification_failed, dict) else {}
+        )
+
+        if version < CURRENT_SCHEMA_VERSION:
+            insights["applications"] = {}
+            version = CURRENT_SCHEMA_VERSION
+
+        return InsightsState(
+            version=version,
+            insights=insights,
+            verification_failed=verification_failed,
+        )
     except Exception:
-        return {k: {} for k in ["countries", "providers", "ports", "applications"]}
+        return InsightsState(
+            version=CURRENT_SCHEMA_VERSION,
+            insights=_empty_insights_dict(),
+            verification_failed={},
+        )
 
 
-def save_insights(path: Path, data: dict[str, Any]) -> None:
-    """Save insights to a JSON file, using historical wrapper contract.
+def save_insights(path: Path, state: InsightsState) -> None:
+    """Save InsightsState to a JSON file as one atomic unit.
 
     Args:
         path: Path to the insights file.
-        data: Raw dict to save.
+        state: InsightsState to persist.
 
     Raises:
         OSError: If the insights file cannot be written or replaced.
@@ -46,7 +82,11 @@ def save_insights(path: Path, data: dict[str, Any]) -> None:
 
     with tmp_path.open("w", encoding="utf-8") as f:
         json.dump(
-            {"insights": data},
+            {
+                "version": state.version,
+                "insights": state.insights,
+                "verification_failed": state.verification_failed,
+            },
             f,
             ensure_ascii=False,
             indent=2,

--- a/src/tapmap/significant_connections_persistence.py
+++ b/src/tapmap/significant_connections_persistence.py
@@ -1,0 +1,68 @@
+"""Persistence for the Significant Connections history."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+_SCHEMA_VERSION = 1
+
+
+def load_significant_connections(path: Path) -> list[dict[str, Any]]:
+    """Load Significant Connections events from a JSON file.
+
+    Args:
+        path: Path to the significant_connections file.
+
+    Returns:
+        List of event dicts, oldest first. Empty if the file is missing,
+        corrupt, or malformed; malformed individual records are dropped.
+    """
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+
+        events = data.get("events")
+        if not isinstance(events, list):
+            return []
+
+        return [event for event in events if isinstance(event, dict)]
+    except Exception:
+        return []
+
+
+def save_significant_connections(path: Path, events: list[dict[str, Any]]) -> None:
+    """Save Significant Connections events to a JSON file.
+
+    Args:
+        path: Path to the significant_connections file.
+        events: List of event dicts, oldest first.
+
+    Raises:
+        OSError: If the file cannot be written or replaced.
+    """
+    tmp_path = path.with_suffix(".tmp")
+
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {"schema_version": _SCHEMA_VERSION, "events": events},
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+        f.flush()
+
+    # The temporary file has been closed. Retry the atomic replace in
+    # case another process briefly locks the destination file.
+    for attempt in range(6):
+        try:
+            tmp_path.replace(path)
+            return
+
+        except OSError:
+            if attempt == 5:
+                raise
+
+            time.sleep(1)

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -1,0 +1,40 @@
+"""Analyze external/public connections and update ConnectionState and Insights."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from .connection_state import ConnectionState
+from .insights import process_insights
+
+
+class ConnectionAnalyzer:
+    """Update ConnectionState and Insights from a snapshot's cache_items."""
+
+    def __init__(self, connection_state: ConnectionState, insights: dict[str, Any]) -> None:
+        self.connection_state = connection_state
+        self.insights = insights
+
+    def analyze(self, cache_items: list[dict[str, Any]]) -> dict[str, Any]:
+        """Update ConnectionState with mapped PUBLIC connections; return the Insights result."""
+        mapped = self._classify_mapped_public(cache_items)
+        self.connection_state.merge(mapped)
+
+        now = datetime.now()
+        return process_insights(cache_items, self.insights, now)
+
+    @staticmethod
+    def _classify_mapped_public(cache_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Return cache_items with PUBLIC scope and valid map coordinates."""
+        mapped: list[dict[str, Any]] = []
+        for item in cache_items:
+            if item.get("service_scope") != "PUBLIC":
+                continue
+
+            lat = item.get("lat")
+            lon = item.get("lon")
+            if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+                mapped.append(item)
+
+        return mapped

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -1,4 +1,4 @@
-"""Analyze external/public connections and update ConnectionState and Insights."""
+"""Analyze connections and update ConnectionState, Insights, and Significant Connections."""
 
 from __future__ import annotations
 
@@ -7,27 +7,33 @@ from typing import Any
 
 from .connection_state import ConnectionState
 from .insights import process_insights
+from .significance import SignificanceHistory, get_significant
+from .significant_connections import SignificantConnections
 
 
 class ConnectionAnalyzer:
-    """Update ConnectionState and Insights from a snapshot's cache_items."""
+    """Process a snapshot's cache_items: connection state, Significant Connections, and Insights."""
 
-    def __init__(self, connection_state: ConnectionState, insights: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        connection_state: ConnectionState,
+        insights: dict[str, Any],
+        significant_connections: SignificantConnections,
+        significance_history: SignificanceHistory,
+    ) -> None:
         self.connection_state = connection_state
         self.insights = insights
+        self.significant_connections = significant_connections
+        self.significance_history = significance_history
 
     def analyze(self, cache_items: list[dict[str, Any]]) -> dict[str, Any]:
-        """Update ConnectionState with mapped PUBLIC connections; return the Insights result."""
-        mapped = self._classify_mapped_public(cache_items)
-        self.connection_state.merge(mapped)
+        """Update ConnectionState, Significant Connections, and Insights from cache_items.
 
+        Returns the Insights result ({new, top}).
+        """
         now = datetime.now()
-        return process_insights(cache_items, self.insights, now)
-
-    @staticmethod
-    def _classify_mapped_public(cache_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Return cache_items with PUBLIC scope and valid map coordinates."""
         mapped: list[dict[str, Any]] = []
+
         for item in cache_items:
             if item.get("service_scope") != "PUBLIC":
                 continue
@@ -37,4 +43,10 @@ class ConnectionAnalyzer:
             if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
                 mapped.append(item)
 
-        return mapped
+            significant_connection = get_significant(item, self.significance_history, now)
+            if significant_connection is not None:
+                self.significant_connections.add(significant_connection)
+
+        self.connection_state.merge(mapped)
+
+        return process_insights(cache_items, self.insights, now)

--- a/src/tapmap/state/connection_state.py
+++ b/src/tapmap/state/connection_state.py
@@ -1,0 +1,280 @@
+"""Own the accumulated per-service connection cache for the TapMap state layer.
+
+Merge Model.snapshot() map candidates into a per-service cache, prune
+entries past the configured retention window, and backfill deferred
+AppInfo verification results into retained entries.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from .normalization import safe_int, safe_str
+
+UNKNOWN_APP_KEY = "__unknown_application__"
+
+
+class ConnectionState:
+    """Own and mutate the accumulated per-service connection cache."""
+
+    def __init__(self, cache_retention_min: int = 0) -> None:
+        self.cache_retention_min = int(cache_retention_min)
+        self.logger = logging.getLogger(__name__)
+        self._cache: dict[str, Any] = {}
+
+    @property
+    def cache(self) -> dict[str, Any]:
+        """Current accumulated per-service cache."""
+        return self._cache
+
+    def clear(self) -> dict[str, Any]:
+        """Reset the accumulated cache and return the new (empty) cache."""
+        self._cache = {}
+        return self._cache
+
+    @staticmethod
+    def _service_key(ip: str, port: int) -> str:
+        return f"{ip}|{port}"
+
+    @staticmethod
+    def _now_text() -> str:
+        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    def merge(self, map_candidates: list[dict[str, Any]]) -> dict[str, Any]:
+        """Merge map candidates into the cache, prune stale entries, and return the cache."""
+        now = datetime.now().timestamp()
+        cache = self._cache
+
+        for candidate in map_candidates:
+            if not isinstance(candidate, dict):
+                continue
+
+            ip = safe_str(candidate.get("ip"))
+            if not ip:
+                continue
+
+            port = safe_int(candidate.get("port"))
+            if port <= 0:
+                continue
+
+            proto = safe_str(candidate.get("proto")) or None
+            process_name = safe_str(candidate.get("process_name"))
+            pid = safe_int(candidate.get("pid"))
+            exe = safe_str(candidate.get("exe")) or None
+
+            key = self._service_key(ip, port)
+            entry = cache.get(key)
+
+            if not isinstance(entry, dict):
+                entry = self._new_entry(candidate, ip=ip, port=port, proto=proto)
+                cache[key] = entry
+
+            entry["last_seen"] = now
+
+            self._merge_missing_attrs(
+                entry,
+                candidate,
+                attrs=(
+                    "proto",
+                    "lon",
+                    "lat",
+                    "city",
+                    "country",
+                    "country_code",
+                    "asn",
+                    "asn_org",
+                ),
+            )
+
+            self._merge_application(
+                entry, exe=exe, candidate=candidate, process_name=process_name, pid=pid
+            )
+
+        self._prune_cache(cache, now)
+        return cache
+
+    def pending_exe_paths(self) -> set[str]:
+        """Return exe paths in the cache whose deferred AppInfo data is still missing.
+
+        Scans the accumulated cache, not the current snapshot, so retained
+        applications whose connection has vanished are still included.
+        Excludes the synthetic unknown-application bucket and applications
+        already resolved.
+        """
+        pending: set[str] = set()
+        for entry in self._cache.values():
+            if not isinstance(entry, dict):
+                continue
+            applications = entry.get("applications")
+            if not isinstance(applications, dict):
+                continue
+            for app in applications.values():
+                if not isinstance(app, dict):
+                    continue
+                exe = app.get("exe")
+                if not isinstance(exe, str) or not exe:
+                    continue
+                if app.get("app_verification_status") is None:
+                    pending.add(exe)
+        return pending
+
+    def refresh_resolved_applications(self, resolved: dict[str, dict[str, Any]]) -> None:
+        """Backfill newly-completed AppInfo fields into matching application records.
+
+        resolved maps exe path to a plain dict of app_creator,
+        app_verification_status, app_signature_state, and
+        app_signature_state_details values. Only fills fields still None, so
+        calling this every poll tick is safe even when nothing changed.
+        Mutates the cache in place.
+        """
+        if not resolved:
+            return
+        for entry in self._cache.values():
+            if not isinstance(entry, dict):
+                continue
+            applications = entry.get("applications")
+            if not isinstance(applications, dict):
+                continue
+            for app in applications.values():
+                if not isinstance(app, dict):
+                    continue
+                exe = app.get("exe")
+                if not isinstance(exe, str):
+                    continue
+                update = resolved.get(exe)
+                if update is None:
+                    continue
+                self._merge_missing_attrs(
+                    app,
+                    update,
+                    attrs=(
+                        "app_creator",
+                        "app_verification_status",
+                        "app_signature_state",
+                        "app_signature_state_details",
+                    ),
+                )
+
+    def _prune_cache(
+        self,
+        cache: dict[str, Any],
+        now: float,
+    ) -> None:
+        """Remove cache entries older than the configured retention period."""
+        retention_min = self.cache_retention_min
+
+        if retention_min <= 0:
+            return
+
+        cutoff = now - (retention_min * 60)
+
+        for key, entry in list(cache.items()):
+            if entry["last_seen"] < cutoff:
+                del cache[key]
+
+    def _new_entry(
+        self, candidate: dict[str, Any], *, ip: str, port: int, proto: str | None
+    ) -> dict[str, Any]:
+        return {
+            "ip": ip,
+            "port": port,
+            "proto": proto,
+            "lon": candidate.get("lon"),
+            "lat": candidate.get("lat"),
+            "city": candidate.get("city"),
+            "country": candidate.get("country"),
+            "country_code": candidate.get("country_code"),
+            "asn": candidate.get("asn"),
+            "asn_org": candidate.get("asn_org"),
+            "f": self._now_text(),
+            "l": self._now_text(),
+            "m": 0,
+            "applications": {},
+        }
+
+    @staticmethod
+    def _new_application(exe: str | None) -> dict[str, Any]:
+        return {
+            "app_name": None,
+            "app_creator": None,
+            "app_verification_status": None,
+            "app_signature_state": None,
+            "app_signature_state_details": None,
+            "exe": exe,
+            "processes": [],
+            "proc_pids": {},
+        }
+
+    @staticmethod
+    def _merge_missing_attrs(
+        entry: dict[str, Any],
+        candidate: dict[str, Any],
+        *,
+        attrs: tuple[str, ...],
+    ) -> None:
+        for attr in attrs:
+            if entry.get(attr) is None and candidate.get(attr) is not None:
+                entry[attr] = candidate.get(attr)
+
+    def _merge_application(
+        self,
+        entry: dict[str, Any],
+        *,
+        exe: str | None,
+        candidate: dict[str, Any],
+        process_name: str,
+        pid: int | None,
+    ) -> None:
+        """Merge one candidate's application metadata into its exe-keyed bucket.
+
+        Candidates with no resolvable exe path share UNKNOWN_APP_KEY, since
+        no reliable identity exists to key them individually.
+        """
+        applications = entry.get("applications")
+        apps: dict[str, Any] = applications if isinstance(applications, dict) else {}
+        entry["applications"] = apps
+
+        app_key = exe or UNKNOWN_APP_KEY
+        app = apps.get(app_key)
+        if not isinstance(app, dict):
+            app = self._new_application(exe)
+            apps[app_key] = app
+
+        self._merge_missing_attrs(
+            app,
+            candidate,
+            attrs=(
+                "app_name",
+                "app_creator",
+                "app_verification_status",
+                "app_signature_state",
+                "app_signature_state_details",
+            ),
+        )
+
+        if process_name:
+            self._merge_process(app, process_name=process_name, pid=pid)
+
+    def _merge_process(
+        self, record: dict[str, Any], *, process_name: str, pid: int | None
+    ) -> None:
+        processes = record.get("processes")
+        proc_list = processes if isinstance(processes, list) else []
+        proc_set = {p.strip() for p in proc_list if isinstance(p, str) and p.strip()}
+        proc_set.add(process_name)
+        record["processes"] = sorted(proc_set, key=str.lower)
+
+        proc_pids = record.get("proc_pids")
+        proc_pids_map: dict[str, list[int]] = proc_pids if isinstance(proc_pids, dict) else {}
+        record["proc_pids"] = proc_pids_map
+
+        if pid is None:
+            return
+
+        existing = proc_pids_map.get(process_name)
+        existing_list = existing if isinstance(existing, list) else []
+        pid_set = {int(x) for x in existing_list if isinstance(x, int) and x > 0}
+        pid_set.add(pid)
+        proc_pids_map[process_name] = sorted(pid_set)

--- a/src/tapmap/state/insights.py
+++ b/src/tapmap/state/insights.py
@@ -115,7 +115,7 @@ def process_insights(
         if isinstance(port, int):
             ports.add(str(port))
 
-        app = item.get("process_name")
+        app = item.get("app_name")
         if isinstance(app, str) and app:
             apps.add(app)
 

--- a/src/tapmap/state/insights_state.py
+++ b/src/tapmap/state/insights_state.py
@@ -1,0 +1,25 @@
+"""Complete persisted contents of insights.json."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+CURRENT_SCHEMA_VERSION = 2
+
+
+@dataclass
+class InsightsState:
+    """Insights history plus verification-failure history, persisted as one unit.
+
+    insights: the four 30-day rolling dimensions (countries, providers, ports,
+    applications), each {value: {"l": anchor_day, "m": bitmask}}. Mutated
+    externally by process_insights().
+
+    verification_failed: {app_name: last_failed_seen_day}. Mutated externally
+    by SignificanceHistory, which holds this dict by reference, not a copy.
+    """
+
+    version: int
+    insights: dict[str, Any]
+    verification_failed: dict[str, int]

--- a/src/tapmap/state/normalization.py
+++ b/src/tapmap/state/normalization.py
@@ -1,0 +1,18 @@
+"""Normalize dictionary values to predictable string and integer types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def safe_str(value: Any) -> str:
+    """Return empty string for None, otherwise str(value)."""
+    return "" if value is None else str(value)
+
+
+def safe_int(value: Any, default: int = -1) -> int:
+    """Convert value to int, or return default on failure."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/tapmap/state/significance.py
+++ b/src/tapmap/state/significance.py
@@ -1,0 +1,180 @@
+"""Track 30-day novelty per dimension and evaluate connection significance."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from .insights_state import InsightsState
+
+REASON_NEW_APP = "new_app"
+REASON_NEW_COUNTRY = "new_country"
+REASON_NEW_PROVIDER = "new_provider"
+REASON_NEW_PORT = "new_port"
+REASON_VERIFICATION_FAILED = "verification_failed"
+
+_DIM_APPLICATIONS = "applications"
+_DIM_COUNTRIES = "countries"
+_DIM_PROVIDERS = "providers"
+_DIM_PORTS = "ports"
+_DIM_VERIFICATION_FAILED = "verification_failed"
+
+# Order matches the Significant Connection event schema.
+_KEPT_CACHE_ITEM_FIELDS = (
+    "proto",
+    "ip",
+    "port",
+    "service",
+    "lat",
+    "lon",
+    "process_name",
+    "exe",
+    "city",
+    "country",
+    "country_code",
+    "asn",
+    "asn_org",
+    "app_name",
+    "app_creator",
+    "app_verification_status",
+    "app_signature_state",
+    "app_signature_state_details",
+)
+
+
+class SignificanceHistory:
+    """Own 30-day novelty state for the four Insights dimensions and verification failures."""
+
+    def __init__(
+        self,
+        last_seen: dict[str, dict[Any, int]],
+        verification_failed: dict[str, int],
+    ) -> None:
+        self.last_seen = last_seen
+        self.verification_failed = verification_failed
+
+    @classmethod
+    def from_insights_state(cls, insights_state: InsightsState) -> SignificanceHistory:
+        """Derive runtime last_seen state from persisted Insights bitmasks.
+
+        Read-only against insights_state.insights: does not age or mutate the
+        Insights bitmasks. verification_failed is held by direct reference,
+        not copied, since it has no separate persisted representation of its
+        own outside InsightsState.
+        """
+        last_seen: dict[str, dict[Any, int]] = {
+            _DIM_APPLICATIONS: {},
+            _DIM_COUNTRIES: {},
+            _DIM_PROVIDERS: {},
+            _DIM_PORTS: {},
+        }
+
+        for dimension in (_DIM_APPLICATIONS, _DIM_COUNTRIES, _DIM_PROVIDERS):
+            source = insights_state.insights.get(dimension)
+            if not isinstance(source, dict):
+                continue
+            for key, entry in source.items():
+                day = _last_seen_day(entry)
+                if day is not None:
+                    last_seen[dimension][key] = day
+
+        ports_source = insights_state.insights.get(_DIM_PORTS)
+        if isinstance(ports_source, dict):
+            for key, entry in ports_source.items():
+                day = _last_seen_day(entry)
+                if day is None:
+                    continue
+                try:
+                    last_seen[_DIM_PORTS][int(key)] = day
+                except (TypeError, ValueError):
+                    continue
+
+        return cls(last_seen=last_seen, verification_failed=insights_state.verification_failed)
+
+    def check_and_update(self, dimension: str, key: Any, today: int) -> bool:
+        """Return True if key was not seen within the last 30 days for dimension.
+
+        Always records key as seen today, regardless of the result.
+        """
+        target = (
+            self.verification_failed
+            if dimension == _DIM_VERIFICATION_FAILED
+            else self.last_seen[dimension]
+        )
+        last_day = target.get(key)
+        is_new = last_day is None or (today - last_day) >= 30
+        target[key] = today
+        return is_new
+
+
+def _last_seen_day(entry: Any) -> int | None:
+    """Return the most recent observation day encoded in a persisted {l, m} Insights entry."""
+    if not isinstance(entry, dict):
+        return None
+    anchor_day = entry.get("l")
+    mask = entry.get("m")
+    if not isinstance(anchor_day, int) or not isinstance(mask, int) or mask == 0:
+        return None
+    lowest_set_bit_position = (mask & -mask).bit_length() - 1
+    return anchor_day - lowest_set_bit_position
+
+
+def get_significant(
+    item: dict[str, Any],
+    history: SignificanceHistory,
+    now: datetime,
+) -> dict[str, Any] | None:
+    """Evaluate one PUBLIC connection for significance.
+
+    Checks all applicable criteria unconditionally, since check_and_update()
+    must record every observed value regardless of whether it turns out to be
+    new. Returns None if no criterion applies. Caller is responsible for
+    only invoking this for PUBLIC-scope connections.
+    """
+    today = now.date().toordinal()
+    reasons: list[str] = []
+
+    app_name = item.get("app_name")
+    has_app_name = isinstance(app_name, str) and bool(app_name)
+
+    if has_app_name:
+        if history.check_and_update(_DIM_APPLICATIONS, app_name, today):
+            reasons.append(REASON_NEW_APP)
+
+        if item.get("app_verification_status") == "failed" and history.check_and_update(
+            _DIM_VERIFICATION_FAILED, app_name, today
+        ):
+            reasons.append(REASON_VERIFICATION_FAILED)
+
+    country_code = item.get("country_code")
+    if (
+        isinstance(country_code, str)
+        and country_code
+        and history.check_and_update(_DIM_COUNTRIES, country_code, today)
+    ):
+        reasons.append(REASON_NEW_COUNTRY)
+
+    asn_org = item.get("asn_org")
+    if (
+        isinstance(asn_org, str)
+        and asn_org
+        and history.check_and_update(_DIM_PROVIDERS, asn_org, today)
+    ):
+        reasons.append(REASON_NEW_PROVIDER)
+
+    port = item.get("port")
+    if isinstance(port, int) and history.check_and_update(_DIM_PORTS, port, today):
+        reasons.append(REASON_NEW_PORT)
+
+    if not reasons:
+        return None
+
+    event: dict[str, Any] = {
+        "timestamp": now.isoformat(),
+        "reasons": reasons,
+        "pid": item.get("pid"),
+    }
+    for field_name in _KEPT_CACHE_ITEM_FIELDS:
+        event[field_name] = item.get(field_name)
+
+    return event

--- a/src/tapmap/state/significant_connections.py
+++ b/src/tapmap/state/significant_connections.py
@@ -1,0 +1,25 @@
+"""Own the bounded, chronological history of Significant Connections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+MAX_ENTRIES = 500
+
+
+class SignificantConnections:
+    """Own the Significant Connections event history, oldest first, bounded to MAX_ENTRIES."""
+
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self._items: list[dict[str, Any]] = list(items[-MAX_ENTRIES:])
+
+    @property
+    def items(self) -> list[dict[str, Any]]:
+        """Current history, oldest first."""
+        return self._items
+
+    def add(self, event: dict[str, Any]) -> None:
+        """Append event as the newest entry, then enforce the retention limit."""
+        self._items.append(event)
+        if len(self._items) > MAX_ENTRIES:
+            del self._items[: len(self._items) - MAX_ENTRIES]

--- a/src/tapmap/state/status_cache.py
+++ b/src/tapmap/state/status_cache.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, TypedDict
 
+from .normalization import safe_str
+
 Proto = str
 Ip = str
 Port = int
@@ -228,11 +230,6 @@ class StatusCache:
         return out
 
     @staticmethod
-    def _safe_str(value: Any) -> str:
-        """Return empty string for None, else str(value)."""
-        return "" if value is None else str(value)
-
-    @staticmethod
     def _key_ip_port(key: Any) -> tuple[str, int]:
         """Extract (ip, port) sort key from 'ip|port' service key."""
         if not isinstance(key, str):
@@ -261,7 +258,7 @@ class StatusCache:
                 proc_pids_raw if isinstance(proc_pids_raw, dict) else {}
             )
             for name in procs:
-                name_s = StatusCache._safe_str(name).strip()
+                name_s = safe_str(name).strip()
                 if not name_s:
                     continue
                 pid_set = combined.setdefault(name_s, set())
@@ -304,16 +301,16 @@ class StatusCache:
             if not isinstance(entry, dict):
                 continue
 
-            ip = self._safe_str(entry.get("ip")) or self._safe_str(key).split("|", 1)[0]
+            ip = safe_str(entry.get("ip")) or safe_str(key).split("|", 1)[0]
 
             port = entry.get("port")
             port_txt = str(int(port)) if isinstance(port, int) else "-"
 
             proto = self._normalize_proto(entry.get("proto"))
 
-            asn_org = self._safe_str(entry.get("asn_org")) or "-"
-            city = self._safe_str(entry.get("city")) or ""
-            country = self._safe_str(entry.get("country")) or ""
+            asn_org = safe_str(entry.get("asn_org")) or "-"
+            city = safe_str(entry.get("city")) or ""
+            country = safe_str(entry.get("country")) or ""
             place = ", ".join([x for x in [city, country] if x]) or "-"
 
             procs_txt = self._format_procs_with_pids(entry)

--- a/src/tapmap/ui/cache_view.py
+++ b/src/tapmap/ui/cache_view.py
@@ -1,22 +1,21 @@
 """Cache view preparation helpers for the TapMap UI.
 
-Merge service entries into a stable UI cache and build
-map points, hover summaries, and click details.
+Build map points, hover summaries, and click details from the
+accumulated per-service cache owned by ConnectionState.
 """
 
 from __future__ import annotations
 
 import logging
 from collections import Counter, defaultdict
-from datetime import datetime
 from typing import Any
 
+from ..state.connection_state import UNKNOWN_APP_KEY
 from .formatting import (
     PENDING_VERIFICATION_STATUS,
     country_flag,
     elide_path_middle,
     humanize_camel_case,
-    safe_int,
     safe_str,
     verification_status_color,
     verification_status_glyph,
@@ -33,22 +32,16 @@ _APP_VERIFICATION_STATUS_PRIORITY: dict[str | None, int] = {
 class CacheViewBuilder:
     """Build UI cache and map view data."""
 
-    _UNKNOWN_APP_KEY = "__unknown_application__"
+    _UNKNOWN_APP_KEY = UNKNOWN_APP_KEY
 
     def __init__(
         self,
         coord_precision: int = 3,
         is_docker: bool = False,
-        cache_retention_min: int = 0,
     ) -> None:
         self.coord_precision = int(coord_precision)
         self.is_docker = bool(is_docker)
-        self.cache_retention_min = int(cache_retention_min)
         self.logger = logging.getLogger(__name__)
-
-    @staticmethod
-    def _service_key(ip: str, port: int) -> str:
-        return f"{ip}|{port}"
 
     @staticmethod
     def _fmt_ip_port(ip: str, port: int) -> str:
@@ -62,10 +55,6 @@ class CacheViewBuilder:
     def _safe_proto(value: Any) -> str:
         p = str(value).strip().lower() if value else "tcp"
         return p if p in {"tcp", "udp"} else "tcp"
-
-    @staticmethod
-    def _now_text() -> str:
-        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     @staticmethod
     def format_list_compact(items: list[Any], max_items: int) -> str:
@@ -87,255 +76,13 @@ class CacheViewBuilder:
         shown = ", ".join(cleaned[:max_items])
         return f"{shown} +{len(cleaned) - max_items}"
 
-    def merge_map_candidates(
-        self,
-        ui_cache: dict[str, Any],
-        map_candidates: list[dict[str, Any]],
-    ) -> dict[str, Any]:
-        """Merge map candidates into a per-service cache."""
-        now = datetime.now().timestamp()
-        cache = dict(ui_cache) if isinstance(ui_cache, dict) else {}
-
-        for candidate in map_candidates:
-            if not isinstance(candidate, dict):
-                continue
-
-            ip = safe_str(candidate.get("ip"))
-            if not ip:
-                continue
-
-            port = safe_int(candidate.get("port"))
-            if port is None:
-                continue
-
-            proto = safe_str(candidate.get("proto")) or None
-            process_name = safe_str(candidate.get("process_name"))
-            pid = safe_int(candidate.get("pid"))
-            exe = safe_str(candidate.get("exe")) or None
-
-            key = self._service_key(ip, port)
-            entry = cache.get(key)
-
-            if not isinstance(entry, dict):
-                entry = self._new_entry(candidate, ip=ip, port=port, proto=proto)
-                cache[key] = entry
-
-            entry["last_seen"] = now
-
-            self._merge_missing_attrs(
-                entry,
-                candidate,
-                attrs=(
-                    "proto",
-                    "lon",
-                    "lat",
-                    "city",
-                    "country",
-                    "country_code",
-                    "asn",
-                    "asn_org",
-                ),
-            )
-
-            self._merge_application(
-                entry, exe=exe, candidate=candidate, process_name=process_name, pid=pid
-            )
-
-        self._prune_cache(cache, now)
-        return cache
-
-    @staticmethod
-    def pending_exe_paths(ui_cache: dict[str, Any]) -> set[str]:
-        """Return exe paths in ui_cache whose deferred AppInfo data is still missing.
-
-        Scans ui_cache, not the current snapshot, so retained applications
-        whose connection has vanished are still included. Excludes the
-        synthetic unknown-application bucket and applications already resolved.
-        """
-        pending: set[str] = set()
-        for entry in ui_cache.values():
-            if not isinstance(entry, dict):
-                continue
-            applications = entry.get("applications")
-            if not isinstance(applications, dict):
-                continue
-            for app in applications.values():
-                if not isinstance(app, dict):
-                    continue
-                exe = app.get("exe")
-                if not isinstance(exe, str) or not exe:
-                    continue
-                if app.get("app_verification_status") is None:
-                    pending.add(exe)
-        return pending
-
-    @staticmethod
-    def refresh_resolved_applications(
-        ui_cache: dict[str, Any], resolved: dict[str, dict[str, Any]]
-    ) -> None:
-        """Backfill newly-completed AppInfo fields into matching application records.
-
-        resolved maps exe path to a plain dict of app_creator,
-        app_verification_status, app_signature_state, and
-        app_signature_state_details values. Only fills fields still None, so
-        calling this every poll tick is safe even when nothing changed.
-        Mutates ui_cache in place.
-        """
-        if not resolved:
-            return
-        for entry in ui_cache.values():
-            if not isinstance(entry, dict):
-                continue
-            applications = entry.get("applications")
-            if not isinstance(applications, dict):
-                continue
-            for app in applications.values():
-                if not isinstance(app, dict):
-                    continue
-                exe = app.get("exe")
-                if not isinstance(exe, str):
-                    continue
-                update = resolved.get(exe)
-                if update is None:
-                    continue
-                CacheViewBuilder._merge_missing_attrs(
-                    app,
-                    update,
-                    attrs=(
-                        "app_creator",
-                        "app_verification_status",
-                        "app_signature_state",
-                        "app_signature_state_details",
-                    ),
-                )
-
-    def _prune_cache(
-        self,
-        cache: dict[str, Any],
-        now: float,
-    ) -> None:
-        """Remove cache entries older than the configured retention period."""
-        retention_min = self.cache_retention_min
-
-        if retention_min <= 0:
-            return
-
-        cutoff = now - (retention_min * 60)
-
-        for key, entry in list(cache.items()):
-            if entry["last_seen"] < cutoff:
-                del cache[key]
-
-    def _new_entry(
-        self, candidate: dict[str, Any], *, ip: str, port: int, proto: str | None
-    ) -> dict[str, Any]:
-        return {
-            "ip": ip,
-            "port": port,
-            "proto": proto,
-            "lon": candidate.get("lon"),
-            "lat": candidate.get("lat"),
-            "city": candidate.get("city"),
-            "country": candidate.get("country"),
-            "country_code": candidate.get("country_code"),
-            "asn": candidate.get("asn"),
-            "asn_org": candidate.get("asn_org"),
-            "f": self._now_text(),
-            "l": self._now_text(),
-            "m": 0,
-            "applications": {},
-        }
-
-    @staticmethod
-    def _new_application(exe: str | None) -> dict[str, Any]:
-        return {
-            "app_name": None,
-            "app_creator": None,
-            "app_verification_status": None,
-            "app_signature_state": None,
-            "app_signature_state_details": None,
-            "exe": exe,
-            "processes": [],
-            "proc_pids": {},
-        }
-
-    @staticmethod
-    def _merge_missing_attrs(
-        entry: dict[str, Any],
-        candidate: dict[str, Any],
-        *,
-        attrs: tuple[str, ...],
-    ) -> None:
-        for attr in attrs:
-            if entry.get(attr) is None and candidate.get(attr) is not None:
-                entry[attr] = candidate.get(attr)
-
-    def _merge_application(
-        self,
-        entry: dict[str, Any],
-        *,
-        exe: str | None,
-        candidate: dict[str, Any],
-        process_name: str,
-        pid: int | None,
-    ) -> None:
-        """Merge one candidate's application metadata into its exe-keyed bucket.
-
-        Candidates with no resolvable exe path share _UNKNOWN_APP_KEY, since
-        no reliable identity exists to key them individually.
-        """
-        applications = entry.get("applications")
-        apps: dict[str, Any] = applications if isinstance(applications, dict) else {}
-        entry["applications"] = apps
-
-        app_key = exe or self._UNKNOWN_APP_KEY
-        app = apps.get(app_key)
-        if not isinstance(app, dict):
-            app = self._new_application(exe)
-            apps[app_key] = app
-
-        self._merge_missing_attrs(
-            app,
-            candidate,
-            attrs=(
-                "app_name",
-                "app_creator",
-                "app_verification_status",
-                "app_signature_state",
-                "app_signature_state_details",
-            ),
-        )
-
-        if process_name:
-            self._merge_process(app, process_name=process_name, pid=pid)
-
-    def _merge_process(self, record: dict[str, Any], *, process_name: str, pid: int | None) -> None:
-        processes = record.get("processes")
-        proc_list = processes if isinstance(processes, list) else []
-        proc_set = {p.strip() for p in proc_list if isinstance(p, str) and p.strip()}
-        proc_set.add(process_name)
-        record["processes"] = sorted(proc_set, key=str.lower)
-
-        proc_pids = record.get("proc_pids")
-        proc_pids_map: dict[str, list[int]] = proc_pids if isinstance(proc_pids, dict) else {}
-        record["proc_pids"] = proc_pids_map
-
-        if pid is None:
-            return
-
-        existing = proc_pids_map.get(process_name)
-        existing_list = existing if isinstance(existing, list) else []
-        pid_set = {int(x) for x in existing_list if isinstance(x, int) and x > 0}
-        pid_set.add(pid)
-        proc_pids_map[process_name] = sorted(pid_set)
-
     def build_view_from_cache(
         self, ui_cache: dict[str, Any], technical_details_enabled: bool
     ) -> dict[str, Any]:
         """Group cached entries by rounded coordinates and build map view data.
 
         Args:
-            ui_cache: Per-service cache from merge_map_candidates.
+            ui_cache: Per-service cache from ConnectionState.merge/clear.
             technical_details_enabled: When True, hover summaries use the
                 connection-oriented format. When False, hover summaries use
                 the application-oriented format. Click details are

--- a/tests/test_cache_view.py
+++ b/tests/test_cache_view.py
@@ -1,20 +1,13 @@
-"""Test CacheViewBuilder's per-service cache merge and hover summary generation."""
+"""Test CacheViewBuilder's hover summary and click detail generation."""
 
 from __future__ import annotations
 
 import re
 from typing import Any
 
+from tapmap.state.connection_state import ConnectionState
 from tapmap.ui.cache_view import CacheViewBuilder
 from tapmap.ui.formatting import country_flag, verification_status_glyph
-
-_APP_FIELDS = (
-    "app_name",
-    "app_creator",
-    "app_verification_status",
-    "app_signature_state",
-    "app_signature_state_details",
-)
 
 _DEFAULT_EXE = "/opt/app/app.exe"
 
@@ -43,11 +36,6 @@ def _candidate(**overrides: Any) -> dict[str, Any]:
     }
     candidate.update(overrides)
     return candidate
-
-
-def _app_fields(app: dict[str, Any]) -> dict[str, Any]:
-    """Return only the app_* fields from an application record."""
-    return {field: app.get(field) for field in _APP_FIELDS}
 
 
 def _entry(
@@ -102,147 +90,6 @@ def _app_entry(
         "asn_org": asn_org,
         "applications": {exe: app},
     }
-
-
-# --- merge_map_candidates: application record propagation ---
-
-
-def test_merge_map_candidates_propagates_app_fields_into_new_application() -> None:
-    """A new application record carries all five app_* fields from the candidate."""
-    builder = CacheViewBuilder()
-
-    candidate = _candidate(
-        app_name="Firefox",
-        app_creator="Mozilla Corporation",
-        app_verification_status="verified",
-        app_signature_state="SignedAndTrusted",
-        app_signature_state_details="None",
-    )
-
-    cache = builder.merge_map_candidates({}, [candidate])
-    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
-
-    assert _app_fields(app) == {
-        "app_name": "Firefox",
-        "app_creator": "Mozilla Corporation",
-        "app_verification_status": "verified",
-        "app_signature_state": "SignedAndTrusted",
-        "app_signature_state_details": "None",
-    }
-
-
-def test_merge_map_candidates_leaves_app_fields_none_when_absent() -> None:
-    """A candidate with no app data (AppInfo disabled) leaves app_* fields None."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates({}, [_candidate()])
-    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
-
-    assert _app_fields(app) == dict.fromkeys(_APP_FIELDS)
-
-
-def test_merge_map_candidates_backfills_app_fields_on_existing_application() -> None:
-    """A later candidate fills in app_* fields that were previously missing."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates({}, [_candidate()])
-    cache = builder.merge_map_candidates(
-        cache,
-        [
-            _candidate(
-                app_name="Firefox",
-                app_creator="Mozilla Corporation",
-                app_verification_status="verified",
-                app_signature_state="SignedAndTrusted",
-                app_signature_state_details="None",
-            )
-        ],
-    )
-    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
-
-    assert app["app_name"] == "Firefox"
-    assert app["app_verification_status"] == "verified"
-
-
-def test_merge_map_candidates_keeps_first_app_value_for_same_exe() -> None:
-    """A distinct later value for the same exe path does not overwrite the first."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(app_name="Firefox", app_verification_status="verified")]
-    )
-    cache = builder.merge_map_candidates(
-        cache, [_candidate(app_name="Other Name", app_verification_status="failed")]
-    )
-    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
-
-    assert app["app_name"] == "Firefox"
-    assert app["app_verification_status"] == "verified"
-
-
-def test_merge_map_candidates_keeps_different_exe_paths_separate() -> None:
-    """Two different applications sharing (ip, port) each get their own application record."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates(
-        {},
-        [
-            _candidate(
-                exe="/opt/firefox/firefox.exe",
-                app_name="Firefox",
-                app_verification_status="verified",
-            ),
-            _candidate(
-                exe="/tmp/malware.exe", app_name="Malware", app_verification_status="failed"
-            ),
-        ],
-    )
-    applications = cache["8.8.8.8|443"]["applications"]
-
-    assert applications["/opt/firefox/firefox.exe"]["app_name"] == "Firefox"
-    assert applications["/opt/firefox/firefox.exe"]["app_verification_status"] == "verified"
-    assert applications["/tmp/malware.exe"]["app_name"] == "Malware"
-    assert applications["/tmp/malware.exe"]["app_verification_status"] == "failed"
-
-
-def test_merge_map_candidates_uses_unknown_bucket_when_exe_missing() -> None:
-    """Candidates with no resolvable exe path share a dedicated unknown-application bucket."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(exe=None, process_name="svchost.exe", pid=100)]
-    )
-    applications = cache["8.8.8.8|443"]["applications"]
-
-    assert CacheViewBuilder._UNKNOWN_APP_KEY in applications
-    assert applications[CacheViewBuilder._UNKNOWN_APP_KEY]["processes"] == ["svchost.exe"]
-
-
-def test_merge_map_candidates_accumulates_processes_within_application() -> None:
-    """Multiple processes for the same exe path accumulate in that application's record."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates(
-        {},
-        [
-            _candidate(process_name="Spotify.exe", pid=17840),
-            _candidate(process_name="SpotifyLauncher.exe", pid=16696),
-        ],
-    )
-    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
-
-    assert app["processes"] == ["Spotify.exe", "SpotifyLauncher.exe"]
-    assert app["proc_pids"] == {"Spotify.exe": [17840], "SpotifyLauncher.exe": [16696]}
-
-
-def test_merge_map_candidates_propagates_country_code() -> None:
-    """country_code is propagated the same way as the other geo fields."""
-    builder = CacheViewBuilder()
-
-    cache = builder.merge_map_candidates({}, [_candidate(country_code="NO")])
-    entry = cache["8.8.8.8|443"]
-
-    assert entry["country_code"] == "NO"
 
 
 # --- _pick_representative_app: selection rules ---
@@ -501,8 +348,8 @@ def test_build_view_from_cache_technical_details_off_uses_app_summary() -> None:
     """technical_details_enabled=False produces the application-oriented summary."""
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(app_name="Firefox", app_verification_status="verified")]
+    cache = ConnectionState().merge(
+        [_candidate(app_name="Firefox", app_verification_status="verified")]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=False)
 
@@ -517,15 +364,14 @@ def test_build_view_from_cache_technical_details_on_matches_existing_format() ->
     """
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {},
+    cache = ConnectionState().merge(
         [
             _candidate(
                 app_name="Firefox",
                 app_creator="Mozilla Corp",
                 app_verification_status="verified",
             )
-        ],
+        ]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=True)
 
@@ -545,8 +391,7 @@ def test_build_view_from_cache_shows_failed_app_sharing_endpoint_with_verified_a
     """A failed application is never hidden by a verified application at the same endpoint."""
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {},
+    cache = ConnectionState().merge(
         [
             _candidate(
                 exe="/opt/firefox/firefox.exe",
@@ -556,7 +401,7 @@ def test_build_view_from_cache_shows_failed_app_sharing_endpoint_with_verified_a
             _candidate(
                 exe="/tmp/malware.exe", app_name="Malware", app_verification_status="failed"
             ),
-        ],
+        ]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=False)
 
@@ -567,8 +412,7 @@ def test_build_click_details_shows_processes_from_multiple_applications() -> Non
     """Technical Details lists processes from every application at an endpoint."""
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {},
+    cache = ConnectionState().merge(
         [
             _candidate(
                 exe="/opt/firefox/firefox.exe",
@@ -584,7 +428,7 @@ def test_build_click_details_shows_processes_from_multiple_applications() -> Non
                 app_name="Malware",
                 app_verification_status="failed",
             ),
-        ],
+        ]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=True)
     detail = view["details"]["0"]
@@ -1073,15 +917,14 @@ def test_build_view_from_cache_technical_details_off_uses_app_click_details() ->
     """technical_details_enabled=False routes click details through the new builder."""
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {},
+    cache = ConnectionState().merge(
         [
             _candidate(
                 app_name="Firefox",
                 app_creator="Mozilla Corporation",
                 app_verification_status="verified",
             )
-        ],
+        ]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=False)
     detail = view["details"]["0"]
@@ -1100,8 +943,8 @@ def test_build_view_from_cache_technical_details_on_details_unchanged() -> None:
     """
     builder = CacheViewBuilder()
 
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(app_name="Firefox", app_verification_status="verified")]
+    cache = ConnectionState().merge(
+        [_candidate(app_name="Firefox", app_verification_status="verified")]
     )
     view = builder.build_view_from_cache(cache, technical_details_enabled=True)
     detail = view["details"]["0"]
@@ -1134,142 +977,6 @@ def test_display_verification_status_passes_through_resolved_values() -> None:
     app = {"app_verification_status": "failed", "exe": "/malware.exe"}
 
     assert CacheViewBuilder._display_verification_status(app) == "failed"
-
-
-def test_pending_exe_paths_includes_real_pending_exe() -> None:
-    """An application with a real exe and no verification_status yet is pending."""
-    cache = {
-        "8.8.8.8|443": {
-            "applications": {
-                "/opt/app.exe": {"app_verification_status": None, "exe": "/opt/app.exe"},
-            }
-        }
-    }
-
-    assert CacheViewBuilder.pending_exe_paths(cache) == {"/opt/app.exe"}
-
-
-def test_pending_exe_paths_excludes_unknown_bucket() -> None:
-    """The synthetic unknown-application bucket never contributes a pending exe path."""
-    cache = {
-        "8.8.8.8|443": {
-            "applications": {
-                CacheViewBuilder._UNKNOWN_APP_KEY: {"app_verification_status": None, "exe": None},
-            }
-        }
-    }
-
-    assert CacheViewBuilder.pending_exe_paths(cache) == set()
-
-
-def test_pending_exe_paths_excludes_resolved_apps() -> None:
-    """An application whose verification has already resolved is not pending."""
-    cache = {
-        "8.8.8.8|443": {
-            "applications": {
-                "/opt/app.exe": {"app_verification_status": "verified", "exe": "/opt/app.exe"},
-            }
-        }
-    }
-
-    assert CacheViewBuilder.pending_exe_paths(cache) == set()
-
-
-def test_refresh_resolved_applications_backfills_pending_fields() -> None:
-    """A hand-fed resolved dict backfills the deferred fields on a matching application."""
-    builder = CacheViewBuilder()
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(exe="/opt/app.exe", app_name="Firefox")]
-    )
-
-    builder.refresh_resolved_applications(
-        cache,
-        {
-            "/opt/app.exe": {
-                "app_creator": "Mozilla Corporation",
-                "app_verification_status": "verified",
-                "app_signature_state": "SignedAndTrusted",
-                "app_signature_state_details": None,
-            }
-        },
-    )
-
-    app = cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]
-    assert app["app_creator"] == "Mozilla Corporation"
-    assert app["app_verification_status"] == "verified"
-    assert app["app_signature_state"] == "SignedAndTrusted"
-
-
-def test_refresh_resolved_applications_never_overwrites_a_resolved_value() -> None:
-    """A later resolved dict never overwrites an already-resolved field (backfill-only)."""
-    builder = CacheViewBuilder()
-    cache = builder.merge_map_candidates(
-        {},
-        [
-            _candidate(
-                exe="/opt/app.exe",
-                app_name="Firefox",
-                app_verification_status="verified",
-            )
-        ],
-    )
-
-    builder.refresh_resolved_applications(
-        cache, {"/opt/app.exe": {"app_verification_status": "failed"}}
-    )
-
-    assert cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]["app_verification_status"] == (
-        "verified"
-    )
-
-
-def test_refresh_resolved_applications_ignores_unrelated_exe_paths() -> None:
-    """resolved entries for exe paths not present anywhere in ui_cache are a harmless no-op."""  # noqa: D403
-    builder = CacheViewBuilder()
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(exe="/opt/app.exe", app_name="Firefox")]
-    )
-
-    builder.refresh_resolved_applications(
-        cache, {"/opt/other.exe": {"app_verification_status": "verified"}}
-    )
-
-    assert cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]["app_verification_status"] is None
-
-
-def test_refresh_resolved_applications_updates_entry_whose_connection_has_vanished() -> None:
-    """A retained ui_cache entry whose connection has vanished still gets updated."""
-    builder = CacheViewBuilder()
-
-    # Tick 1: connection present, exe not yet verified.
-    cache = builder.merge_map_candidates(
-        {}, [_candidate(exe="/opt/app.exe", app_name="Firefox")]
-    )
-    assert builder.pending_exe_paths(cache) == {"/opt/app.exe"}
-
-    # Tick 2: connection is gone from the snapshot entirely.
-    cache = builder.merge_map_candidates(cache, [])
-    assert "/opt/app.exe" in cache["8.8.8.8|443"]["applications"]
-    assert builder.pending_exe_paths(cache) == {"/opt/app.exe"}
-
-    # The controller would now call AppInfo.resolved_for(pending_exe_paths(cache))
-    # and translate the result into this plain-dict shape.
-    builder.refresh_resolved_applications(
-        cache,
-        {
-            "/opt/app.exe": {
-                "app_creator": "Mozilla Corporation",
-                "app_verification_status": "verified",
-                "app_signature_state": "SignedAndTrusted",
-                "app_signature_state_details": None,
-            }
-        },
-    )
-
-    app = cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]
-    assert app["app_verification_status"] == "verified"
-    assert app["app_creator"] == "Mozilla Corporation"
-    assert builder.pending_exe_paths(cache) == set()
 
 
 def test_verification_status_text_pending_shows_retrieving() -> None:

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -1,4 +1,4 @@
-"""Test ConnectionAnalyzer's mapped-PUBLIC classification and insights update."""
+"""Test ConnectionAnalyzer's PUBLIC classification, insights update, and significance wiring."""
 
 from __future__ import annotations
 
@@ -6,6 +6,9 @@ from typing import Any
 
 from tapmap.state.connection_analyzer import ConnectionAnalyzer
 from tapmap.state.connection_state import ConnectionState
+from tapmap.state.insights_state import InsightsState
+from tapmap.state.significance import SignificanceHistory
+from tapmap.state.significant_connections import SignificantConnections
 
 
 def _cache_item(**overrides: Any) -> dict[str, Any]:
@@ -35,13 +38,32 @@ def _cache_item(**overrides: Any) -> dict[str, Any]:
     return item
 
 
+def _analyzer(
+    connection_state: ConnectionState | None = None,
+    insights: dict[str, Any] | None = None,
+) -> ConnectionAnalyzer:
+    """Build a ConnectionAnalyzer with fresh, empty significance collaborators."""
+    return ConnectionAnalyzer(
+        connection_state if connection_state is not None else ConnectionState(),
+        insights if insights is not None else {},
+        SignificantConnections([]),
+        SignificanceHistory.from_insights_state(
+            InsightsState(
+                version=2,
+                insights={"countries": {}, "providers": {}, "ports": {}, "applications": {}},
+                verification_failed={},
+            )
+        ),
+    )
+
+
 # --- classification: mapped PUBLIC vs. everything else ---
 
 
 def test_analyze_merges_public_connection_with_coordinates() -> None:
     """A PUBLIC connection with valid lat/lon is classified as mapped and merged."""
     connection_state = ConnectionState()
-    analyzer = ConnectionAnalyzer(connection_state, {})
+    analyzer = _analyzer(connection_state)
 
     analyzer.analyze([_cache_item()])
 
@@ -51,7 +73,7 @@ def test_analyze_merges_public_connection_with_coordinates() -> None:
 def test_analyze_excludes_public_connection_without_coordinates() -> None:
     """A PUBLIC connection missing lat/lon is not merged into ConnectionState."""
     connection_state = ConnectionState()
-    analyzer = ConnectionAnalyzer(connection_state, {})
+    analyzer = _analyzer(connection_state)
 
     analyzer.analyze([_cache_item(lat=None, lon=None)])
 
@@ -61,7 +83,7 @@ def test_analyze_excludes_public_connection_without_coordinates() -> None:
 def test_analyze_excludes_non_public_scopes() -> None:
     """LAN, LOCAL, and UNKNOWN scoped connections are never merged into ConnectionState."""
     connection_state = ConnectionState()
-    analyzer = ConnectionAnalyzer(connection_state, {})
+    analyzer = _analyzer(connection_state)
 
     analyzer.analyze(
         [
@@ -80,7 +102,7 @@ def test_analyze_excludes_non_public_scopes() -> None:
 def test_analyze_feeds_full_cache_items_to_insights_not_just_mapped() -> None:
     """Insights are updated from every PUBLIC connection, including unmapped ones."""
     insights: dict[str, Any] = {}
-    analyzer = ConnectionAnalyzer(ConnectionState(), insights)
+    analyzer = _analyzer(insights=insights)
 
     analyzer.analyze([_cache_item(lat=None, lon=None, country_code="NO")])
 
@@ -90,7 +112,7 @@ def test_analyze_feeds_full_cache_items_to_insights_not_just_mapped() -> None:
 def test_analyze_excludes_non_public_connections_from_insights() -> None:
     """LAN/LOCAL/UNKNOWN connections do not contribute to Insights."""
     insights: dict[str, Any] = {}
-    analyzer = ConnectionAnalyzer(ConnectionState(), insights)
+    analyzer = _analyzer(insights=insights)
 
     analyzer.analyze([_cache_item(ip="192.168.1.1", service_scope="LAN", country_code="NO")])
 
@@ -99,9 +121,77 @@ def test_analyze_excludes_non_public_connections_from_insights() -> None:
 
 def test_analyze_returns_process_insights_result() -> None:
     """analyze() returns the same {new, top} shape process_insights() produces."""
-    analyzer = ConnectionAnalyzer(ConnectionState(), {})
+    analyzer = _analyzer()
 
     result = analyzer.analyze([_cache_item()])
 
     assert set(result.keys()) == {"new", "top"}
     assert result["new"]["countries"][0]["value"] == "US"
+
+
+# --- significant connections wiring ---
+
+
+def test_analyze_records_significant_event_for_novel_public_connection() -> None:
+    """A PUBLIC connection with a never-seen country produces one Significant Connection event."""
+    significant_connections = SignificantConnections([])
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        {},
+        significant_connections,
+        SignificanceHistory.from_insights_state(
+            InsightsState(
+                version=2,
+                insights={"countries": {}, "providers": {}, "ports": {}, "applications": {}},
+                verification_failed={},
+            )
+        ),
+    )
+
+    analyzer.analyze([_cache_item(country_code="US")])
+
+    assert len(significant_connections.items) == 1
+    event = significant_connections.items[0]
+    assert "new_country" in event["reasons"]
+    assert event["ip"] == "8.8.8.8"
+
+
+def test_analyze_does_not_evaluate_significance_for_non_public_connections() -> None:
+    """LAN/LOCAL/UNKNOWN connections are filtered out before significance is ever checked."""
+    significant_connections = SignificantConnections([])
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        {},
+        significant_connections,
+        SignificanceHistory.from_insights_state(
+            InsightsState(
+                version=2,
+                insights={"countries": {}, "providers": {}, "ports": {}, "applications": {}},
+                verification_failed={},
+            )
+        ),
+    )
+
+    analyzer.analyze(
+        [_cache_item(ip="192.168.1.1", service_scope="LAN", country_code="NO", port=9999)]
+    )
+
+    assert significant_connections.items == []
+
+
+def test_analyze_does_not_repeat_significant_event_for_same_snapshot_repeat() -> None:
+    """Two consecutive analyze() calls with the same connection produce only one event."""
+    significant_connections = SignificantConnections([])
+    history = SignificanceHistory.from_insights_state(
+        InsightsState(
+            version=2,
+            insights={"countries": {}, "providers": {}, "ports": {}, "applications": {}},
+            verification_failed={},
+        )
+    )
+    analyzer = ConnectionAnalyzer(ConnectionState(), {}, significant_connections, history)
+
+    analyzer.analyze([_cache_item(country_code="US")])
+    analyzer.analyze([_cache_item(country_code="US")])
+
+    assert len(significant_connections.items) == 1

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -1,0 +1,107 @@
+"""Test ConnectionAnalyzer's mapped-PUBLIC classification and insights update."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tapmap.state.connection_analyzer import ConnectionAnalyzer
+from tapmap.state.connection_state import ConnectionState
+
+
+def _cache_item(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal cache_items-shaped dict (as produced by Model.snapshot())."""
+    item = {
+        "ip": "8.8.8.8",
+        "port": 443,
+        "proto": "tcp",
+        "service_scope": "PUBLIC",
+        "lat": 37.4,
+        "lon": -122.1,
+        "city": "Mountain View",
+        "country": "United States",
+        "country_code": "US",
+        "asn": 15169,
+        "asn_org": "Google LLC",
+        "process_name": None,
+        "pid": None,
+        "exe": None,
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    item.update(overrides)
+    return item
+
+
+# --- classification: mapped PUBLIC vs. everything else ---
+
+
+def test_analyze_merges_public_connection_with_coordinates() -> None:
+    """A PUBLIC connection with valid lat/lon is classified as mapped and merged."""
+    connection_state = ConnectionState()
+    analyzer = ConnectionAnalyzer(connection_state, {})
+
+    analyzer.analyze([_cache_item()])
+
+    assert "8.8.8.8|443" in connection_state.cache
+
+
+def test_analyze_excludes_public_connection_without_coordinates() -> None:
+    """A PUBLIC connection missing lat/lon is not merged into ConnectionState."""
+    connection_state = ConnectionState()
+    analyzer = ConnectionAnalyzer(connection_state, {})
+
+    analyzer.analyze([_cache_item(lat=None, lon=None)])
+
+    assert connection_state.cache == {}
+
+
+def test_analyze_excludes_non_public_scopes() -> None:
+    """LAN, LOCAL, and UNKNOWN scoped connections are never merged into ConnectionState."""
+    connection_state = ConnectionState()
+    analyzer = ConnectionAnalyzer(connection_state, {})
+
+    analyzer.analyze(
+        [
+            _cache_item(ip="192.168.1.1", service_scope="LAN"),
+            _cache_item(ip="127.0.0.1", service_scope="LOCAL"),
+            _cache_item(ip="10.0.0.1", service_scope="UNKNOWN"),
+        ]
+    )
+
+    assert connection_state.cache == {}
+
+
+# --- insights: updated from the full connection set, not just mapped ---
+
+
+def test_analyze_feeds_full_cache_items_to_insights_not_just_mapped() -> None:
+    """Insights are updated from every PUBLIC connection, including unmapped ones."""
+    insights: dict[str, Any] = {}
+    analyzer = ConnectionAnalyzer(ConnectionState(), insights)
+
+    analyzer.analyze([_cache_item(lat=None, lon=None, country_code="NO")])
+
+    assert "NO" in insights["countries"]
+
+
+def test_analyze_excludes_non_public_connections_from_insights() -> None:
+    """LAN/LOCAL/UNKNOWN connections do not contribute to Insights."""
+    insights: dict[str, Any] = {}
+    analyzer = ConnectionAnalyzer(ConnectionState(), insights)
+
+    analyzer.analyze([_cache_item(ip="192.168.1.1", service_scope="LAN", country_code="NO")])
+
+    assert insights.get("countries", {}) == {}
+
+
+def test_analyze_returns_process_insights_result() -> None:
+    """analyze() returns the same {new, top} shape process_insights() produces."""
+    analyzer = ConnectionAnalyzer(ConnectionState(), {})
+
+    result = analyzer.analyze([_cache_item()])
+
+    assert set(result.keys()) == {"new", "top"}
+    assert result["new"]["countries"][0]["value"] == "US"

--- a/tests/test_connection_state.py
+++ b/tests/test_connection_state.py
@@ -1,0 +1,347 @@
+"""Test ConnectionState's per-service cache merge, retention, and AppInfo backfill."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tapmap.state.connection_state import UNKNOWN_APP_KEY, ConnectionState
+
+_APP_FIELDS = (
+    "app_name",
+    "app_creator",
+    "app_verification_status",
+    "app_signature_state",
+    "app_signature_state_details",
+)
+
+_DEFAULT_EXE = "/opt/app/app.exe"
+
+
+def _candidate(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid map candidate (as produced by Model.snapshot())."""
+    candidate = {
+        "ip": "8.8.8.8",
+        "port": 443,
+        "proto": "tcp",
+        "process_name": None,
+        "pid": None,
+        "exe": _DEFAULT_EXE,
+        "lon": 37.4,
+        "lat": -122.1,
+        "city": "Mountain View",
+        "country": "United States",
+        "country_code": "US",
+        "asn": 15169,
+        "asn_org": "Google LLC",
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _app_fields(app: dict[str, Any]) -> dict[str, Any]:
+    """Return only the app_* fields from an application record."""
+    return {field: app.get(field) for field in _APP_FIELDS}
+
+
+# --- merge: application record propagation ---
+
+
+def test_merge_propagates_app_fields_into_new_application() -> None:
+    """A new application record carries all five app_* fields from the candidate."""
+    state = ConnectionState()
+
+    candidate = _candidate(
+        app_name="Firefox",
+        app_creator="Mozilla Corporation",
+        app_verification_status="verified",
+        app_signature_state="SignedAndTrusted",
+        app_signature_state_details="None",
+    )
+
+    cache = state.merge([candidate])
+    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
+
+    assert _app_fields(app) == {
+        "app_name": "Firefox",
+        "app_creator": "Mozilla Corporation",
+        "app_verification_status": "verified",
+        "app_signature_state": "SignedAndTrusted",
+        "app_signature_state_details": "None",
+    }
+
+
+def test_merge_leaves_app_fields_none_when_absent() -> None:
+    """A candidate with no app data (AppInfo disabled) leaves app_* fields None."""
+    state = ConnectionState()
+
+    cache = state.merge([_candidate()])
+    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
+
+    assert _app_fields(app) == dict.fromkeys(_APP_FIELDS)
+
+
+def test_merge_backfills_app_fields_on_existing_application() -> None:
+    """A later candidate fills in app_* fields that were previously missing."""
+    state = ConnectionState()
+
+    state.merge([_candidate()])
+    cache = state.merge(
+        [
+            _candidate(
+                app_name="Firefox",
+                app_creator="Mozilla Corporation",
+                app_verification_status="verified",
+                app_signature_state="SignedAndTrusted",
+                app_signature_state_details="None",
+            )
+        ]
+    )
+    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
+
+    assert app["app_name"] == "Firefox"
+    assert app["app_verification_status"] == "verified"
+
+
+def test_merge_keeps_first_app_value_for_same_exe() -> None:
+    """A distinct later value for the same exe path does not overwrite the first."""
+    state = ConnectionState()
+
+    state.merge([_candidate(app_name="Firefox", app_verification_status="verified")])
+    cache = state.merge([_candidate(app_name="Other Name", app_verification_status="failed")])
+    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
+
+    assert app["app_name"] == "Firefox"
+    assert app["app_verification_status"] == "verified"
+
+
+def test_merge_keeps_different_exe_paths_separate() -> None:
+    """Two different applications sharing (ip, port) each get their own application record."""
+    state = ConnectionState()
+
+    cache = state.merge(
+        [
+            _candidate(
+                exe="/opt/firefox/firefox.exe",
+                app_name="Firefox",
+                app_verification_status="verified",
+            ),
+            _candidate(
+                exe="/tmp/malware.exe", app_name="Malware", app_verification_status="failed"
+            ),
+        ]
+    )
+    applications = cache["8.8.8.8|443"]["applications"]
+
+    assert applications["/opt/firefox/firefox.exe"]["app_name"] == "Firefox"
+    assert applications["/opt/firefox/firefox.exe"]["app_verification_status"] == "verified"
+    assert applications["/tmp/malware.exe"]["app_name"] == "Malware"
+    assert applications["/tmp/malware.exe"]["app_verification_status"] == "failed"
+
+
+def test_merge_uses_unknown_bucket_when_exe_missing() -> None:
+    """Candidates with no resolvable exe path share a dedicated unknown-application bucket."""
+    state = ConnectionState()
+
+    cache = state.merge([_candidate(exe=None, process_name="svchost.exe", pid=100)])
+    applications = cache["8.8.8.8|443"]["applications"]
+
+    assert UNKNOWN_APP_KEY in applications
+    assert applications[UNKNOWN_APP_KEY]["processes"] == ["svchost.exe"]
+
+
+def test_merge_accumulates_processes_within_application() -> None:
+    """Multiple processes for the same exe path accumulate in that application's record."""
+    state = ConnectionState()
+
+    cache = state.merge(
+        [
+            _candidate(process_name="Spotify.exe", pid=17840),
+            _candidate(process_name="SpotifyLauncher.exe", pid=16696),
+        ]
+    )
+    app = cache["8.8.8.8|443"]["applications"][_DEFAULT_EXE]
+
+    assert app["processes"] == ["Spotify.exe", "SpotifyLauncher.exe"]
+    assert app["proc_pids"] == {"Spotify.exe": [17840], "SpotifyLauncher.exe": [16696]}
+
+
+def test_merge_propagates_country_code() -> None:
+    """country_code is propagated the same way as the other geo fields."""
+    state = ConnectionState()
+
+    cache = state.merge([_candidate(country_code="NO")])
+    entry = cache["8.8.8.8|443"]
+
+    assert entry["country_code"] == "NO"
+
+
+def test_merge_drops_candidate_with_invalid_port() -> None:
+    """A candidate with a missing or non-numeric port is dropped, not stored under a -1 key."""
+    state = ConnectionState()
+
+    cache = state.merge([_candidate(port=None), _candidate(exe="/other.exe", port="not-a-port")])
+
+    assert cache == {}
+
+
+# --- clear: reset behavior ---
+
+
+def test_clear_empties_the_cache() -> None:
+    """clear() drops all accumulated entries and returns the new empty cache."""
+    state = ConnectionState()
+    state.merge([_candidate()])
+
+    cache = state.clear()
+
+    assert cache == {}
+    assert state.cache == {}
+
+
+# --- retention: pruning stale entries ---
+
+
+def test_merge_prunes_entries_past_retention_window() -> None:
+    """An entry whose last_seen predates the retention cutoff is dropped on the next merge."""
+    state = ConnectionState(cache_retention_min=5)
+    cache = state.merge([_candidate()])
+    cache["8.8.8.8|443"]["last_seen"] -= 10 * 60
+
+    cache = state.merge([])
+
+    assert cache == {}
+
+
+def test_merge_keeps_entries_when_retention_disabled() -> None:
+    """cache_retention_min=0 (the default) disables pruning entirely."""
+    state = ConnectionState(cache_retention_min=0)
+    cache = state.merge([_candidate()])
+    cache["8.8.8.8|443"]["last_seen"] -= 10_000 * 60
+
+    cache = state.merge([])
+
+    assert "8.8.8.8|443" in cache
+
+
+# --- pending verification: AppInfo backfill ---
+
+
+def test_pending_exe_paths_includes_real_pending_exe() -> None:
+    """An application with a real exe and no verification_status yet is pending."""
+    state = ConnectionState()
+    state.merge([_candidate(exe="/opt/app.exe", app_name="Firefox")])
+
+    assert state.pending_exe_paths() == {"/opt/app.exe"}
+
+
+def test_pending_exe_paths_excludes_unknown_bucket() -> None:
+    """The synthetic unknown-application bucket never contributes a pending exe path."""
+    state = ConnectionState()
+    state.merge([_candidate(exe=None, process_name="svchost.exe", pid=100)])
+
+    assert state.pending_exe_paths() == set()
+
+
+def test_pending_exe_paths_excludes_resolved_apps() -> None:
+    """An application whose verification has already resolved is not pending."""
+    state = ConnectionState()
+    state.merge(
+        [_candidate(exe="/opt/app.exe", app_name="Firefox", app_verification_status="verified")]
+    )
+
+    assert state.pending_exe_paths() == set()
+
+
+def test_refresh_resolved_applications_backfills_pending_fields() -> None:
+    """A hand-fed resolved dict backfills the deferred fields on a matching application."""
+    state = ConnectionState()
+    state.merge([_candidate(exe="/opt/app.exe", app_name="Firefox")])
+
+    state.refresh_resolved_applications(
+        {
+            "/opt/app.exe": {
+                "app_creator": "Mozilla Corporation",
+                "app_verification_status": "verified",
+                "app_signature_state": "SignedAndTrusted",
+                "app_signature_state_details": None,
+            }
+        }
+    )
+
+    app = state.cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]
+    assert app["app_creator"] == "Mozilla Corporation"
+    assert app["app_verification_status"] == "verified"
+    assert app["app_signature_state"] == "SignedAndTrusted"
+
+
+def test_refresh_resolved_applications_never_overwrites_a_resolved_value() -> None:
+    """A later resolved dict never overwrites an already-resolved field (backfill-only)."""
+    state = ConnectionState()
+    state.merge(
+        [
+            _candidate(
+                exe="/opt/app.exe",
+                app_name="Firefox",
+                app_verification_status="verified",
+            )
+        ]
+    )
+
+    state.refresh_resolved_applications({"/opt/app.exe": {"app_verification_status": "failed"}})
+
+    assert (
+        state.cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]["app_verification_status"]
+        == "verified"
+    )
+
+
+def test_refresh_resolved_applications_ignores_unrelated_exe_paths() -> None:
+    """Resolved entries for exe paths not present anywhere in the cache are a harmless no-op."""
+    state = ConnectionState()
+    state.merge([_candidate(exe="/opt/app.exe", app_name="Firefox")])
+
+    state.refresh_resolved_applications(
+        {"/opt/other.exe": {"app_verification_status": "verified"}}
+    )
+
+    assert (
+        state.cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]["app_verification_status"]
+        is None
+    )
+
+
+def test_refresh_resolved_applications_updates_entry_whose_connection_has_vanished() -> None:
+    """A retained cache entry whose connection has vanished still gets updated."""
+    state = ConnectionState()
+
+    # Tick 1: connection present, exe not yet verified.
+    state.merge([_candidate(exe="/opt/app.exe", app_name="Firefox")])
+    assert state.pending_exe_paths() == {"/opt/app.exe"}
+
+    # Tick 2: connection is gone from the snapshot entirely.
+    cache = state.merge([])
+    assert "/opt/app.exe" in cache["8.8.8.8|443"]["applications"]
+    assert state.pending_exe_paths() == {"/opt/app.exe"}
+
+    # The controller would now call AppInfo.resolved_for(pending_exe_paths())
+    # and translate the result into this plain-dict shape.
+    state.refresh_resolved_applications(
+        {
+            "/opt/app.exe": {
+                "app_creator": "Mozilla Corporation",
+                "app_verification_status": "verified",
+                "app_signature_state": "SignedAndTrusted",
+                "app_signature_state_details": None,
+            }
+        }
+    )
+
+    app = state.cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]
+    assert app["app_verification_status"] == "verified"
+    assert app["app_creator"] == "Mozilla Corporation"
+    assert state.pending_exe_paths() == set()

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -553,7 +553,7 @@ class TestInputFiltering:
             "country_code": "US",
             "asn_org": "Acme Inc",
             "port": 443,
-            "process_name": "nginx",
+            "app_name": "nginx",
         }]
         insights: dict[str, Any] = {}
         process_insights(items, insights, _now(1))
@@ -561,6 +561,16 @@ class TestInputFiltering:
         assert "Acme Inc" in insights["providers"]
         assert "443" in insights["ports"]
         assert "nginx" in insights["applications"]
+
+    def test_applications_dimension_uses_app_name_not_process_name(self) -> None:
+        """The applications dimension is keyed by app_name; process_name alone is not sufficient."""
+        items = [{
+            "service_scope": "PUBLIC",
+            "process_name": "nginx",
+        }]
+        insights: dict[str, Any] = {}
+        process_insights(items, insights, _now(1))
+        assert insights.get("applications", {}) == {}
 
     def test_missing_service_scope_field_is_not_treated_as_public(self) -> None:
         """Item with no service_scope key is not counted (treated as non-PUBLIC)."""

--- a/tests/test_insights_persistence.py
+++ b/tests/test_insights_persistence.py
@@ -14,30 +14,60 @@ import pytest
 
 from tapmap.app import TapMap
 from tapmap.settings_persistence import Settings
+from tapmap.state.insights_state import CURRENT_SCHEMA_VERSION, InsightsState
+from tapmap.state.significant_connections import SignificantConnections
 
 
 def test_failed_save_does_not_corrupt_state(tmp_path: Path) -> None:
-    """A failed save does not corrupt or clear in-memory state."""
+    """A failed save does not corrupt or clear in-memory state, for either history file."""
     app = _bare_app(tmp_path)
-    app.insights = {
-        "countries": {"NO": 1},
-        "providers": {},
-        "ports": {},
-        "applications": {},
-    }
+    app.insights_state = InsightsState(
+        version=CURRENT_SCHEMA_VERSION,
+        insights={"countries": {"NO": 1}, "providers": {}, "ports": {}, "applications": {}},
+        verification_failed={},
+    )
+    app.significant_connections = SignificantConnections([{"timestamp": "t", "reasons": ["x"]}])
     # Simulate save failure by patching Path.open to raise OSError
     with (
         unittest.mock.patch.object(Path, "open", side_effect=OSError("disk full")),
         contextlib.suppress(OSError),
     ):
-        app._save_insights()
+        app._save_history()
     # State should be unchanged
-    assert app.insights == {
+    assert app.insights_state.insights == {
         "countries": {"NO": 1},
         "providers": {},
         "ports": {},
         "applications": {},
     }
+    assert app.significant_connections.items == [{"timestamp": "t", "reasons": ["x"]}]
+
+
+def test_save_history_isolates_failure_per_file(tmp_path: Path) -> None:
+    """A failing insights save must not prevent Significant Connections from being saved."""
+    app = _bare_app(tmp_path)
+    app.insights_state = InsightsState(
+        version=CURRENT_SCHEMA_VERSION,
+        insights=_EMPTY,
+        verification_failed={},
+    )
+    app.significant_connections = SignificantConnections([{"timestamp": "t", "reasons": ["x"]}])
+
+    real_open = Path.open
+
+    def _flaky_open(self: Path, *args: object, **kwargs: object):
+        if self.name.startswith("insights"):
+            raise OSError("disk full")
+        return real_open(self, *args, **kwargs)
+
+    with (
+        unittest.mock.patch.object(Path, "open", _flaky_open),
+        contextlib.suppress(OSError),
+    ):
+        app._save_history()
+
+    assert not app.insights_path.exists()
+    assert app.significant_connections_path.exists()
 
 
 def test_failed_save_settings_does_not_corrupt_state(tmp_path: Path) -> None:
@@ -61,79 +91,150 @@ def _bare_app(tmp_path: Path) -> TapMap:
     """Return a TapMap instance with only the attributes needed for method-level tests."""
     app = object.__new__(TapMap)
     app.logger = logging.getLogger("test")
-    app.insights = {}
+    app.insights_state = InsightsState(
+        version=CURRENT_SCHEMA_VERSION, insights={}, verification_failed={}
+    )
     app.insights_path = tmp_path / "insights.json"
+    app.significant_connections = SignificantConnections([])
+    app.significant_connections_path = tmp_path / "significant_connections.json"
     app.settings = Settings()
     app.settings_path = tmp_path / "settings.json"
     app._lock_path = tmp_path / "tapmap.lock"
     return app
 
 
-# --- _load_insights: corrupt JSON ---
+# --- _load_history: corrupt JSON ---
 
 
-def test_load_insights_corrupt_json_fallback(tmp_path: Path) -> None:
+def test_load_history_corrupt_json_fallback(tmp_path: Path) -> None:
     """Corrupt JSON must not crash; insights must become the empty structure."""
     app = _bare_app(tmp_path)
     app.insights_path.write_text("not valid json", encoding="utf-8")
-    app._load_insights()
-    assert app.insights == _EMPTY
+    app._load_history()
+    assert app.insights_state.insights == _EMPTY
+    assert app.insights_state.verification_failed == {}
+    assert app.significant_connections.items == []
 
 
-# --- _load_insights: unexpected structure ---
+# --- _load_history: unexpected structure ---
 
 
-def test_load_insights_wrong_structure_fallback(tmp_path: Path) -> None:
+def test_load_history_wrong_structure_fallback(tmp_path: Path) -> None:
     """A non-dict 'insights' value must fall back to the empty structure."""
     app = _bare_app(tmp_path)
     app.insights_path.write_text(json.dumps({"insights": ["not", "a", "dict"]}), encoding="utf-8")
-    app._load_insights()
-    assert app.insights == _EMPTY
+    app._load_history()
+    assert app.insights_state.insights == _EMPTY
 
 
-# --- _load_insights: unknown top-level keys are discarded ---
+# --- _load_history: unknown top-level keys are discarded ---
 
 
-def test_load_insights_strips_unknown_keys(tmp_path: Path) -> None:
-    """Only the four recognised keys should be kept; unknown keys are discarded."""
+def test_load_history_strips_unknown_keys(tmp_path: Path) -> None:
+    """Only the four recognised Insights keys should be kept; unknown keys are discarded."""
     app = _bare_app(tmp_path)
     data = {
+        "version": CURRENT_SCHEMA_VERSION,
         "insights": {
             "countries": {"US": 1},
             "providers": {},
             "ports": {},
             "applications": {},
             "legacy_field": {"should": "be_removed"},
-        }
+        },
     }
     app.insights_path.write_text(json.dumps(data), encoding="utf-8")
-    app._load_insights()
-    assert set(app.insights.keys()) == {"countries", "providers", "ports", "applications"}
-    assert "legacy_field" not in app.insights
-    assert app.insights["countries"] == {"US": 1}
+    app._load_history()
+    assert set(app.insights_state.insights.keys()) == {
+        "countries",
+        "providers",
+        "ports",
+        "applications",
+    }
+    assert "legacy_field" not in app.insights_state.insights
+    assert app.insights_state.insights["countries"] == {"US": 1}
 
 
-# --- _save_insights / _load_insights: roundtrip ---
+# --- _save_history / _load_history: roundtrip ---
 
 
 def test_save_and_reload_preserves_data(tmp_path: Path) -> None:
-    """Saving and reloading insights must preserve all data exactly."""
+    """Saving and reloading both history files must preserve all data exactly."""
     app = _bare_app(tmp_path)
-    app.insights = {
+    app.insights_state = InsightsState(
+        version=CURRENT_SCHEMA_VERSION,
+        insights={
+            "countries": {"DE": 3},
+            "providers": {"AS1234": 1},
+            "ports": {"443": 5},
+            "applications": {"curl": 2},
+        },
+        verification_failed={"BadApp": 738000},
+    )
+    app.significant_connections = SignificantConnections(
+        [{"timestamp": "2026-08-01T00:00:00", "reasons": ["new_app"]}]
+    )
+    app._save_history()
+
+    app.insights_state = InsightsState(version=0, insights={}, verification_failed={})
+    app.significant_connections = SignificantConnections([])
+    app._load_history()
+
+    assert app.insights_state.insights == {
         "countries": {"DE": 3},
         "providers": {"AS1234": 1},
         "ports": {"443": 5},
         "applications": {"curl": 2},
     }
-    app._save_insights()
-    app.insights = {}
-    app._load_insights()
-    assert app.insights == {
-        "countries": {"DE": 3},
-        "providers": {"AS1234": 1},
-        "ports": {"443": 5},
-        "applications": {"curl": 2},
+    assert app.insights_state.verification_failed == {"BadApp": 738000}
+    assert app.insights_state.version == CURRENT_SCHEMA_VERSION
+    assert app.significant_connections.items == [
+        {"timestamp": "2026-08-01T00:00:00", "reasons": ["new_app"]}
+    ]
+
+
+# --- _load_history: applications-only migration ---
+
+
+def test_load_history_migrates_pre_v2_applications_only(tmp_path: Path) -> None:
+    """A file with no version marker resets applications but preserves other dimensions."""
+    app = _bare_app(tmp_path)
+    data = {
+        "insights": {
+            "countries": {"US": 1},
+            "providers": {"AS15169": 1},
+            "ports": {"443": 1},
+            "applications": {"chrome.exe": {"l": 738000, "m": 1}},
+        }
     }
+    app.insights_path.write_text(json.dumps(data), encoding="utf-8")
+    app._load_history()
+
+    assert app.insights_state.insights["applications"] == {}
+    assert app.insights_state.insights["countries"] == {"US": 1}
+    assert app.insights_state.insights["providers"] == {"AS15169": 1}
+    assert app.insights_state.insights["ports"] == {"443": 1}
+    assert app.insights_state.version == CURRENT_SCHEMA_VERSION
+
+
+def test_load_history_does_not_migrate_current_version(tmp_path: Path) -> None:
+    """A file already at the current schema version keeps its applications history."""
+    app = _bare_app(tmp_path)
+    data = {
+        "version": CURRENT_SCHEMA_VERSION,
+        "insights": {
+            "countries": {},
+            "providers": {},
+            "ports": {},
+            "applications": {"Google Chrome": {"l": 738000, "m": 1}},
+        },
+        "verification_failed": {},
+    }
+    app.insights_path.write_text(json.dumps(data), encoding="utf-8")
+    app._load_history()
+
+    assert app.insights_state.insights["applications"] == {"Google Chrome": {"l": 738000, "m": 1}}
+
 
 # --- _acquire_lock ---
 

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -1,0 +1,268 @@
+"""Tests for SignificanceHistory reconstruction and get_significant() evaluation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from tapmap.state.insights_state import InsightsState
+from tapmap.state.significance import (
+    REASON_NEW_APP,
+    REASON_NEW_COUNTRY,
+    REASON_NEW_PORT,
+    REASON_NEW_PROVIDER,
+    REASON_VERIFICATION_FAILED,
+    SignificanceHistory,
+    get_significant,
+)
+
+
+def _cache_item(**overrides: Any) -> dict[str, Any]:
+    item = {
+        "proto": "tcp",
+        "ip": "8.8.8.8",
+        "port": 443,
+        "service": "https",
+        "lat": 37.4,
+        "lon": -122.1,
+        "process_name": "chrome.exe",
+        "exe": r"C:\chrome.exe",
+        "city": "Mountain View",
+        "country": "United States",
+        "country_code": "US",
+        "asn": 15169,
+        "asn_org": "Google LLC",
+        "app_name": "Google Chrome",
+        "app_creator": "Google LLC",
+        "app_verification_status": "verified",
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+        "pid": 1234,
+    }
+    item.update(overrides)
+    return item
+
+
+def _bitmask_entry(anchor_day: int, days_ago_seen: int) -> dict[str, int]:
+    """Return a {l, m} entry recording one observation days_ago_seen days before anchor_day."""
+    return {"l": anchor_day, "m": 1 << days_ago_seen}
+
+
+def _empty_last_seen() -> dict[str, dict[Any, int]]:
+    return {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
+
+
+# --- SignificanceHistory.from_insights_state ---
+
+
+def test_from_insights_state_reconstructs_last_seen_and_shares_verification_failed() -> None:
+    """last_seen is derived from Insights bitmasks; verification_failed is shared by reference."""
+    today = datetime(2026, 8, 22).date().toordinal()
+    verification_failed = {"BadApp": today - 5}
+    insights_state = InsightsState(
+        version=2,
+        insights={
+            "countries": {"US": _bitmask_entry(today, 2)},
+            "providers": {"Google LLC": _bitmask_entry(today, 0)},
+            "ports": {"443": _bitmask_entry(today, 10)},
+            "applications": {"Google Chrome": _bitmask_entry(today, 1)},
+        },
+        verification_failed=verification_failed,
+    )
+
+    history = SignificanceHistory.from_insights_state(insights_state)
+
+    assert history.last_seen["countries"]["US"] == today - 2
+    assert history.last_seen["providers"]["Google LLC"] == today
+    assert history.last_seen["ports"][443] == today - 10
+    assert isinstance(next(iter(history.last_seen["ports"].keys())), int)
+    assert history.last_seen["applications"]["Google Chrome"] == today - 1
+    assert history.verification_failed is verification_failed
+
+
+def test_from_insights_state_skips_zeroed_and_malformed_entries() -> None:
+    """Entries with m == 0 or non-int port keys are silently skipped, not treated as errors."""
+    today = datetime(2026, 8, 22).date().toordinal()
+    insights_state = InsightsState(
+        version=2,
+        insights={
+            "countries": {"XX": {"l": today, "m": 0}},
+            "providers": {},
+            "ports": {"not-a-port": _bitmask_entry(today, 0)},
+            "applications": {},
+        },
+        verification_failed={},
+    )
+
+    history = SignificanceHistory.from_insights_state(insights_state)
+
+    assert history.last_seen["countries"] == {}
+    assert history.last_seen["ports"] == {}
+
+
+# --- check_and_update: 30-day boundary ---
+
+
+@pytest.mark.parametrize(
+    ("days_since_last_seen", "expected_is_new"),
+    [
+        (0, False),
+        (1, False),
+        (29, False),
+        (30, True),
+        (31, True),
+    ],
+)
+def test_check_and_update_30_day_boundary(
+    days_since_last_seen: int, expected_is_new: bool
+) -> None:
+    """A value is new again once it has been at least 30 days since it was last recorded."""
+    today = 738000
+    history = SignificanceHistory(
+        last_seen={**_empty_last_seen(), "countries": {"US": today - days_since_last_seen}},
+        verification_failed={},
+    )
+
+    assert history.check_and_update("countries", "US", today) is expected_is_new
+    # Always updates, regardless of outcome.
+    assert history.last_seen["countries"]["US"] == today
+
+
+def test_check_and_update_unseen_value_is_new() -> None:
+    """A value never seen before is new."""
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+
+    assert history.check_and_update("countries", "US", 738000) is True
+    assert history.last_seen["countries"]["US"] == 738000
+
+
+# --- get_significant: reason/dimension mapping and event shape ---
+
+
+def test_get_significant_returns_none_when_nothing_is_new() -> None:
+    """A connection whose app/country/provider/port were all already seen produces no event."""
+    today = 738000
+    history = SignificanceHistory(
+        last_seen={
+            "countries": {"US": today},
+            "providers": {"Google LLC": today},
+            "ports": {443: today},
+            "applications": {"Google Chrome": today},
+        },
+        verification_failed={},
+    )
+
+    result = get_significant(_cache_item(), history, datetime.fromordinal(today))
+
+    assert result is None
+
+
+def test_get_significant_new_connection_reports_all_four_new_reasons() -> None:
+    """A connection novel in all four dimensions produces one event with all four reasons."""
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+
+    result = get_significant(_cache_item(), history, datetime(2026, 8, 22))
+
+    assert result is not None
+    assert set(result["reasons"]) == {
+        REASON_NEW_APP,
+        REASON_NEW_COUNTRY,
+        REASON_NEW_PROVIDER,
+        REASON_NEW_PORT,
+    }
+
+
+def test_get_significant_event_preserves_full_connection_detail() -> None:
+    """The event carries the documented fields plus timestamp/reasons/pid, and drops the rest."""
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+    now = datetime(2026, 8, 22, 10, 30, 0)
+
+    result = get_significant(_cache_item(), history, now)
+
+    assert result is not None
+    assert result["timestamp"] == now.isoformat()
+    assert result["pid"] == 1234
+    assert result["ip"] == "8.8.8.8"
+    assert result["app_name"] == "Google Chrome"
+    assert "cmdline" not in result
+    assert "service_hint" not in result
+    assert "process_status" not in result
+    assert "service_scope" not in result
+    assert "connection_key" not in result
+
+
+def test_get_significant_verification_failed_reason() -> None:
+    """A FAILED verification status on an already-known app produces only verification_failed."""
+    today_dt = datetime(2026, 8, 22)
+    today = today_dt.date().toordinal()
+    history = SignificanceHistory(
+        last_seen={
+            "countries": {"US": today},
+            "providers": {"Google LLC": today},
+            "ports": {443: today},
+            "applications": {"Google Chrome": today},
+        },
+        verification_failed={},
+    )
+
+    result = get_significant(_cache_item(app_verification_status="failed"), history, today_dt)
+
+    assert result is not None
+    assert result["reasons"] == [REASON_VERIFICATION_FAILED]
+
+
+def test_get_significant_missing_app_name_excludes_new_app_and_verification_failed_only() -> None:
+    """No app_name means new_app/verification_failed can't be evaluated; other reasons still can."""
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+
+    result = get_significant(
+        _cache_item(app_name=None, app_verification_status="failed"),
+        history,
+        datetime(2026, 8, 22),
+    )
+
+    assert result is not None
+    assert REASON_NEW_APP not in result["reasons"]
+    assert REASON_VERIFICATION_FAILED not in result["reasons"]
+    assert REASON_NEW_COUNTRY in result["reasons"]
+
+
+# --- realistic multi-poll scenarios ---
+
+
+def test_first_connection_owns_new_reason_within_one_poll() -> None:
+    """When two connections in one poll introduce the same new country, only the first gets it."""
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+    now = datetime(2026, 8, 22)
+
+    first = get_significant(_cache_item(ip="1.1.1.1", port=80), history, now)
+    second = get_significant(_cache_item(ip="2.2.2.2", port=80), history, now)
+
+    assert first is not None
+    assert REASON_NEW_COUNTRY in first["reasons"]
+    assert second is None
+
+
+def test_significance_across_polls_deduplicates_then_becomes_new_again_after_30_days() -> None:
+    """A value stays non-new across polls until 30 days have passed since it was last recorded.
+
+    check_and_update() refreshes last_seen on every call, including
+    duplicate (non-new) observations, so the 30-day window is measured from
+    day2 (the last observation), not day1 (the first).
+    """
+    history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
+    day1 = datetime(2026, 1, 1)
+    day2 = datetime(2026, 1, 2)
+    day_after_30_more = datetime(2026, 2, 1)
+
+    poll1 = get_significant(_cache_item(), history, day1)
+    poll2 = get_significant(_cache_item(), history, day2)
+    poll3 = get_significant(_cache_item(), history, day_after_30_more)
+
+    assert poll1 is not None
+    assert REASON_NEW_COUNTRY in poll1["reasons"]
+    assert poll2 is None
+    assert poll3 is not None
+    assert REASON_NEW_COUNTRY in poll3["reasons"]

--- a/tests/test_significant_connections.py
+++ b/tests/test_significant_connections.py
@@ -1,0 +1,46 @@
+"""Tests for SignificantConnections' bounded, chronological history."""
+
+from __future__ import annotations
+
+import pytest
+
+from tapmap.state.significant_connections import MAX_ENTRIES, SignificantConnections
+
+
+def _events(n: int) -> list[dict[str, int]]:
+    return [{"seq": i} for i in range(n)]
+
+
+@pytest.mark.parametrize(
+    ("count",),
+    [(0,), (1,), (MAX_ENTRIES,), (MAX_ENTRIES + 1,), (MAX_ENTRIES + 250,)],
+)
+def test_construction_trims_to_newest_max_entries(count: int) -> None:
+    """__init__ trims to the newest MAX_ENTRIES items, trusting the input's chronological order."""
+    items = _events(count)
+
+    history = SignificantConnections(items)
+
+    expected = items[-MAX_ENTRIES:]
+    assert history.items == expected
+    assert len(history.items) <= MAX_ENTRIES
+
+
+def test_add_appends_as_newest_and_evicts_oldest_when_over_limit() -> None:
+    """add() appends to the end; once over MAX_ENTRIES, the oldest entries are evicted."""
+    history = SignificantConnections(_events(MAX_ENTRIES))
+
+    history.add({"seq": "new"})
+
+    assert len(history.items) == MAX_ENTRIES
+    assert history.items[-1] == {"seq": "new"}
+    assert history.items[0] == {"seq": 1}
+
+
+def test_add_below_limit_does_not_evict() -> None:
+    """add() below the limit simply appends without dropping anything."""
+    history = SignificantConnections(_events(3))
+
+    history.add({"seq": "new"})
+
+    assert history.items == [{"seq": 0}, {"seq": 1}, {"seq": 2}, {"seq": "new"}]

--- a/tests/test_significant_connections_persistence.py
+++ b/tests/test_significant_connections_persistence.py
@@ -1,0 +1,70 @@
+"""Tests for Significant Connections persistence robustness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tapmap.significant_connections_persistence import (
+    load_significant_connections,
+    save_significant_connections,
+)
+
+
+def test_save_and_reload_preserves_order_and_content(tmp_path: Path) -> None:
+    """Saving and reloading must preserve event order and content exactly."""
+    path = tmp_path / "significant_connections.json"
+    events = [
+        {"timestamp": "2026-08-01T00:00:00", "reasons": ["new_app"], "ip": "1.1.1.1"},
+        {"timestamp": "2026-08-02T00:00:00", "reasons": ["new_country"], "ip": "2.2.2.2"},
+    ]
+
+    save_significant_connections(path, events)
+    loaded = load_significant_connections(path)
+
+    assert loaded == events
+
+
+def test_load_missing_file_returns_empty_list(tmp_path: Path) -> None:
+    """A missing file returns an empty list rather than raising."""
+    path = tmp_path / "does_not_exist.json"
+
+    assert load_significant_connections(path) == []
+
+
+def test_load_corrupt_json_returns_empty_list(tmp_path: Path) -> None:
+    """Corrupt JSON must not crash; loading falls back to an empty list."""
+    path = tmp_path / "significant_connections.json"
+    path.write_text("not valid json", encoding="utf-8")
+
+    assert load_significant_connections(path) == []
+
+
+def test_load_drops_malformed_records_but_keeps_valid_ones(tmp_path: Path) -> None:
+    """Non-dict entries in 'events' are dropped; well-formed entries are kept."""
+    path = tmp_path / "significant_connections.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "events": [
+                    {"timestamp": "t", "reasons": ["new_app"]},
+                    "not-a-dict",
+                    123,
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_significant_connections(path)
+
+    assert loaded == [{"timestamp": "t", "reasons": ["new_app"]}]
+
+
+def test_load_wrong_events_type_returns_empty_list(tmp_path: Path) -> None:
+    """A non-list 'events' value falls back to an empty list."""
+    path = tmp_path / "significant_connections.json"
+    path.write_text(json.dumps({"events": "not-a-list"}), encoding="utf-8")
+
+    assert load_significant_connections(path) == []


### PR DESCRIPTION
## Summary

- move the connection cache from the UI layer to state
- add ConnectionAnalyzer as the central connection processing path
- add significant connection tracking for new applications, countries, providers, ports, and failed verification
- persist significant connections and significance history
- update Insights application tracking to use app_name

## Testing

- ruff check .
- python -m pytest -q
- 586 passed, 2 skipped
- manually tested new applications, countries, providers, ports, deduplication, restart behavior, and failed verification
