### PR TITLE
refactor: centralize connection and unmapped state

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -79,13 +79,13 @@ from tapmap.state.significance import SignificanceHistory
 from tapmap.state.significant_connections import SignificantConnections
 from tapmap.state.status_cache import StatusCache
 from tapmap.state.status_line import render_status_text
-from tapmap.ui.cache_view import CacheViewBuilder
 from tapmap.ui.daily_activity_report_view import render_daily_activity_report
 from tapmap.ui.insights_log_view import render_insights_log
 from tapmap.ui.insights_view import render_insights_panel
 from tapmap.ui.layout_view import render_layout
 from tapmap.ui.map_view import MapUI
 from tapmap.ui.modal_view import ModalTextBuilder
+from tapmap.ui.service_point_view import ServicePointViewBuilder
 
 from .app_dirs import open_folder, reveal_in_file_manager
 from .config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
@@ -151,7 +151,7 @@ class TapMap:
         )
 
         self.ui = MapUI(zoom_near_km=ZOOM_NEAR_KM)
-        self.view_builder = CacheViewBuilder(
+        self.view_builder = ServicePointViewBuilder(
             coord_precision=COORD_PRECISION,
             is_docker=self.runtime.is_docker,
         )

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -79,6 +79,7 @@ from tapmap.state.significance import SignificanceHistory
 from tapmap.state.significant_connections import SignificantConnections
 from tapmap.state.status_cache import StatusCache
 from tapmap.state.status_line import render_status_text
+from tapmap.state.unmapped_state import UnmappedState
 from tapmap.ui.daily_activity_report_view import render_daily_activity_report
 from tapmap.ui.insights_log_view import render_insights_log
 from tapmap.ui.insights_view import render_insights_panel
@@ -138,6 +139,7 @@ class TapMap:
     MIN_FLASH_S = 3.0
 
     def __init__(self, runtime_ctx: RuntimeContext) -> None:
+        """Build runtime state, wire Dash callbacks, and start from persisted history."""
         self.runtime = runtime_ctx
         self.logger = logging.getLogger(__name__)
         self._lock_path = self.runtime.app_data_dir / "tapmap.lock"
@@ -156,6 +158,9 @@ class TapMap:
             is_docker=self.runtime.is_docker,
         )
         self.connection_state = ConnectionState(
+            cache_retention_min=self.runtime.cache_retention_min
+        )
+        self.unmapped_state = UnmappedState(
             cache_retention_min=self.runtime.cache_retention_min
         )
         self._status_cache = StatusCache()
@@ -207,6 +212,7 @@ class TapMap:
         self.significance_history = SignificanceHistory.from_insights_state(self.insights_state)
         self.connection_analyzer = ConnectionAnalyzer(
             self.connection_state,
+            self.unmapped_state,
             self.insights_state.insights,
             self.significant_connections,
             self.significance_history,
@@ -477,9 +483,10 @@ class TapMap:
     def _handle_clear_cache(
         self, status_cache: StatusCache, technical_details_enabled: bool
     ) -> tuple[Any, Any, Any, Any, Any]:
-        """Reset the runtime cache without observing the monitored system."""
+        """Reset connection and unmapped state without observing the monitored system."""
         status_cache.clear()
         cache = self.connection_state.clear()
+        self.unmapped_state.clear()
         view = self.view_builder.build_view_from_cache(cache, technical_details_enabled)
         flash = self._flash("Clearing cache...", self.MIN_FLASH_S)
         return no_update, status_cache.to_store(), view, flash, no_update
@@ -523,10 +530,13 @@ class TapMap:
     def _refresh_pending_app_verifications(self) -> None:
         """Backfill AppInfo verification results that completed since the last poll.
 
-        Covers connection-state entries whose connection has left the
-        current snapshot but are still retained. Never triggers new AppInfo work.
+        Covers connection-state and unmapped-state entries whose connection
+        has left the current snapshot but are still retained. Never triggers
+        new AppInfo work.
         """
-        pending = self.connection_state.pending_exe_paths()
+        pending = (
+            self.connection_state.pending_exe_paths() | self.unmapped_state.pending_exe_paths()
+        )
         if not pending:
             return
 
@@ -548,6 +558,7 @@ class TapMap:
             for exe, metadata in resolved.items()
         }
         self.connection_state.refresh_resolved_applications(fields)
+        self.unmapped_state.refresh_resolved_applications(fields)
 
     def _open_browser(self, url: str, delay_s: float = 0.8) -> None:
         try:
@@ -615,8 +626,9 @@ class TapMap:
         ui_view: Any,
         geo_path: str,
         geodb_event: dict[str, Any] | None,
+        technical_details_enabled: bool,
     ) -> tuple[list[Any], str]:
-        
+        """Return modal body children and CSS class for the current modal screen."""
         if not isinstance(modal_state, dict):
             return [], "modal-body"
 
@@ -687,6 +699,8 @@ class TapMap:
                 snapshot=snapshot,
                 show_system=show_system,
                 is_docker=self.runtime.is_docker,
+                unmapped_cache=self.unmapped_state.cache,
+                technical_details_enabled=technical_details_enabled,
             )
             return self._as_children(body), self._class_for_modal_screen(screen)
 
@@ -1060,6 +1074,7 @@ class TapMap:
             Input("geodb_event", "data"),
             State("ui_view", "data"),
             State("model_snapshot", "data"),
+            State("technical_details_on", "data"),
             prevent_initial_call=False,
         )
         def modal_renderer(
@@ -1067,6 +1082,7 @@ class TapMap:
             geodb_event_data: Any,
             ui_view: Any,
             snapshot: Any,
+            technical_details_data: Any,
         ):
             geo_path = str(self.runtime.geo_data_dir)
 
@@ -1076,6 +1092,7 @@ class TapMap:
                 ui_view,
                 geo_path,
                 geodb_event_data,
+                bool(technical_details_data),
             )
 
             overlay_class = self._modal_overlay_class(

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -1,4 +1,8 @@
-"""Analyze connections and update ConnectionState, Insights, and Significant Connections."""
+"""Analyze connections and route them to state: mapped, unmapped, insights, significant.
+
+Mapped PUBLIC connections update ConnectionState; PUBLIC connections without
+usable GeoIP update UnmappedState.
+"""
 
 from __future__ import annotations
 
@@ -9,30 +13,35 @@ from .connection_state import ConnectionState
 from .insights import process_insights
 from .significance import SignificanceHistory, get_significant
 from .significant_connections import SignificantConnections
+from .unmapped_state import UnmappedState
 
 
 class ConnectionAnalyzer:
-    """Process a snapshot's cache_items: connection state, Significant Connections, and Insights."""
+    """Process a snapshot's cache_items: connection, unmapped, insights, and significant state."""
 
     def __init__(
         self,
         connection_state: ConnectionState,
+        unmapped_state: UnmappedState,
         insights: dict[str, Any],
         significant_connections: SignificantConnections,
         significance_history: SignificanceHistory,
     ) -> None:
+        """Store references to the collaborating state and history objects."""
         self.connection_state = connection_state
+        self.unmapped_state = unmapped_state
         self.insights = insights
         self.significant_connections = significant_connections
         self.significance_history = significance_history
 
     def analyze(self, cache_items: list[dict[str, Any]]) -> dict[str, Any]:
-        """Update ConnectionState, Significant Connections, and Insights from cache_items.
+        """Update ConnectionState, UnmappedState, Significant Connections, and Insights.
 
         Returns the Insights result ({new, top}).
         """
         now = datetime.now()
         mapped: list[dict[str, Any]] = []
+        unmapped: list[dict[str, Any]] = []
 
         for item in cache_items:
             if item.get("service_scope") != "PUBLIC":
@@ -42,11 +51,14 @@ class ConnectionAnalyzer:
             lon = item.get("lon")
             if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
                 mapped.append(item)
+            else:
+                unmapped.append(item)
 
             significant_connection = get_significant(item, self.significance_history, now)
             if significant_connection is not None:
                 self.significant_connections.add(significant_connection)
 
         self.connection_state.merge(mapped)
+        self.unmapped_state.merge(unmapped)
 
         return process_insights(cache_items, self.insights, now)

--- a/src/tapmap/state/service_entries.py
+++ b/src/tapmap/state/service_entries.py
@@ -1,0 +1,171 @@
+"""Shared per-service entry identity and application/process bookkeeping.
+
+Used by both ConnectionState (mapped) and UnmappedState (unmapped). Every
+function here operates purely on the {exe_or_UNKNOWN_APP_KEY: {app_*, exe,
+processes, proc_pids}} "applications" sub-dict convention, with no
+dependency on which kind of service entry it is attached to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+UNKNOWN_APP_KEY = "__unknown_application__"
+
+
+def service_key(ip: str, port: int) -> str:
+    """Return the identity key for a service entry."""
+    return f"{ip}|{port}"
+
+
+def new_application(exe: str | None) -> dict[str, Any]:
+    """Return a new, empty application record for one executable path."""
+    return {
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+        "exe": exe,
+        "processes": [],
+        "proc_pids": {},
+    }
+
+
+def merge_missing_attrs(
+    entry: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    attrs: tuple[str, ...],
+) -> None:
+    """Fill attrs on entry from candidate, but only where entry's value is still None."""
+    for attr in attrs:
+        if entry.get(attr) is None and candidate.get(attr) is not None:
+            entry[attr] = candidate.get(attr)
+
+
+def merge_application(
+    entry: dict[str, Any],
+    *,
+    exe: str | None,
+    candidate: dict[str, Any],
+    process_name: str,
+    pid: int | None,
+) -> None:
+    """Merge one candidate's application metadata into its exe-keyed bucket.
+
+    Candidates with no resolvable exe path share UNKNOWN_APP_KEY, since
+    no reliable identity exists to key them individually.
+    """
+    applications = entry.get("applications")
+    apps: dict[str, Any] = applications if isinstance(applications, dict) else {}
+    entry["applications"] = apps
+
+    app_key = exe or UNKNOWN_APP_KEY
+    app = apps.get(app_key)
+    if not isinstance(app, dict):
+        app = new_application(exe)
+        apps[app_key] = app
+
+    merge_missing_attrs(
+        app,
+        candidate,
+        attrs=(
+            "app_name",
+            "app_creator",
+            "app_verification_status",
+            "app_signature_state",
+            "app_signature_state_details",
+        ),
+    )
+
+    if process_name:
+        merge_process(app, process_name=process_name, pid=pid)
+
+
+def merge_process(record: dict[str, Any], *, process_name: str, pid: int | None) -> None:
+    """Accumulate one process name and its PID into an application record."""
+    processes = record.get("processes")
+    proc_list = processes if isinstance(processes, list) else []
+    proc_set = {p.strip() for p in proc_list if isinstance(p, str) and p.strip()}
+    proc_set.add(process_name)
+    record["processes"] = sorted(proc_set, key=str.lower)
+
+    proc_pids = record.get("proc_pids")
+    proc_pids_map: dict[str, list[int]] = proc_pids if isinstance(proc_pids, dict) else {}
+    record["proc_pids"] = proc_pids_map
+
+    if pid is None:
+        return
+
+    existing = proc_pids_map.get(process_name)
+    existing_list = existing if isinstance(existing, list) else []
+    pid_set = {int(x) for x in existing_list if isinstance(x, int) and x > 0}
+    pid_set.add(pid)
+    proc_pids_map[process_name] = sorted(pid_set)
+
+
+def pending_exe_paths(cache: dict[str, Any]) -> set[str]:
+    """Return exe paths in cache whose deferred AppInfo data is still missing.
+
+    Scans the accumulated cache, not the current snapshot, so retained
+    applications whose connection has vanished are still included.
+    Excludes the synthetic unknown-application bucket and applications
+    already resolved.
+    """
+    pending: set[str] = set()
+    for entry in cache.values():
+        if not isinstance(entry, dict):
+            continue
+        applications = entry.get("applications")
+        if not isinstance(applications, dict):
+            continue
+        for app in applications.values():
+            if not isinstance(app, dict):
+                continue
+            exe = app.get("exe")
+            if not isinstance(exe, str) or not exe:
+                continue
+            if app.get("app_verification_status") is None:
+                pending.add(exe)
+    return pending
+
+
+def refresh_resolved_applications(
+    cache: dict[str, Any], resolved: dict[str, dict[str, Any]]
+) -> None:
+    """Backfill newly-completed AppInfo fields into matching application records.
+
+    resolved maps exe path to a plain dict of app_creator,
+    app_verification_status, app_signature_state, and
+    app_signature_state_details values. Only fills fields still None, so
+    calling this every poll tick is safe even when nothing changed.
+    Mutates cache in place.
+    """
+    if not resolved:
+        return
+    for entry in cache.values():
+        if not isinstance(entry, dict):
+            continue
+        applications = entry.get("applications")
+        if not isinstance(applications, dict):
+            continue
+        for app in applications.values():
+            if not isinstance(app, dict):
+                continue
+            exe = app.get("exe")
+            if not isinstance(exe, str):
+                continue
+            update = resolved.get(exe)
+            if update is None:
+                continue
+            merge_missing_attrs(
+                app,
+                update,
+                attrs=(
+                    "app_creator",
+                    "app_verification_status",
+                    "app_signature_state",
+                    "app_signature_state_details",
+                ),
+            )

--- a/src/tapmap/state/unmapped_state.py
+++ b/src/tapmap/state/unmapped_state.py
@@ -1,8 +1,6 @@
-"""Own the accumulated per-service connection cache for the TapMap state layer.
+"""Own the accumulated per-service cache of unmapped PUBLIC services.
 
-Merge Model.snapshot() map candidates into a per-service cache, prune
-entries past the configured retention window, and backfill deferred
-AppInfo verification results into retained entries.
+Contains no mapped-only GeoIP fields.
 """
 
 from __future__ import annotations
@@ -15,10 +13,11 @@ from . import service_entries
 from .normalization import safe_int, safe_str
 
 
-class ConnectionState:
-    """Own and mutate the accumulated per-service connection cache."""
+class UnmappedState:
+    """Own and mutate the accumulated per-service cache of unmapped PUBLIC services."""
 
     def __init__(self, cache_retention_min: int = 0) -> None:
+        """Initialize with an empty cache and the given retention window."""
         self.cache_retention_min = int(cache_retention_min)
         self.logger = logging.getLogger(__name__)
         self._cache: dict[str, Any] = {}
@@ -33,16 +32,12 @@ class ConnectionState:
         self._cache = {}
         return self._cache
 
-    @staticmethod
-    def _now_text() -> str:
-        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-    def merge(self, map_candidates: list[dict[str, Any]]) -> dict[str, Any]:
-        """Merge map candidates into the cache, prune stale entries, and return the cache."""
+    def merge(self, candidates: list[dict[str, Any]]) -> dict[str, Any]:
+        """Merge unmapped PUBLIC candidates into the cache, prune stale entries, return cache."""
         now = datetime.now().timestamp()
         cache = self._cache
 
-        for candidate in map_candidates:
+        for candidate in candidates:
             if not isinstance(candidate, dict):
                 continue
 
@@ -71,16 +66,7 @@ class ConnectionState:
             service_entries.merge_missing_attrs(
                 entry,
                 candidate,
-                attrs=(
-                    "proto",
-                    "lon",
-                    "lat",
-                    "city",
-                    "country",
-                    "country_code",
-                    "asn",
-                    "asn_org",
-                ),
+                attrs=("proto", "service"),
             )
 
             service_entries.merge_application(
@@ -91,24 +77,11 @@ class ConnectionState:
         return cache
 
     def pending_exe_paths(self) -> set[str]:
-        """Return exe paths in the cache whose deferred AppInfo data is still missing.
-
-        Scans the accumulated cache, not the current snapshot, so retained
-        applications whose connection has vanished are still included.
-        Excludes the synthetic unknown-application bucket and applications
-        already resolved.
-        """
+        """Return exe paths in the cache whose deferred AppInfo data is still missing."""
         return service_entries.pending_exe_paths(self._cache)
 
     def refresh_resolved_applications(self, resolved: dict[str, dict[str, Any]]) -> None:
-        """Backfill newly-completed AppInfo fields into matching application records.
-
-        resolved maps exe path to a plain dict of app_creator,
-        app_verification_status, app_signature_state, and
-        app_signature_state_details values. Only fills fields still None, so
-        calling this every poll tick is safe even when nothing changed.
-        Mutates the cache in place.
-        """
+        """Backfill newly-completed AppInfo fields into matching application records."""
         service_entries.refresh_resolved_applications(self._cache, resolved)
 
     def _prune_cache(
@@ -128,22 +101,15 @@ class ConnectionState:
             if entry["last_seen"] < cutoff:
                 del cache[key]
 
+    @staticmethod
     def _new_entry(
-        self, candidate: dict[str, Any], *, ip: str, port: int, proto: str | None
+        candidate: dict[str, Any], *, ip: str, port: int, proto: str | None
     ) -> dict[str, Any]:
+        """Return a new entry dict for one unmapped service."""
         return {
             "ip": ip,
             "port": port,
             "proto": proto,
-            "lon": candidate.get("lon"),
-            "lat": candidate.get("lat"),
-            "city": candidate.get("city"),
-            "country": candidate.get("country"),
-            "country_code": candidate.get("country_code"),
-            "asn": candidate.get("asn"),
-            "asn_org": candidate.get("asn_org"),
-            "f": self._now_text(),
-            "l": self._now_text(),
-            "m": 0,
+            "service": candidate.get("service"),
             "applications": {},
         }

--- a/src/tapmap/ui/cache_view.py
+++ b/src/tapmap/ui/cache_view.py
@@ -6,7 +6,6 @@ accumulated per-service cache owned by ConnectionState.
 
 from __future__ import annotations
 
-import logging
 from collections import Counter, defaultdict
 from typing import Any
 
@@ -41,7 +40,6 @@ class CacheViewBuilder:
     ) -> None:
         self.coord_precision = int(coord_precision)
         self.is_docker = bool(is_docker)
-        self.logger = logging.getLogger(__name__)
 
     @staticmethod
     def _fmt_ip_port(ip: str, port: int) -> str:
@@ -638,38 +636,3 @@ class CacheViewBuilder:
 
         return ", ".join(parts)
 
-    def _format_procs_with_pids(self, entry: dict[str, Any]) -> str:
-        """Format every process/PID observed at this entry, across all applications."""
-        applications = entry.get("applications")
-        apps = applications if isinstance(applications, dict) else {}
-
-        combined: dict[str, set[int]] = {}
-        for app in apps.values():
-            if not isinstance(app, dict):
-                continue
-            processes = app.get("processes")
-            procs = processes if isinstance(processes, list) else []
-            proc_pids_raw = app.get("proc_pids")
-            proc_pids: dict[str, list[int]] = (
-                proc_pids_raw if isinstance(proc_pids_raw, dict) else {}
-            )
-            for name in procs:
-                if not isinstance(name, str):
-                    continue
-                name_s = name.strip()
-                if not name_s:
-                    continue
-                pid_set = combined.setdefault(name_s, set())
-                pids_raw = proc_pids.get(name_s)
-                if isinstance(pids_raw, list):
-                    pid_set.update(x for x in pids_raw if isinstance(x, int) and x > 0)
-
-        parts: list[str] = []
-        for name in sorted(combined, key=str.lower):
-            pids = sorted(combined[name])
-            if pids:
-                parts.append(f"{name} (pid {', '.join(str(x) for x in pids)})")
-            else:
-                parts.append(name)
-
-        return ", ".join(parts) if parts else "-"

--- a/src/tapmap/ui/formatting.py
+++ b/src/tapmap/ui/formatting.py
@@ -97,6 +97,32 @@ def verification_status_glyph(verification_status: str | None) -> str:
     return f'<span style="color:{verification_status_color(verification_status)}">■</span>'
 
 
+_VERIFICATION_STATUS_PRIORITY = {
+    "failed": 0,
+    "unknown": 1,
+    PENDING_VERIFICATION_STATUS: 2,
+    "verified": 3,
+}
+
+
+def verification_status_priority(verification_status: str | None) -> int:
+    """Return the severity rank for an app_verification_status value: lower is more concerning."""
+    return _VERIFICATION_STATUS_PRIORITY.get(verification_status, 1)
+
+
+def display_verification_status(app: dict[str, Any]) -> str | None:
+    """Return app_verification_status for display, substituting the pending sentinel.
+
+    Only substitutes for a real application (exe is not None) - the
+    synthetic unknown-application bucket has no pending work and must
+    keep showing "unknown".
+    """
+    status = app.get("app_verification_status")
+    if status is None and app.get("exe") is not None:
+        return PENDING_VERIFICATION_STATUS
+    return status
+
+
 def elide_path_middle(path: str, max_length: int = 60) -> str:
     r"""Shorten a filesystem path for display by collapsing middle directory components.
 

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -23,6 +23,7 @@ from .formatting import (
 )
 from .help_view import render_help
 from .tables import ColumnSpec, build_table, cell
+from .unmapped_view import render_unmapped
 
 _EMBEDDED_MARKUP_RE = re.compile(
     r'<span style="color:(?P<color>#[0-9a-fA-F]{6})">(?P<glyph>.*?)</span>'
@@ -60,6 +61,8 @@ class ModalTextBuilder:
         snapshot: Any | None = None,
         show_system: bool = False,
         is_docker: bool,
+        unmapped_cache: dict[str, Any] | None = None,
+        technical_details_enabled: bool = False,
     ) -> list[Any]:
         """Build modal body content for a menu action.
 
@@ -68,12 +71,17 @@ class ModalTextBuilder:
             snapshot: Latest model snapshot (dict) or None.
             show_system: Open ports view toggle state.
             is_docker: Whether the application is running in Docker.
+            unmapped_cache: UnmappedState.cache, used for menu_unmapped.
+            technical_details_enabled: Technical details setting, used for
+                menu_unmapped's presentation mode.
 
         Returns:
             Dash components for the modal body.
         """
         if action == "menu_unmapped":
-            return self._render_unmapped(snapshot)
+            return render_unmapped(
+                unmapped_cache or {}, technical_details_enabled=technical_details_enabled
+            )
 
         if action == "menu_lan_local":
             return self._render_lan_local(snapshot)
@@ -448,43 +456,6 @@ class ModalTextBuilder:
             header_cells=[c.header for c in columns],
             body_rows=cls._build_service_body_rows(aggregated),
         )
-
-    @classmethod
-    def _render_unmapped(cls, snapshot: Any | None) -> list[Any]:
-        """Render unmapped services.
-
-        Render established TCP services with PUBLIC service_scope and missing geolocation.
-        """
-        snap = snapshot if isinstance(snapshot, dict) else {}
-        items = snap.get("cache_items")
-        rows = items if isinstance(items, list) else []
-
-        cleaned: list[dict[str, Any]] = [r for r in rows if isinstance(r, dict)]
-
-        def has_geo(r: dict[str, Any]) -> bool:
-            lat = r.get("lat")
-            lon = r.get("lon")
-            return isinstance(lat, (int, float)) and isinstance(lon, (int, float))
-
-        filtered: list[dict[str, Any]] = []
-        for r in cleaned:
-            scope = safe_str(r.get("service_scope")) or "UNKNOWN"
-            geo_ok = has_geo(r)
-            if scope == "PUBLIC" and not geo_ok:
-                filtered.append(r)
-
-        header = html.H1("Unmapped public services (missing geolocation)", className="mx-h1")
-
-        if not filtered:
-            return [header, html.Pre("(no unmapped public services)")]
-
-        aggregated = cls._aggregate_service_rows(filtered)
-        table = cls._build_service_table(
-            aggregated,
-            class_name="mx-table mx-unmapped",
-        )
-
-        return [header, table]
 
     @classmethod
     def _render_lan_local(cls, snapshot: Any | None) -> list[Any]:

--- a/src/tapmap/ui/service_point_view.py
+++ b/src/tapmap/ui/service_point_view.py
@@ -1,4 +1,4 @@
-"""Cache view preparation helpers for the TapMap UI.
+"""Service point view preparation helpers for the TapMap UI.
 
 Build map points, hover summaries, and click details from the
 accumulated per-service cache owned by ConnectionState.
@@ -28,8 +28,8 @@ _APP_VERIFICATION_STATUS_PRIORITY: dict[str | None, int] = {
 }
 
 
-class CacheViewBuilder:
-    """Build UI cache and map view data."""
+class ServicePointViewBuilder:
+    """Build map view data grouped into ServicePoints."""
 
     _UNKNOWN_APP_KEY = UNKNOWN_APP_KEY
 
@@ -75,19 +75,18 @@ class CacheViewBuilder:
         return f"{shown} +{len(cleaned) - max_items}"
 
     def build_view_from_cache(
-        self, ui_cache: dict[str, Any], technical_details_enabled: bool
+        self, cache: dict[str, Any], technical_details_enabled: bool
     ) -> dict[str, Any]:
         """Group cached entries by rounded coordinates and build map view data.
 
         Args:
-            ui_cache: Per-service cache from ConnectionState.merge/clear.
+            cache: Per-service cache from ConnectionState.merge/clear.
             technical_details_enabled: When True, hover summaries use the
                 connection-oriented format. When False, hover summaries use
                 the application-oriented format. Click details are
                 unaffected either way.
         """
-        cache = ui_cache if isinstance(ui_cache, dict) else {}
-        groups = self._group_by_coord(cache)
+        groups = self._group_by_coord(cache if isinstance(cache, dict) else {})
 
         points: list[tuple[float, float]] = []
         summaries: dict[str, str] = {}
@@ -255,7 +254,7 @@ class CacheViewBuilder:
                 name = app.get("app_name")
                 key = name if isinstance(name, str) and name.strip() else None
                 verification_status_by_key.setdefault(
-                    key, CacheViewBuilder._display_verification_status(app)
+                    key, ServicePointViewBuilder._display_verification_status(app)
                 )
                 if key in seen_keys:
                     continue
@@ -341,7 +340,7 @@ class CacheViewBuilder:
                     by_exe.setdefault(exe_key, app)
 
         def sort_key(app: dict[str, Any]) -> tuple[int, str]:
-            verification_status = CacheViewBuilder._display_verification_status(app)
+            verification_status = ServicePointViewBuilder._display_verification_status(app)
             name = app.get("app_name") or "Unknown application"
             return (_APP_VERIFICATION_STATUS_PRIORITY.get(verification_status, 1), name.lower())
 
@@ -386,7 +385,7 @@ class CacheViewBuilder:
         Uses the platform-specific signature state (humanized) and details
         when available. Falls back to the raw verification status otherwise.
         """
-        display_status = CacheViewBuilder._display_verification_status(app)
+        display_status = ServicePointViewBuilder._display_verification_status(app)
         if display_status == PENDING_VERIFICATION_STATUS:
             return "Retrieving..."
 

--- a/src/tapmap/ui/service_point_view.py
+++ b/src/tapmap/ui/service_point_view.py
@@ -9,23 +9,18 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from typing import Any
 
-from ..state.connection_state import UNKNOWN_APP_KEY
+from ..state.service_entries import UNKNOWN_APP_KEY
 from .formatting import (
     PENDING_VERIFICATION_STATUS,
     country_flag,
+    display_verification_status,
     elide_path_middle,
     humanize_camel_case,
     safe_str,
     verification_status_color,
     verification_status_glyph,
+    verification_status_priority,
 )
-
-_APP_VERIFICATION_STATUS_PRIORITY: dict[str | None, int] = {
-    "failed": 0,
-    "unknown": 1,
-    PENDING_VERIFICATION_STATUS: 2,
-    "verified": 3,
-}
 
 
 class ServicePointViewBuilder:
@@ -214,19 +209,6 @@ class ServicePointViewBuilder:
         return Counter(codes).most_common(1)[0][0] if codes else None
 
     @staticmethod
-    def _display_verification_status(app: dict[str, Any]) -> str | None:
-        """Return app_verification_status for display, substituting the pending sentinel.
-
-        Only substitutes for a real application (exe is not None) - the
-        synthetic unknown-application bucket has no pending work and must
-        keep showing "unknown".
-        """
-        status = app.get("app_verification_status")
-        if status is None and app.get("exe") is not None:
-            return PENDING_VERIFICATION_STATUS
-        return status
-
-    @staticmethod
     def _pick_representative_app(
         entries: list[dict[str, Any]],
     ) -> tuple[str, str | None, list[dict[str, Any]], int]:
@@ -253,9 +235,7 @@ class ServicePointViewBuilder:
                     continue
                 name = app.get("app_name")
                 key = name if isinstance(name, str) and name.strip() else None
-                verification_status_by_key.setdefault(
-                    key, ServicePointViewBuilder._display_verification_status(app)
-                )
+                verification_status_by_key.setdefault(key, display_verification_status(app))
                 if key in seen_keys:
                     continue
                 seen_keys.add(key)
@@ -269,7 +249,7 @@ class ServicePointViewBuilder:
             verification_status = verification_status_by_key.get(key)
             display = key or "Unknown"
             return (
-                _APP_VERIFICATION_STATUS_PRIORITY.get(verification_status, 1),
+                verification_status_priority(verification_status),
                 -len(group_entries),
                 display.lower(),
             )
@@ -322,7 +302,7 @@ class ServicePointViewBuilder:
                 continue
             lines = [f"Network operator: {org}"]
             for app in apps:
-                bullet = verification_status_glyph(self._display_verification_status(app))
+                bullet = verification_status_glyph(display_verification_status(app))
                 lines.append(f"    {bullet} {self._format_app_line(app)}")
             org_blocks.append("\n".join(lines))
 
@@ -340,9 +320,9 @@ class ServicePointViewBuilder:
                     by_exe.setdefault(exe_key, app)
 
         def sort_key(app: dict[str, Any]) -> tuple[int, str]:
-            verification_status = ServicePointViewBuilder._display_verification_status(app)
+            verification_status = display_verification_status(app)
             name = app.get("app_name") or "Unknown application"
-            return (_APP_VERIFICATION_STATUS_PRIORITY.get(verification_status, 1), name.lower())
+            return (verification_status_priority(verification_status), name.lower())
 
         ordered = sorted(by_exe.values(), key=sort_key)
 
@@ -367,7 +347,7 @@ class ServicePointViewBuilder:
 
     def _format_app_line(self, app: dict[str, Any]) -> str:
         name = app.get("app_name") or "Unknown application"
-        display_status = self._display_verification_status(app)
+        display_status = display_verification_status(app)
         if display_status == PENDING_VERIFICATION_STATUS:
             creator = "Retrieving..."
         else:
@@ -385,7 +365,7 @@ class ServicePointViewBuilder:
         Uses the platform-specific signature state (humanized) and details
         when available. Falls back to the raw verification status otherwise.
         """
-        display_status = ServicePointViewBuilder._display_verification_status(app)
+        display_status = display_verification_status(app)
         if display_status == PENDING_VERIFICATION_STATUS:
             return "Retrieving..."
 

--- a/src/tapmap/ui/unmapped_view.py
+++ b/src/tapmap/ui/unmapped_view.py
@@ -1,0 +1,210 @@
+"""Unmapped view rendering for the TapMap UI.
+
+Build the Unmapped modal content from accumulated UnmappedState: PUBLIC
+services observed without usable GeoIP coordinates.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dash import html
+
+from .formatting import (
+    PENDING_VERIFICATION_STATUS,
+    display_verification_status,
+    safe_str,
+    verification_status_priority,
+)
+from .tables import ColumnSpec, build_table, cell
+
+_TECHNICAL_COLUMNS = [
+    ColumnSpec("Scope", "8%"),
+    ColumnSpec("Remote IP", "28%"),
+    ColumnSpec("Port", "8%"),
+    ColumnSpec("Port service", "20%"),
+    ColumnSpec("PID", "12%"),
+    ColumnSpec("Process", "24%"),
+]
+
+_GENERAL_COLUMNS = [
+    ColumnSpec("Application", "34%"),
+    ColumnSpec("Creator", "34%"),
+    ColumnSpec("Verification", "16%"),
+    ColumnSpec("Services", "16%"),
+]
+
+
+def render_unmapped(cache: dict[str, Any], *, technical_details_enabled: bool) -> list[Any]:
+    """Build modal content for the Unmapped view from accumulated UnmappedState.
+
+    Args:
+        cache: UnmappedState.cache - PUBLIC services observed without usable
+            GeoIP coordinates.
+        technical_details_enabled: When True, render the per-service
+            technical table. When False, render the application-oriented
+            summary.
+    """
+    header = html.H1("Unmapped public services (missing geolocation)", className="mx-h1")
+
+    if not cache:
+        return [header, html.Pre("(no unmapped public services)")]
+
+    if technical_details_enabled:
+        table = build_table(
+            class_name="mx-table mx-unmapped",
+            columns=_TECHNICAL_COLUMNS,
+            header_cells=[c.header for c in _TECHNICAL_COLUMNS],
+            body_rows=_build_technical_rows(cache),
+        )
+    else:
+        table = build_table(
+            class_name="mx-table mx-unmapped",
+            columns=_GENERAL_COLUMNS,
+            header_cells=[c.header for c in _GENERAL_COLUMNS],
+            body_rows=_build_general_rows(cache),
+        )
+
+    return [header, table]
+
+
+def _entry_sort_key(item: tuple[str, dict[str, Any]]) -> tuple[str, int]:
+    """Return an (ip, port) sort key from a (service_key, entry) pair."""
+    _, entry = item
+    ip = safe_str(entry.get("ip"))
+    port = entry.get("port")
+    return (ip, port if isinstance(port, int) else -1)
+
+
+def _unique_processes(app: dict[str, Any]) -> list[str]:
+    """Return sorted distinct process names recorded for one application."""
+    processes = app.get("processes")
+    if not isinstance(processes, list):
+        return []
+    return sorted({p.strip() for p in processes if isinstance(p, str) and p.strip()}, key=str.lower)
+
+
+def _unique_pids(app: dict[str, Any]) -> list[int]:
+    """Return sorted distinct PIDs recorded for one application."""
+    proc_pids = app.get("proc_pids")
+    pids: set[int] = set()
+    if isinstance(proc_pids, dict):
+        for pid_list in proc_pids.values():
+            if isinstance(pid_list, list):
+                pids.update(p for p in pid_list if isinstance(p, int) and p > 0)
+    return sorted(pids)
+
+
+def _build_technical_rows(cache: dict[str, Any]) -> list[Any]:
+    """Build one technical row per (service, application) pair.
+
+    A row's PID/Process cells summarize every distinct PID and process name
+    accumulated for that application at that service - no separate "Count"
+    column, since a raw poll-observation count has no honest equivalent once
+    the source is accumulated state rather than a single snapshot.
+    """
+    rows: list[Any] = []
+
+    for _key, entry in sorted(cache.items(), key=_entry_sort_key):
+        if not isinstance(entry, dict):
+            continue
+
+        applications = entry.get("applications")
+        apps = applications if isinstance(applications, dict) else {}
+
+        ip = safe_str(entry.get("ip")) or "-"
+        port = entry.get("port")
+        port_text = str(port) if isinstance(port, int) and port > 0 else "-"
+        service = safe_str(entry.get("service")) or "Unknown"
+
+        for _exe_key, app in sorted(
+            apps.items(), key=lambda kv: (safe_str(kv[1].get("app_name")).lower(), kv[0])
+        ):
+            if not isinstance(app, dict):
+                continue
+
+            processes = _unique_processes(app)
+            pids = _unique_pids(app)
+
+            rows.append(
+                html.Tr(
+                    [
+                        cell("PUBLIC"),
+                        cell(ip),
+                        cell(port_text),
+                        cell(service),
+                        cell(", ".join(str(p) for p in pids)),
+                        cell(", ".join(processes) or "-"),
+                    ]
+                )
+            )
+
+    return rows
+
+
+def _status_text(status: str | None) -> str:
+    """Return the display label for a verification status."""
+    return {
+        "verified": "Verified",
+        "failed": "Failed",
+        "unknown": "Unknown",
+        PENDING_VERIFICATION_STATUS: "Pending",
+    }.get(status, "Unknown")
+
+
+def _build_general_rows(cache: dict[str, Any]) -> list[Any]:
+    """Build one row per distinct application, grouped across all unmapped services."""
+    groups: dict[str | None, dict[str, Any]] = {}
+
+    for service_key, entry in cache.items():
+        if not isinstance(entry, dict):
+            continue
+
+        applications = entry.get("applications")
+        apps = applications if isinstance(applications, dict) else {}
+
+        for app in apps.values():
+            if not isinstance(app, dict):
+                continue
+
+            name = app.get("app_name")
+            group_key = name if isinstance(name, str) and name.strip() else None
+
+            group = groups.setdefault(
+                group_key, {"services": set(), "creator": None, "status": None}
+            )
+            group["services"].add(service_key)
+
+            creator = app.get("app_creator")
+            if not group["creator"] and creator:
+                group["creator"] = creator
+
+            status = display_verification_status(app)
+            current = group["status"]
+            if current is None or verification_status_priority(
+                status
+            ) < verification_status_priority(current):
+                group["status"] = status
+
+    rows: list[Any] = []
+    for name, group in sorted(groups.items(), key=lambda kv: (kv[0] or "Unknown").lower()):
+        status = group["status"]
+        display_name = name or "Unknown"
+        creator = (
+            "Retrieving..."
+            if status == PENDING_VERIFICATION_STATUS
+            else (group["creator"] or "Unknown creator")
+        )
+
+        rows.append(
+            html.Tr(
+                [
+                    cell(display_name),
+                    cell(creator),
+                    cell(_status_text(status)),
+                    cell(str(len(group["services"]))),
+                ]
+            )
+        )
+
+    return rows

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,115 @@
+"""Test TapMap's coordination of ConnectionState and UnmappedState."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tapmap.app import TapMap
+from tapmap.model.appinfo import ApplicationMetadata, VerificationStatus
+from tapmap.state.connection_state import ConnectionState
+from tapmap.state.status_cache import StatusCache
+from tapmap.state.unmapped_state import UnmappedState
+from tapmap.ui.service_point_view import ServicePointViewBuilder
+
+
+def _bare_app() -> TapMap:
+    """Return a TapMap instance with only the attributes needed for method-level tests."""
+    app = object.__new__(TapMap)
+    app.connection_state = ConnectionState()
+    app.unmapped_state = UnmappedState()
+    app.view_builder = ServicePointViewBuilder(coord_precision=3, is_docker=False)
+    app.model = SimpleNamespace(appinfo=MagicMock())
+    app.MIN_FLASH_S = TapMap.MIN_FLASH_S
+    return app
+
+
+def _mapped_candidate(**overrides: object) -> dict[str, object]:
+    """Return a minimal mapped PUBLIC candidate for ConnectionState.merge()."""
+    candidate = {
+        "ip": "8.8.8.8",
+        "port": 443,
+        "proto": "tcp",
+        "process_name": None,
+        "pid": None,
+        "exe": "/opt/app.exe",
+        "lon": 37.4,
+        "lat": -122.1,
+        "city": "Mountain View",
+        "country": "United States",
+        "country_code": "US",
+        "asn": 15169,
+        "asn_org": "Google LLC",
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _unmapped_candidate(**overrides: object) -> dict[str, object]:
+    """Return a minimal unmapped PUBLIC candidate for UnmappedState.merge()."""
+    candidate = {
+        "ip": "203.0.113.7",
+        "port": 8443,
+        "proto": "tcp",
+        "service": "https",
+        "process_name": None,
+        "pid": None,
+        "exe": "/opt/app.exe",
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+# --- Clear cache ---
+
+
+def test_handle_clear_cache_clears_both_connection_and_unmapped_state() -> None:
+    """Clear cache empties both ConnectionState and UnmappedState, not just the mapped one."""
+    app = _bare_app()
+    app.connection_state.merge([_mapped_candidate()])
+    app.unmapped_state.merge([_unmapped_candidate()])
+
+    app._handle_clear_cache(StatusCache(), False)
+
+    assert app.connection_state.cache == {}
+    assert app.unmapped_state.cache == {}
+
+
+# --- Deferred AppInfo verification ---
+
+
+def test_refresh_pending_app_verifications_updates_both_states() -> None:
+    """A resolved exe backfills matching entries in both ConnectionState and UnmappedState."""
+    app = _bare_app()
+    app.connection_state.merge([_mapped_candidate(exe="/opt/app.exe", app_name="Firefox")])
+    app.unmapped_state.merge([_unmapped_candidate(exe="/opt/app.exe", app_name="Firefox")])
+
+    app.model.appinfo.resolved_for.return_value = {
+        "/opt/app.exe": ApplicationMetadata(
+            name="Firefox",
+            creator="Mozilla Corporation",
+            verification_status=VerificationStatus.VERIFIED,
+            signature_state="SignedAndTrusted",
+            signature_state_details=None,
+        )
+    }
+
+    app._refresh_pending_app_verifications()
+
+    mapped_app = app.connection_state.cache["8.8.8.8|443"]["applications"]["/opt/app.exe"]
+    unmapped_app = app.unmapped_state.cache["203.0.113.7|8443"]["applications"]["/opt/app.exe"]
+
+    assert mapped_app["app_verification_status"] == "verified"
+    assert mapped_app["app_creator"] == "Mozilla Corporation"
+    assert unmapped_app["app_verification_status"] == "verified"
+    assert unmapped_app["app_creator"] == "Mozilla Corporation"

--- a/tests/test_cache_view.py
+++ b/tests/test_cache_view.py
@@ -310,37 +310,6 @@ def test_build_app_summary_aligns_app_value_with_other_rows() -> None:
     assert operators_rendered.index("Google LLC") == apps_rendered.index("Spotify")
 
 
-# --- _format_procs_with_pids: multi-application rendering ---
-
-
-def test_format_procs_with_pids_combines_multiple_applications() -> None:
-    """Procs text lists processes from every application, sorted alphabetically."""
-    builder = CacheViewBuilder()
-    entry = {
-        "applications": {
-            "/opt/spotify/Spotify.exe": {
-                "processes": ["Spotify.exe"],
-                "proc_pids": {"Spotify.exe": [17840]},
-            },
-            "/opt/spotify/SpotifyLauncher.exe": {
-                "processes": ["SpotifyLauncher.exe"],
-                "proc_pids": {"SpotifyLauncher.exe": [16696]},
-            },
-        }
-    }
-
-    text = builder._format_procs_with_pids(entry)
-
-    assert text == "Spotify.exe (pid 17840), SpotifyLauncher.exe (pid 16696)"
-
-
-def test_format_procs_with_pids_returns_placeholder_for_no_applications() -> None:
-    """An entry with no applications formats as '-'."""
-    builder = CacheViewBuilder()
-
-    assert builder._format_procs_with_pids({"applications": {}}) == "-"
-
-
 # --- build_view_from_cache: mode selection and multi-application behavior ---
 
 

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -9,6 +9,7 @@ from tapmap.state.connection_state import ConnectionState
 from tapmap.state.insights_state import InsightsState
 from tapmap.state.significance import SignificanceHistory
 from tapmap.state.significant_connections import SignificantConnections
+from tapmap.state.unmapped_state import UnmappedState
 
 
 def _cache_item(**overrides: Any) -> dict[str, Any]:
@@ -40,11 +41,13 @@ def _cache_item(**overrides: Any) -> dict[str, Any]:
 
 def _analyzer(
     connection_state: ConnectionState | None = None,
+    unmapped_state: UnmappedState | None = None,
     insights: dict[str, Any] | None = None,
 ) -> ConnectionAnalyzer:
     """Build a ConnectionAnalyzer with fresh, empty significance collaborators."""
     return ConnectionAnalyzer(
         connection_state if connection_state is not None else ConnectionState(),
+        unmapped_state if unmapped_state is not None else UnmappedState(),
         insights if insights is not None else {},
         SignificantConnections([]),
         SignificanceHistory.from_insights_state(
@@ -137,6 +140,7 @@ def test_analyze_records_significant_event_for_novel_public_connection() -> None
     significant_connections = SignificantConnections([])
     analyzer = ConnectionAnalyzer(
         ConnectionState(),
+        UnmappedState(),
         {},
         significant_connections,
         SignificanceHistory.from_insights_state(
@@ -161,6 +165,7 @@ def test_analyze_does_not_evaluate_significance_for_non_public_connections() -> 
     significant_connections = SignificantConnections([])
     analyzer = ConnectionAnalyzer(
         ConnectionState(),
+        UnmappedState(),
         {},
         significant_connections,
         SignificanceHistory.from_insights_state(
@@ -189,9 +194,38 @@ def test_analyze_does_not_repeat_significant_event_for_same_snapshot_repeat() ->
             verification_failed={},
         )
     )
-    analyzer = ConnectionAnalyzer(ConnectionState(), {}, significant_connections, history)
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(), UnmappedState(), {}, significant_connections, history
+    )
 
     analyzer.analyze([_cache_item(country_code="US")])
     analyzer.analyze([_cache_item(country_code="US")])
 
     assert len(significant_connections.items) == 1
+
+
+# --- mapped/unmapped routing ---
+
+
+def test_analyze_routes_public_without_geo_to_unmapped_state() -> None:
+    """A PUBLIC connection missing lat/lon is merged into UnmappedState, not ConnectionState."""
+    connection_state = ConnectionState()
+    unmapped_state = UnmappedState()
+    analyzer = _analyzer(connection_state, unmapped_state)
+
+    analyzer.analyze([_cache_item(lat=None, lon=None)])
+
+    assert connection_state.cache == {}
+    assert "8.8.8.8|443" in unmapped_state.cache
+
+
+def test_analyze_routes_public_with_geo_to_connection_state_only() -> None:
+    """A PUBLIC connection with valid lat/lon is merged into ConnectionState, not UnmappedState."""
+    connection_state = ConnectionState()
+    unmapped_state = UnmappedState()
+    analyzer = _analyzer(connection_state, unmapped_state)
+
+    analyzer.analyze([_cache_item()])
+
+    assert "8.8.8.8|443" in connection_state.cache
+    assert unmapped_state.cache == {}

--- a/tests/test_connection_state.py
+++ b/tests/test_connection_state.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from tapmap.state.connection_state import UNKNOWN_APP_KEY, ConnectionState
+from tapmap.state.connection_state import ConnectionState
+from tapmap.state.service_entries import UNKNOWN_APP_KEY
 
 _APP_FIELDS = (
     "app_name",

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from tapmap.ui.formatting import (
     PENDING_VERIFICATION_STATUS,
+    display_verification_status,
     elide_path_middle,
     humanize_camel_case,
     verification_status_color,
@@ -27,6 +28,27 @@ def test_verification_status_glyph_pending_is_white_bullet() -> None:
     assert verification_status_glyph(PENDING_VERIFICATION_STATUS) == (
         '<span style="color:#ffffff">■</span>'
     )
+
+
+def test_display_verification_status_pending_for_real_exe() -> None:
+    """A real application with no verification_status yet displays as pending."""
+    app = {"app_name": "Firefox", "app_verification_status": None, "exe": "/firefox.exe"}
+
+    assert display_verification_status(app) == "pending"
+
+
+def test_display_verification_status_unknown_bucket_stays_none() -> None:
+    """The synthetic unknown-application bucket (no exe) is never treated as pending."""
+    app = {"app_name": None, "app_verification_status": None, "exe": None}
+
+    assert display_verification_status(app) is None
+
+
+def test_display_verification_status_passes_through_resolved_values() -> None:
+    """A resolved verification_status is returned unchanged, regardless of exe."""
+    app = {"app_verification_status": "failed", "exe": "/malware.exe"}
+
+    assert display_verification_status(app) == "failed"
 
 
 def test_humanize_camel_case_splits_multiple_words() -> None:

--- a/tests/test_modal_view.py
+++ b/tests/test_modal_view.py
@@ -112,3 +112,27 @@ def test_for_click_renders_exe_tag_as_plain_text_in_docker() -> None:
     assert not any(isinstance(c, html.Span) for c in children)
     assert "C:\\...\\Feed.exe" in children
     assert not any(isinstance(c, str) and "<exe" in c for c in children)
+
+
+def test_for_action_menu_unmapped_routes_to_unmapped_view() -> None:
+    """menu_unmapped renders from unmapped_cache via unmapped_view, not the latest snapshot."""
+    unmapped_cache = {
+        "203.0.113.7|8443": {
+            "ip": "203.0.113.7",
+            "port": 8443,
+            "proto": "tcp",
+            "service": "https",
+            "applications": {},
+        }
+    }
+
+    result = _builder().for_action(
+        "menu_unmapped",
+        snapshot={"cache_items": []},
+        is_docker=False,
+        unmapped_cache=unmapped_cache,
+        technical_details_enabled=True,
+    )
+
+    table = next(c for c in result if isinstance(c, html.Table))
+    assert table is not None

--- a/tests/test_modal_view.py
+++ b/tests/test_modal_view.py
@@ -21,7 +21,7 @@ def test_for_click_does_not_prepend_its_own_coordinate_line() -> None:
     """for_click renders detail as-is; it no longer prepends its own lon/lat line.
 
     The Technical Details view's own 'Coordinates:' line is now built by
-    cache_view.py as part of detail itself, not injected here.
+    service_point_view.py as part of detail itself, not injected here.
     """
     view = {"details": {"0": "Location: US\nSomething"}}
 

--- a/tests/test_service_point_view.py
+++ b/tests/test_service_point_view.py
@@ -929,27 +929,6 @@ def test_build_view_from_cache_technical_details_on_details_unchanged() -> None:
 # --- pending verification: representation, propagation, and display ---
 
 
-def test_display_verification_status_pending_for_real_exe() -> None:
-    """A real application with no verification_status yet displays as pending."""
-    app = {"app_name": "Firefox", "app_verification_status": None, "exe": "/firefox.exe"}
-
-    assert ServicePointViewBuilder._display_verification_status(app) == "pending"
-
-
-def test_display_verification_status_unknown_bucket_stays_none() -> None:
-    """The synthetic unknown-application bucket (no exe) is never treated as pending."""
-    app = {"app_name": None, "app_verification_status": None, "exe": None}
-
-    assert ServicePointViewBuilder._display_verification_status(app) is None
-
-
-def test_display_verification_status_passes_through_resolved_values() -> None:
-    """A resolved verification_status is returned unchanged, regardless of exe."""
-    app = {"app_verification_status": "failed", "exe": "/malware.exe"}
-
-    assert ServicePointViewBuilder._display_verification_status(app) == "failed"
-
-
 def test_verification_status_text_pending_shows_retrieving() -> None:
     """A pending real application shows 'Retrieving...' rather than 'Unknown'."""
     app = {"app_verification_status": None, "exe": "/opt/app.exe"}

--- a/tests/test_service_point_view.py
+++ b/tests/test_service_point_view.py
@@ -1,4 +1,4 @@
-"""Test CacheViewBuilder's hover summary and click detail generation."""
+"""Test ServicePointViewBuilder's hover summary and click detail generation."""
 
 from __future__ import annotations
 
@@ -6,8 +6,8 @@ import re
 from typing import Any
 
 from tapmap.state.connection_state import ConnectionState
-from tapmap.ui.cache_view import CacheViewBuilder
 from tapmap.ui.formatting import country_flag, verification_status_glyph
+from tapmap.ui.service_point_view import ServicePointViewBuilder
 
 _DEFAULT_EXE = "/opt/app/app.exe"
 
@@ -44,7 +44,7 @@ def _entry(
     app_verification_status: str | None = None,
     **overrides: Any,
 ) -> dict[str, Any]:
-    """Return a minimal ui_cache entry with a single application.
+    """Return a minimal cache entry with a single application.
 
     As consumed by summary-building methods. exe is set whenever app_name
     is (absent otherwise, matching the unknown-application bucket).
@@ -74,7 +74,7 @@ def _app_entry(
     exe: str = "/opt/app.exe",
     **app_overrides: Any,
 ) -> dict[str, Any]:
-    """Return a ui_cache entry with one fully-specified application record."""
+    """Return a cache entry with one fully-specified application record."""
     app: dict[str, Any] = {
         "app_name": None,
         "app_creator": None,
@@ -103,8 +103,8 @@ def test_pick_representative_app_prefers_failed_tier() -> None:
         _entry(app_name="Bad App", app_verification_status="failed"),
     ]
 
-    name, verification_status, app_entries, count = CacheViewBuilder._pick_representative_app(
-        entries
+    name, verification_status, app_entries, count = (
+        ServicePointViewBuilder._pick_representative_app(entries)
     )
 
     assert name == "Bad App"
@@ -120,7 +120,7 @@ def test_pick_representative_app_prefers_unknown_over_verified() -> None:
         _entry(app_name="Mystery App", app_verification_status="unknown"),
     ]
 
-    name, verification_status, _, _ = CacheViewBuilder._pick_representative_app(entries)
+    name, verification_status, _, _ = ServicePointViewBuilder._pick_representative_app(entries)
 
     assert name == "Mystery App"
     assert verification_status == "unknown"
@@ -134,7 +134,7 @@ def test_pick_representative_app_breaks_tie_by_connection_count() -> None:
         _entry(app_name="Big App", app_verification_status="verified"),
     ]
 
-    name, _, app_entries, _ = CacheViewBuilder._pick_representative_app(entries)
+    name, _, app_entries, _ = ServicePointViewBuilder._pick_representative_app(entries)
 
     assert name == "Big App"
     assert len(app_entries) == 2
@@ -147,7 +147,7 @@ def test_pick_representative_app_breaks_remaining_tie_alphabetically() -> None:
         _entry(app_name="Alpha App", app_verification_status="verified"),
     ]
 
-    name, _, _, _ = CacheViewBuilder._pick_representative_app(entries)
+    name, _, _, _ = ServicePointViewBuilder._pick_representative_app(entries)
 
     assert name == "Alpha App"
 
@@ -159,8 +159,8 @@ def test_pick_representative_app_groups_missing_names_as_unknown() -> None:
         _entry(app_name=None, app_verification_status=None),
     ]
 
-    name, verification_status, app_entries, count = CacheViewBuilder._pick_representative_app(
-        entries
+    name, verification_status, app_entries, count = (
+        ServicePointViewBuilder._pick_representative_app(entries)
     )
 
     assert name == "Unknown"
@@ -173,8 +173,8 @@ def test_pick_representative_app_returns_unknown_for_no_applications() -> None:
     """Entries with no applications at all produce the empty/Unknown result."""
     entries = [{"ip": "8.8.8.8", "port": 443, "applications": {}}]
 
-    name, verification_status, app_entries, count = CacheViewBuilder._pick_representative_app(
-        entries
+    name, verification_status, app_entries, count = (
+        ServicePointViewBuilder._pick_representative_app(entries)
     )
 
     assert name == "Unknown"
@@ -188,9 +188,11 @@ def test_pick_representative_app_returns_unknown_for_no_applications() -> None:
 
 def test_format_summary_row_aligns_value_regardless_of_icon_width() -> None:
     """Value text starts at the same column whether or not a row has an icon."""
-    row_with_wide_icon = CacheViewBuilder._format_summary_row("Location:", "XX", "value")
-    row_without_icon = CacheViewBuilder._format_summary_row("Network operator:", "  ", "value")
-    row_with_narrow_icon = CacheViewBuilder._format_summary_row("App:", "X ", "value")
+    row_with_wide_icon = ServicePointViewBuilder._format_summary_row("Location:", "XX", "value")
+    row_without_icon = ServicePointViewBuilder._format_summary_row(
+        "Network operator:", "  ", "value"
+    )
+    row_with_narrow_icon = ServicePointViewBuilder._format_summary_row("App:", "X ", "value")
 
     assert row_with_wide_icon.index("value") == row_without_icon.index("value")
     assert row_without_icon.index("value") == row_with_narrow_icon.index("value")
@@ -203,7 +205,7 @@ def test_build_app_summary_shows_location_with_flag() -> None:
     """Location row shows city, country and the matching flag."""
     entries = [_entry(app_name="Firefox", app_verification_status="verified")]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Kansas City, United States", country_code="US", entries=entries
     )
 
@@ -220,7 +222,7 @@ def test_build_app_summary_scopes_network_operator_to_selected_app() -> None:
         _entry(app_name="Bad App", app_verification_status="failed", asn_org="Org B2"),
     ]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -238,7 +240,7 @@ def test_build_app_summary_appends_count_for_additional_apps() -> None:
         _entry(app_name="App Three", app_verification_status="verified"),
     ]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -251,7 +253,7 @@ def test_build_app_summary_omits_count_for_single_app() -> None:
     """No +N suffix appears when only one unique app is present."""
     entries = [_entry(app_name="Only App", app_verification_status="verified")]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -264,7 +266,7 @@ def test_build_app_summary_uses_singular_labels() -> None:
     """Location, network operator and app labels are all singular."""
     entries = [_entry(app_name="Solo App", app_verification_status="verified")]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -278,7 +280,7 @@ def test_build_app_summary_uses_colored_bullet_verification_indicator() -> None:
     """The app row's verification indicator is a single colored bullet character."""
     entries = [_entry(app_name="Solo App", app_verification_status="verified")]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -297,7 +299,7 @@ def test_build_app_summary_aligns_app_value_with_other_rows() -> None:
         _entry(app_name="Spotify", app_verification_status="verified", asn_org="Google LLC")
     ]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="United States", country_code="US", entries=entries
     )
 
@@ -315,7 +317,7 @@ def test_build_app_summary_aligns_app_value_with_other_rows() -> None:
 
 def test_build_view_from_cache_technical_details_off_uses_app_summary() -> None:
     """technical_details_enabled=False produces the application-oriented summary."""
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [_candidate(app_name="Firefox", app_verification_status="verified")]
@@ -331,7 +333,7 @@ def test_build_view_from_cache_technical_details_on_matches_existing_format() ->
     The click-details panel now shows the app name via its own App: field
     (see _format_process_blocks), but never creator or verification-status wording.
     """
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [
@@ -358,7 +360,7 @@ def test_build_view_from_cache_technical_details_on_matches_existing_format() ->
 
 def test_build_view_from_cache_shows_failed_app_sharing_endpoint_with_verified_app() -> None:
     """A failed application is never hidden by a verified application at the same endpoint."""
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [
@@ -379,7 +381,7 @@ def test_build_view_from_cache_shows_failed_app_sharing_endpoint_with_verified_a
 
 def test_build_click_details_shows_processes_from_multiple_applications() -> None:
     """Technical Details lists processes from every application at an endpoint."""
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [
@@ -422,7 +424,7 @@ def test_format_process_blocks_elides_long_executable_path() -> None:
         },
     }
 
-    _, _, exe_line = CacheViewBuilder()._format_process_blocks(entry)
+    _, _, exe_line = ServicePointViewBuilder()._format_process_blocks(entry)
     visible_text = re.sub(r"<[^>]+>", "", exe_line)
 
     assert long_exe not in visible_text
@@ -447,7 +449,7 @@ def test_format_org_block_shows_process_app_and_executable_fields() -> None:
         },
     }
 
-    block = CacheViewBuilder()._format_org_block("Org A", [entry])
+    block = ServicePointViewBuilder()._format_org_block("Org A", [entry])
 
     assert "Process:" in block
     assert "firefox.exe (pid 1000)" in block
@@ -459,14 +461,14 @@ def test_format_org_block_shows_process_app_and_executable_fields() -> None:
 
 def test_display_exe_wraps_resolved_path_with_full_path_attribute() -> None:
     """A resolved executable is wrapped in an <exe full="..."> tag carrying the raw path."""
-    result = CacheViewBuilder()._display_exe(r"C:\opt\app.exe")
+    result = ServicePointViewBuilder()._display_exe(r"C:\opt\app.exe")
 
     assert result == r'<exe full="C:\opt\app.exe">C:\opt\app.exe</exe>'
 
 
 def test_display_exe_does_not_wrap_unknown_executable() -> None:
     """An unresolved executable shows plain 'Unknown', not wrapped in a tag."""
-    result = CacheViewBuilder()._display_exe(CacheViewBuilder._UNKNOWN_APP_KEY)
+    result = ServicePointViewBuilder()._display_exe(ServicePointViewBuilder._UNKNOWN_APP_KEY)
 
     assert result == "Unknown"
 
@@ -478,7 +480,7 @@ def test_format_org_block_shows_unknown_for_unresolved_executable() -> None:
         "port": 443,
         "proto": "tcp",
         "applications": {
-            CacheViewBuilder._UNKNOWN_APP_KEY: {
+            ServicePointViewBuilder._UNKNOWN_APP_KEY: {
                 "app_name": None,
                 "processes": ["svchost.exe"],
                 "proc_pids": {},
@@ -486,11 +488,11 @@ def test_format_org_block_shows_unknown_for_unresolved_executable() -> None:
         },
     }
 
-    block = CacheViewBuilder()._format_org_block("Org A", [entry])
+    block = ServicePointViewBuilder()._format_org_block("Org A", [entry])
 
     assert "Executable:" in block
     assert "Unknown" in block
-    assert CacheViewBuilder._UNKNOWN_APP_KEY not in block
+    assert ServicePointViewBuilder._UNKNOWN_APP_KEY not in block
 
 
 def test_format_org_block_separates_multiple_process_blocks_with_one_blank_line() -> None:
@@ -505,7 +507,7 @@ def test_format_org_block_separates_multiple_process_blocks_with_one_blank_line(
         },
     }
 
-    block = CacheViewBuilder()._format_org_block("Org A", [entry])
+    block = ServicePointViewBuilder()._format_org_block("Org A", [entry])
 
     assert block.split("\n").count("") == 1
 
@@ -531,7 +533,7 @@ def test_format_org_block_has_no_blank_line_between_connections() -> None:
         },
     ]
 
-    block = CacheViewBuilder()._format_org_block("Org A", entries)
+    block = ServicePointViewBuilder()._format_org_block("Org A", entries)
 
     assert "" not in block.split("\n")
 
@@ -552,7 +554,7 @@ def test_format_process_blocks_aligns_values_in_same_column() -> None:
         },
     }
 
-    process_line, app_line, exe_line = CacheViewBuilder()._format_process_blocks(entry)
+    process_line, app_line, exe_line = ServicePointViewBuilder()._format_process_blocks(entry)
     exe_visible = re.sub(r"<[^>]+>", "", exe_line)
 
     assert process_line.index("firefox.exe") == app_line.index("Firefox")
@@ -569,7 +571,7 @@ def test_build_app_click_details_shows_location_once() -> None:
         _app_entry(exe="/b.exe", app_name="App B", asn_org="Org B"),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Oslo, Norway", country_code="NO", entries=entries
     )
 
@@ -585,7 +587,7 @@ def test_build_app_click_details_groups_by_network_operator() -> None:
         _app_entry(exe="/b.exe", app_name="App B", asn_org="Org B"),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -604,7 +606,7 @@ def test_build_app_click_details_deduplicates_same_exe_within_operator() -> None
         _app_entry(port=8080, exe="/a.exe", app_name="App A", asn_org="Org A"),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -638,7 +640,7 @@ def test_build_app_click_details_deduplicates_same_named_app_across_different_ex
         ),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -666,7 +668,7 @@ def test_build_app_click_details_keeps_differently_verified_same_named_apps_sepa
         ),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -690,7 +692,7 @@ def test_build_app_click_details_lists_different_exe_paths_separately() -> None:
         ),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -712,7 +714,7 @@ def test_build_app_click_details_sorts_failed_first() -> None:
         ),
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -731,7 +733,7 @@ def test_build_app_click_details_uses_humanized_state_with_details() -> None:
         )
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
     visible = re.sub(r"<[^>]+>", "", details)
@@ -750,7 +752,7 @@ def test_build_app_click_details_uses_humanized_state_without_details() -> None:
         )
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
     visible = re.sub(r"<[^>]+>", "", details)
@@ -770,7 +772,7 @@ def test_build_app_click_details_renders_macos_developer_signed_with_notarized_d
         )
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
     visible = re.sub(r"<[^>]+>", "", details)
@@ -789,7 +791,7 @@ def test_build_app_click_details_ignores_literal_none_details_string() -> None:
         )
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
     visible = re.sub(r"<[^>]+>", "", details)
@@ -801,7 +803,7 @@ def test_build_app_click_details_falls_back_to_verification_status_without_state
     """With no signature state, the raw verification status is shown."""
     entries = [_app_entry(app_name="Some App", app_verification_status="unknown")]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
     visible = re.sub(r"<[^>]+>", "", details)
@@ -819,7 +821,7 @@ def test_format_app_line_colorizes_only_the_verification_status_text() -> None:
         "app_signature_state_details": None,
     }
 
-    line = CacheViewBuilder()._format_app_line(app)
+    line = ServicePointViewBuilder()._format_app_line(app)
 
     assert line == (
         'Firefox (Mozilla Corporation, '
@@ -837,7 +839,7 @@ def test_format_app_line_uses_failed_color_for_unsigned() -> None:
         "app_signature_state_details": None,
     }
 
-    line = CacheViewBuilder()._format_app_line(app)
+    line = ServicePointViewBuilder()._format_app_line(app)
 
     assert '<span style="color:#ff4444">Unsigned</span>' in line
 
@@ -846,7 +848,7 @@ def test_build_app_click_details_includes_verification_status_note() -> None:
     """The verification-status disclaimer is always present."""
     entries = [_app_entry(app_name="App A")]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -872,7 +874,7 @@ def test_build_app_click_details_never_shows_process_pid_ip_or_port() -> None:
         }
     ]
 
-    details = CacheViewBuilder()._build_app_click_details(
+    details = ServicePointViewBuilder()._build_app_click_details(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -884,7 +886,7 @@ def test_build_app_click_details_never_shows_process_pid_ip_or_port() -> None:
 
 def test_build_view_from_cache_technical_details_off_uses_app_click_details() -> None:
     """technical_details_enabled=False routes click details through the new builder."""
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [
@@ -910,7 +912,7 @@ def test_build_view_from_cache_technical_details_on_details_unchanged() -> None:
     The org header stays the bare organization name (no 'Network operator:'
     label), matching the Non-Technical view's own, differently-labeled section.
     """
-    builder = CacheViewBuilder()
+    builder = ServicePointViewBuilder()
 
     cache = ConnectionState().merge(
         [_candidate(app_name="Firefox", app_verification_status="verified")]
@@ -931,35 +933,35 @@ def test_display_verification_status_pending_for_real_exe() -> None:
     """A real application with no verification_status yet displays as pending."""
     app = {"app_name": "Firefox", "app_verification_status": None, "exe": "/firefox.exe"}
 
-    assert CacheViewBuilder._display_verification_status(app) == "pending"
+    assert ServicePointViewBuilder._display_verification_status(app) == "pending"
 
 
 def test_display_verification_status_unknown_bucket_stays_none() -> None:
     """The synthetic unknown-application bucket (no exe) is never treated as pending."""
     app = {"app_name": None, "app_verification_status": None, "exe": None}
 
-    assert CacheViewBuilder._display_verification_status(app) is None
+    assert ServicePointViewBuilder._display_verification_status(app) is None
 
 
 def test_display_verification_status_passes_through_resolved_values() -> None:
     """A resolved verification_status is returned unchanged, regardless of exe."""
     app = {"app_verification_status": "failed", "exe": "/malware.exe"}
 
-    assert CacheViewBuilder._display_verification_status(app) == "failed"
+    assert ServicePointViewBuilder._display_verification_status(app) == "failed"
 
 
 def test_verification_status_text_pending_shows_retrieving() -> None:
     """A pending real application shows 'Retrieving...' rather than 'Unknown'."""
     app = {"app_verification_status": None, "exe": "/opt/app.exe"}
 
-    assert CacheViewBuilder._verification_status_text(app) == "Retrieving..."
+    assert ServicePointViewBuilder._verification_status_text(app) == "Retrieving..."
 
 
 def test_verification_status_text_unknown_bucket_still_shows_unknown() -> None:
     """The synthetic unknown-application bucket is unaffected by pending handling."""
     app = {"app_verification_status": None, "exe": None}
 
-    assert CacheViewBuilder._verification_status_text(app) == "Unknown"
+    assert ServicePointViewBuilder._verification_status_text(app) == "Unknown"
 
 
 def test_format_app_line_pending_shows_white_bullet_and_retrieving_text() -> None:
@@ -973,7 +975,7 @@ def test_format_app_line_pending_shows_white_bullet_and_retrieving_text() -> Non
         "exe": "/opt/app.exe",
     }
 
-    line = CacheViewBuilder()._format_app_line(app)
+    line = ServicePointViewBuilder()._format_app_line(app)
 
     assert '<span style="color:#ffffff">Retrieving...</span>' in line
 
@@ -989,7 +991,7 @@ def test_format_app_line_pending_creator_shows_retrieving() -> None:
         "exe": "/opt/app.exe",
     }
 
-    line = CacheViewBuilder()._format_app_line(app)
+    line = ServicePointViewBuilder()._format_app_line(app)
 
     assert line.startswith("Firefox (Retrieving..., ")
 
@@ -1005,7 +1007,7 @@ def test_format_app_line_resolved_with_no_creator_shows_unknown_creator() -> Non
         "exe": "/opt/app.exe",
     }
 
-    line = CacheViewBuilder()._format_app_line(app)
+    line = ServicePointViewBuilder()._format_app_line(app)
 
     assert line.startswith("Some App (Unknown creator, ")
 
@@ -1014,7 +1016,7 @@ def test_build_app_summary_pending_app_shows_white_bullet() -> None:
     """A pending representative app renders a white bullet in the hover summary."""
     entries = [_entry(app_name="New App", app_verification_status=None)]
 
-    summary = CacheViewBuilder()._build_app_summary(
+    summary = ServicePointViewBuilder()._build_app_summary(
         place="Somewhere", country_code=None, entries=entries
     )
 
@@ -1030,7 +1032,7 @@ def test_app_verification_status_priority_orders_pending_between_unknown_and_ver
         _entry(app_name="Mystery App", app_verification_status="unknown"),
     ]
 
-    name, verification_status, _, _ = CacheViewBuilder._pick_representative_app(entries)
+    name, verification_status, _, _ = ServicePointViewBuilder._pick_representative_app(entries)
 
     assert name == "Mystery App"
     assert verification_status == "unknown"
@@ -1043,7 +1045,7 @@ def test_app_verification_status_priority_prefers_pending_over_verified() -> Non
         _entry(app_name="Pending App", app_verification_status=None),
     ]
 
-    name, verification_status, _, _ = CacheViewBuilder._pick_representative_app(entries)
+    name, verification_status, _, _ = ServicePointViewBuilder._pick_representative_app(entries)
 
     assert name == "Pending App"
     assert verification_status == "pending"

--- a/tests/test_unmapped_state.py
+++ b/tests/test_unmapped_state.py
@@ -1,0 +1,216 @@
+"""Test UnmappedState's per-service cache merge, retention, and AppInfo backfill."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tapmap.state.service_entries import UNKNOWN_APP_KEY
+from tapmap.state.unmapped_state import UnmappedState
+
+_APP_FIELDS = (
+    "app_name",
+    "app_creator",
+    "app_verification_status",
+    "app_signature_state",
+    "app_signature_state_details",
+)
+
+_DEFAULT_EXE = "/opt/app/app.exe"
+
+
+def _candidate(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal unmapped PUBLIC candidate (as classified by ConnectionAnalyzer)."""
+    candidate = {
+        "ip": "203.0.113.7",
+        "port": 8443,
+        "proto": "tcp",
+        "service": "https",
+        "process_name": None,
+        "pid": None,
+        "exe": _DEFAULT_EXE,
+        "app_name": None,
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _app_fields(app: dict[str, Any]) -> dict[str, Any]:
+    """Return only the app_* fields from an application record."""
+    return {field: app.get(field) for field in _APP_FIELDS}
+
+
+# --- merge: identity, deduplication, and field content ---
+
+
+def test_merge_creates_entry_keyed_by_ip_port() -> None:
+    """A new candidate creates one entry keyed by ip|port."""
+    state = UnmappedState()
+
+    cache = state.merge([_candidate()])
+
+    assert "203.0.113.7|8443" in cache
+
+
+def test_merge_deduplicates_repeated_observations_of_the_same_service() -> None:
+    """Repeated merges of the same (ip, port) accumulate into one entry, not several."""
+    state = UnmappedState()
+
+    state.merge([_candidate()])
+    cache = state.merge([_candidate()])
+
+    assert len(cache) == 1
+
+
+def test_merge_contains_no_geoip_fields() -> None:
+    """An UnmappedState entry never carries mapped-only GeoIP fields."""
+    state = UnmappedState()
+
+    cache = state.merge([_candidate()])
+    entry = cache["203.0.113.7|8443"]
+
+    for field in ("lat", "lon", "city", "country", "country_code", "asn", "asn_org"):
+        assert field not in entry
+
+
+def test_merge_stores_service_field() -> None:
+    """The port-service label is retained, since the technical view needs it."""
+    state = UnmappedState()
+
+    cache = state.merge([_candidate(service="https")])
+
+    assert cache["203.0.113.7|8443"]["service"] == "https"
+
+
+def test_merge_propagates_app_fields_into_new_application() -> None:
+    """A new application record carries all five app_* fields from the candidate."""
+    state = UnmappedState()
+
+    candidate = _candidate(
+        app_name="Firefox",
+        app_creator="Mozilla Corporation",
+        app_verification_status="verified",
+        app_signature_state="SignedAndTrusted",
+        app_signature_state_details="None",
+    )
+
+    cache = state.merge([candidate])
+    app = cache["203.0.113.7|8443"]["applications"][_DEFAULT_EXE]
+
+    assert _app_fields(app) == {
+        "app_name": "Firefox",
+        "app_creator": "Mozilla Corporation",
+        "app_verification_status": "verified",
+        "app_signature_state": "SignedAndTrusted",
+        "app_signature_state_details": "None",
+    }
+
+
+def test_merge_uses_unknown_bucket_when_exe_missing() -> None:
+    """Candidates with no resolvable exe path share a dedicated unknown-application bucket."""
+    state = UnmappedState()
+
+    cache = state.merge([_candidate(exe=None, process_name="svchost.exe", pid=100)])
+    applications = cache["203.0.113.7|8443"]["applications"]
+
+    assert UNKNOWN_APP_KEY in applications
+    assert applications[UNKNOWN_APP_KEY]["processes"] == ["svchost.exe"]
+
+
+def test_merge_accumulates_distinct_pids_for_the_same_process() -> None:
+    """Multiple PIDs of the same process name accumulate under that application's record."""
+    state = UnmappedState()
+
+    cache = state.merge(
+        [
+            _candidate(process_name="firefox.exe", pid=4821),
+            _candidate(process_name="firefox.exe", pid=5190),
+        ]
+    )
+    app = cache["203.0.113.7|8443"]["applications"][_DEFAULT_EXE]
+
+    assert app["proc_pids"] == {"firefox.exe": [4821, 5190]}
+
+
+def test_merge_drops_candidate_with_invalid_port() -> None:
+    """A candidate with a missing or non-numeric port is dropped, not stored under a -1 key."""
+    state = UnmappedState()
+
+    cache = state.merge([_candidate(port=None), _candidate(exe="/other.exe", port="not-a-port")])
+
+    assert cache == {}
+
+
+# --- clear: reset behavior ---
+
+
+def test_clear_empties_the_cache() -> None:
+    """clear() drops all accumulated entries and returns the new empty cache."""
+    state = UnmappedState()
+    state.merge([_candidate()])
+
+    cache = state.clear()
+
+    assert cache == {}
+    assert state.cache == {}
+
+
+# --- retention: pruning stale entries ---
+
+
+def test_merge_prunes_entries_past_retention_window() -> None:
+    """An entry whose last_seen predates the retention cutoff is dropped on the next merge."""
+    state = UnmappedState(cache_retention_min=5)
+    cache = state.merge([_candidate()])
+    cache["203.0.113.7|8443"]["last_seen"] -= 10 * 60
+
+    cache = state.merge([])
+
+    assert cache == {}
+
+
+def test_merge_keeps_entries_when_retention_disabled() -> None:
+    """cache_retention_min=0 (the default) disables pruning entirely."""
+    state = UnmappedState(cache_retention_min=0)
+    cache = state.merge([_candidate()])
+    cache["203.0.113.7|8443"]["last_seen"] -= 10_000 * 60
+
+    cache = state.merge([])
+
+    assert "203.0.113.7|8443" in cache
+
+
+# --- pending verification: AppInfo backfill ---
+
+
+def test_refresh_resolved_applications_updates_entry_whose_connection_has_vanished() -> None:
+    """A retained cache entry whose connection has vanished still gets updated."""
+    state = UnmappedState()
+
+    # Tick 1: connection present, exe not yet verified.
+    state.merge([_candidate(exe="/opt/app.exe", app_name="Firefox")])
+    assert state.pending_exe_paths() == {"/opt/app.exe"}
+
+    # Tick 2: connection is gone from the snapshot entirely.
+    cache = state.merge([])
+    assert "/opt/app.exe" in cache["203.0.113.7|8443"]["applications"]
+    assert state.pending_exe_paths() == {"/opt/app.exe"}
+
+    state.refresh_resolved_applications(
+        {
+            "/opt/app.exe": {
+                "app_creator": "Mozilla Corporation",
+                "app_verification_status": "verified",
+                "app_signature_state": "SignedAndTrusted",
+                "app_signature_state_details": None,
+            }
+        }
+    )
+
+    app = state.cache["203.0.113.7|8443"]["applications"]["/opt/app.exe"]
+    assert app["app_verification_status"] == "verified"
+    assert app["app_creator"] == "Mozilla Corporation"
+    assert state.pending_exe_paths() == set()

--- a/tests/test_unmapped_view.py
+++ b/tests/test_unmapped_view.py
@@ -1,0 +1,342 @@
+"""Test unmapped_view's technical and application-oriented presentations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dash import html
+
+from tapmap.state.unmapped_state import UnmappedState
+from tapmap.ui.unmapped_view import render_unmapped
+
+
+def _entry(
+    *,
+    ip: str = "203.0.113.7",
+    port: int = 8443,
+    service: str = "https",
+    applications: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a minimal UnmappedState-shaped cache entry."""
+    return {
+        "ip": ip,
+        "port": port,
+        "proto": "tcp",
+        "service": service,
+        "applications": applications if applications is not None else {},
+    }
+
+
+def _app(
+    *,
+    app_name: str | None = None,
+    app_creator: str | None = None,
+    app_verification_status: str | None = None,
+    exe: str | None = "/opt/app.exe",
+    processes: list[str] | None = None,
+    proc_pids: dict[str, list[int]] | None = None,
+) -> dict[str, Any]:
+    """Return a minimal application record for one entry's applications dict."""
+    return {
+        "app_name": app_name,
+        "app_creator": app_creator,
+        "app_verification_status": app_verification_status,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+        "exe": exe,
+        "processes": processes if processes is not None else [],
+        "proc_pids": proc_pids if proc_pids is not None else {},
+    }
+
+
+def _table_rows(component: html.Table) -> list[html.Tr]:
+    """Return the body rows from a rendered table component."""
+    tbody = next(c for c in component.children if isinstance(c, html.Tbody))
+    return tbody.children
+
+
+def _cell_text(td: html.Td) -> str:
+    """Return the visible text of one rendered table cell."""
+    return td.children.children
+
+
+# --- empty state ---
+
+
+def test_render_unmapped_empty_cache_shows_placeholder() -> None:
+    """An empty UnmappedState renders a placeholder, not a table, in either mode."""
+    result = render_unmapped({}, technical_details_enabled=True)
+
+    assert isinstance(result[1], html.Pre)
+    assert "no unmapped" in result[1].children.lower()
+
+
+# --- technical details ON ---
+
+
+def test_technical_table_has_no_count_column() -> None:
+    """The technical table's headers do not include Count."""
+    cache = {"203.0.113.7|8443": _entry(applications={"/opt/app.exe": _app(app_name="Firefox")})}
+
+    result = render_unmapped(cache, technical_details_enabled=True)
+    table = result[1]
+
+    thead = next(c for c in table.children if isinstance(c, html.Thead))
+    headers = [th.children for th in thead.children.children]
+
+    assert headers == ["Scope", "Remote IP", "Port", "Port service", "PID", "Process"]
+
+
+def test_technical_row_shows_service_identity_and_joined_pids() -> None:
+    """A technical row shows Scope/IP/Port/Port service, plus every distinct PID joined."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            ip="203.0.113.7",
+            port=8443,
+            service="https",
+            applications={
+                "/opt/firefox.exe": _app(
+                    app_name="Firefox",
+                    processes=["firefox.exe"],
+                    proc_pids={"firefox.exe": [4821, 5190]},
+                )
+            },
+        )
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=True)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells == ["PUBLIC", "203.0.113.7", "8443", "https", "4821, 5190", "firefox.exe"]
+
+
+def test_technical_view_gives_each_application_at_a_service_its_own_row() -> None:
+    """Two different applications sharing (ip, port) each get their own technical row."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            applications={
+                "/opt/firefox.exe": _app(app_name="Firefox"),
+                "/tmp/malware.exe": _app(app_name="Malware"),
+            }
+        )
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=True)
+    rows = _table_rows(result[1])
+
+    assert len(rows) == 2
+
+
+def test_technical_view_shows_multiple_services() -> None:
+    """Each distinct service entry contributes its own row(s)."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            ip="203.0.113.7", port=8443, applications={"/a.exe": _app(app_name="App A")}
+        ),
+        "198.51.100.4|443": _entry(
+            ip="198.51.100.4", port=443, applications={"/b.exe": _app(app_name="App B")}
+        ),
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=True)
+    rows = _table_rows(result[1])
+
+    assert len(rows) == 2
+
+
+def test_technical_view_shows_unknown_bucket_process_without_app_name() -> None:
+    """An application with no resolvable exe still shows its process name in the technical view."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            applications={
+                "__unknown_application__": _app(
+                    app_name=None,
+                    exe=None,
+                    processes=["svchost.exe"],
+                    proc_pids={"svchost.exe": [100]},
+                )
+            }
+        )
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=True)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells[5] == "svchost.exe"
+    assert cells[4] == "100"
+
+
+# --- technical details OFF ---
+
+
+def test_general_table_has_expected_columns() -> None:
+    """The application-oriented table has the Application/Creator/Verification/Services headers."""
+    cache = {"203.0.113.7|8443": _entry(applications={"/a.exe": _app(app_name="Firefox")})}
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    table = result[1]
+    thead = next(c for c in table.children if isinstance(c, html.Thead))
+    headers = [th.children for th in thead.children.children]
+
+    assert headers == ["Application", "Creator", "Verification", "Services"]
+
+
+def test_general_view_services_counts_distinct_ip_port_entries() -> None:
+    """Services is the number of distinct ip|port entries observed for that application."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            ip="203.0.113.7",
+            port=8443,
+            applications={
+                "/firefox.exe": _app(
+                    app_name="Firefox",
+                    app_creator="Mozilla",
+                    app_verification_status="verified",
+                )
+            },
+        ),
+        "198.51.100.4|443": _entry(
+            ip="198.51.100.4",
+            port=443,
+            applications={
+                "/firefox.exe": _app(
+                    app_name="Firefox",
+                    app_creator="Mozilla",
+                    app_verification_status="verified",
+                )
+            },
+        ),
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells[0] == "Firefox"
+    assert cells[1] == "Mozilla"
+    assert cells[3] == "2"
+
+
+def test_general_view_groups_different_exe_paths_sharing_app_name_into_one_row() -> None:
+    """Different exe paths that report the same app_name collapse into one application row."""
+    cache = {
+        "1.1.1.1|443": _entry(
+            ip="1.1.1.1",
+            port=443,
+            applications={
+                "/OneDrive.exe": _app(app_name="Microsoft OneDrive", app_creator="Microsoft"),
+            },
+        ),
+        "2.2.2.2|443": _entry(
+            ip="2.2.2.2",
+            port=443,
+            applications={
+                "/FileSyncHelper.exe": _app(
+                    app_name="Microsoft OneDrive", app_creator="Microsoft"
+                ),
+            },
+        ),
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    rows = _table_rows(result[1])
+
+    assert len(rows) == 1
+    assert _cell_text(rows[0].children[3]) == "2"
+
+
+def test_general_view_shows_failed_verification_over_verified() -> None:
+    """When the same app_name appears with different statuses, the most concerning one is shown."""
+    cache = {
+        "1.1.1.1|443": _entry(
+            ip="1.1.1.1",
+            port=443,
+            applications={
+                "/a.exe": _app(app_name="Widget", app_verification_status="verified"),
+            },
+        ),
+        "2.2.2.2|443": _entry(
+            ip="2.2.2.2",
+            port=443,
+            applications={
+                "/b.exe": _app(app_name="Widget", app_verification_status="failed"),
+            },
+        ),
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells[2] == "Failed"
+
+
+def test_general_view_shows_unknown_for_missing_app_name() -> None:
+    """Applications with no resolvable app_name are grouped under 'Unknown', not dropped."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            applications={
+                "__unknown_application__": _app(app_name=None, exe=None),
+            }
+        )
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells[0] == "Unknown"
+
+
+def test_general_view_pending_application_shows_retrieving_creator() -> None:
+    """An application still awaiting verification shows 'Retrieving...' as its creator."""
+    cache = {
+        "203.0.113.7|8443": _entry(
+            applications={
+                "/opt/app.exe": _app(
+                    app_name="New App", app_creator=None, app_verification_status=None
+                ),
+            }
+        )
+    }
+
+    result = render_unmapped(cache, technical_details_enabled=False)
+    rows = _table_rows(result[1])
+    cells = [_cell_text(td) for td in rows[0].children]
+
+    assert cells[1] == "Retrieving..."
+    assert cells[2] == "Pending"
+
+
+# --- integration: real UnmappedState wiring ---
+
+
+def test_render_unmapped_reads_from_real_unmapped_state() -> None:
+    """render_unmapped works directly against UnmappedState.cache as merge() produces it."""
+    state = UnmappedState()
+    state.merge(
+        [
+            {
+                "ip": "203.0.113.7",
+                "port": 8443,
+                "proto": "tcp",
+                "service": "https",
+                "process_name": "firefox.exe",
+                "pid": 4821,
+                "exe": "/opt/firefox.exe",
+                "app_name": "Firefox",
+                "app_creator": "Mozilla Corporation",
+                "app_verification_status": "verified",
+                "app_signature_state": None,
+                "app_signature_state_details": None,
+            }
+        ]
+    )
+
+    technical = render_unmapped(state.cache, technical_details_enabled=True)
+    general = render_unmapped(state.cache, technical_details_enabled=False)
+
+    assert isinstance(technical[1], html.Table)
+    assert isinstance(general[1], html.Table)


### PR DESCRIPTION
## Summary

- remove obsolete cache view code and rename the remaining view to service point view
- centralize mapped connection data in ConnectionState
- add accumulated UnmappedState with shared application and process handling
- enrich unmapped connections with AppInfo and verification data
- provide general and technical unmapped views
- share verification status formatting across mapped and unmapped views

## Verification

- ruff check .
- python -m pytest -q: 614 passed, 2 skipped
- manually tested mapped and unmapped views, technical details, Clear cache, LAN/local, and Open Ports