### PR TITLE
refactor: align insights with connection state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,7 +113,9 @@ The state layer contains deterministic application logic.
 
 Examples include:
 
+- Connection and Unmapped state (session-lifetime)
 - Insights processing
+- Significant Connections evaluation and history
 - Menu state
 - Modal state
 - Keyboard handling
@@ -190,23 +192,34 @@ Used for real-time visualization.
 ```text
 model_snapshot
        │
-       ▼
+       ├──────────────────────┬───────────────────────┐
+       │                      │                        │
+       ▼                      ▼                        ▼
 
-    ui_cache
+ConnectionAnalyzer         Open Ports        LAN/LOCAL Services
        │
-       ▼
+  ┌────┴────┐
+  │         │
+  ▼         ▼
 
-    ui_view
-       │
-       ▼
+mapped   unmapped
+  │         │
+  ▼         ▼
 
-Map
-Open Ports
-LAN/LOCAL Services
-Unmapped Services
+ConnectionState   UnmappedState
+  │                    │
+  ▼                    ▼
+
+ui_view            Unmapped Services
+  │
+  ▼
+
+  Map
 ```
 
-Session state exists only while the application is running.
+ConnectionAnalyzer classifies each PUBLIC connection as mapped (usable GeoIP) or unmapped, and routes it into ConnectionState or UnmappedState accordingly. ConnectionState and UnmappedState accumulate observations for the lifetime of the application session.
+
+Open Ports and LAN/LOCAL Services are not accumulated. They are read directly from the current snapshot on each render and never pass through ConnectionAnalyzer or either session state store.
 
 ### AppInfo Flow
 
@@ -221,7 +234,7 @@ Model.snapshot()
    model_snapshot
        │
        ▼
-    ui_cache
+ConnectionState / UnmappedState
 
 Background verification
        │
@@ -232,10 +245,10 @@ Background verification
  normal poll
        │
        ▼
-    ui_cache
+ConnectionState / UnmappedState
 ```
 
-Pending verification does not block snapshot creation or map updates. Completed verification information is merged into retained session state during subsequent polling.
+Pending verification does not block snapshot creation or map updates. Completed verification information is merged into ConnectionState and UnmappedState independently during subsequent polling.
 
 ### Historical Flow
 
@@ -245,6 +258,16 @@ Used for long-term analysis.
 model_snapshot
        │
        ▼
+
+ConnectionAnalyzer
+       │
+       ├── per PUBLIC connection (mapped and unmapped):
+       │      evaluate significance against SignificanceHistory
+       │      │
+       │      ▼
+       │   significant? ──▶ SignificantConnections ──▶ significant_connections.json
+       │
+       ▼  (after the loop; mapped PUBLIC connections only)
 
 process_insights()
        │
@@ -262,6 +285,10 @@ process_insights()
   insights.json
 ```
 
+Significant Connections evaluation runs per connection, inside the same loop that classifies mapped/unmapped connections, for every PUBLIC connection regardless of mapped/unmapped status. Novelty is judged against SignificanceHistory, an in-memory structure seeded from the persisted Insights bitmasks at startup and updated as each connection is evaluated; SignificanceHistory itself is not directly persisted. Connections judged significant are appended to SignificantConnections, a bounded, persisted event log.
+
+Insights is a separate, batch-updated structure: after the per-connection loop completes, process_insights() updates the rolling 30-day Insights history using only the mapped PUBLIC connections observed in that poll. Unmapped PUBLIC connections are evaluated for significance but do not contribute to Insights.
+
 Historical state survives application restarts.
 
 ---
@@ -274,35 +301,60 @@ Represents the current network snapshot.
 
 This state is transient and replaced during each polling cycle.
 
-### ui_cache
+### ConnectionState
 
 Session-scoped state.
 
-Contains activity accumulated during the current application session.
+Accumulates mapped PUBLIC connections (usable GeoIP) observed during the current application session, routed here by ConnectionAnalyzer.
 
 Retained entries may be enriched with completed AppInfo verification results during subsequent polling, even when the corresponding connection is no longer present in the latest snapshot.
 
-Used by:
-
-- Interactive Map
-- Open Ports
-- LAN/LOCAL Services
-- Unmapped Services
+Used by the Interactive Map.
 
 Cleared when the application exits or the user clears the cache.
+
+### UnmappedState
+
+Session-scoped state.
+
+Accumulates PUBLIC connections without usable GeoIP observed during the current application session, routed here by ConnectionAnalyzer.
+
+Retained entries may be enriched with completed AppInfo verification results during subsequent polling, the same as ConnectionState.
+
+Used by Unmapped Services.
+
+Cleared when the application exits or the user clears the cache.
+
+### SignificanceHistory
+
+Runtime-only novelty tracking. Not directly persisted.
+
+Records the last-seen day for each observed application, country, provider, and port, plus verification-failure history. The last-seen dictionaries are seeded once from the persisted Insights bitmasks at startup; verification-failure history is shared with InsightsState. The history is then updated in memory as each PUBLIC connection is evaluated.
+
+Used by ConnectionAnalyzer to decide whether a connection is significant.
+
+### SignificantConnections
+
+Persistent historical state.
+
+A bounded, chronological event log (most recent 500) of PUBLIC connections judged significant against SignificanceHistory, covering both mapped and unmapped connections.
+
+Loaded at startup and periodically written to disk as significant_connections.json.
 
 ### insights
 
 Persistent historical state.
 
-Maintains rolling activity history for:
+Maintains rolling 30-day activity history for:
 
 - Applications
 - Countries
 - Providers (ASN)
 - Ports
 
-Loaded at startup and periodically written to disk.
+Populated only from mapped PUBLIC connections; unmapped PUBLIC connections do not contribute.
+
+Loaded at startup and periodically written to disk as insights.json.
 
 Used by:
 

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -513,7 +513,7 @@ class TapMap:
             )
             return snap, status_cache.to_store(), view, no_update, no_update
 
-        items_any = snap.get("cache_items")
+        items_any = snap.get("connections")
         items = items_any if isinstance(items_any, list) else []
 
         insights_data = self.connection_analyzer.analyze(items)

--- a/src/tapmap/model/model.py
+++ b/src/tapmap/model/model.py
@@ -13,8 +13,8 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 
-class CacheItem(TypedDict):
-    """Define one cache item for the UI."""
+class Connection(TypedDict):
+    """Define one connection observed in a Model snapshot."""
 
     proto: str
     ip: str
@@ -60,8 +60,7 @@ class SnapshotPayload(TypedDict):
 
     error: bool
     stats: dict[str, Any]
-    cache_items: list[CacheItem]
-    map_candidates: list[CacheItem]
+    connections: list[Connection]
     open_ports: list[OpenPort]
 
 
@@ -81,13 +80,13 @@ class Model:
         app_enabled = self._appinfo_enabled()
 
         try:
-            connections = self.netinfo.get_data()
+            records = self.netinfo.get_data()
 
             if geo_enabled:
-                self.geoinfo.enrich(connections)
+                self.geoinfo.enrich(records)
 
             if app_enabled:
-                self.appinfo.enrich(connections)
+                self.appinfo.enrich(records)
 
             live_tcp_total = 0
             live_tcp_established = 0
@@ -96,11 +95,10 @@ class Model:
             live_udp_bound = 0
             dropped_missing_remote = 0
 
-            cache_items: list[CacheItem] = []
-            map_candidates: list[CacheItem] = []
+            connections: list[Connection] = []
             open_ports: list[OpenPort] = []
 
-            for conn in connections:
+            for conn in records:
                 if not isinstance(conn, dict):
                     continue
 
@@ -117,9 +115,7 @@ class Model:
                             dropped_missing_remote += 1
                             continue
 
-                        cache_items.append(item)
-                        if self._is_map_candidate(item):
-                            map_candidates.append(item)
+                        connections.append(item)
                         continue
 
                     if status == "LISTEN":
@@ -135,9 +131,7 @@ class Model:
                     item = self._build_remote_endpoint_item(conn, proto="udp")
                     if item is not None:
                         live_udp_remote += 1
-                        cache_items.append(item)
-                        if self._is_map_candidate(item):
-                            map_candidates.append(item)
+                        connections.append(item)
                         continue
 
                     live_udp_bound += 1
@@ -159,8 +153,7 @@ class Model:
                     "geoinfo_enabled": geo_enabled,
                     "appinfo_enabled": app_enabled,
                 },
-                "cache_items": cache_items,
-                "map_candidates": map_candidates,
+                "connections": connections,
                 "open_ports": open_ports,
             }
 
@@ -179,8 +172,7 @@ class Model:
                     "geoinfo_enabled": geo_enabled,
                     "appinfo_enabled": app_enabled,
                 },
-                "cache_items": [],
-                "map_candidates": [],
+                "connections": [],
                 "open_ports": [],
             }
 
@@ -189,15 +181,6 @@ class Model:
 
     def _appinfo_enabled(self) -> bool:
         return bool(getattr(self.appinfo, "enabled", False))
-
-    @staticmethod
-    def _is_map_candidate(item: CacheItem) -> bool:
-        """Return True if PUBLIC service with valid geolocation."""
-        if item.get("service_scope") != "PUBLIC":
-            return False
-        lat = item.get("lat")
-        lon = item.get("lon")
-        return isinstance(lat, (int, float)) and isinstance(lon, (int, float))
 
     @staticmethod
     def _bind_scope(ip: str | None) -> str:
@@ -286,7 +269,7 @@ class Model:
             "bind_scope": self._bind_scope(l_ip),
         }
 
-    def _build_remote_endpoint_item(self, conn: dict[str, Any], *, proto: str) -> CacheItem | None:
+    def _build_remote_endpoint_item(self, conn: dict[str, Any], *, proto: str) -> Connection | None:
         proto_norm = str(proto).lower() or "tcp"
 
         remote_ip = conn.get("raddr_ip")
@@ -320,8 +303,8 @@ class Model:
             "lat": lat_value,
             "lon": lon_value,
             "pid": conn.get("pid"),
-            # CacheItem.process_name intentionally stores the display-oriented
-            # process label, not the raw backend process name. Cache items are
+            # Connection.process_name intentionally stores the display-oriented
+            # process label, not the raw backend process name. Connections are
             # used for UI aggregation, grouping, and summaries where fallback
             # labels such as "System" are required.
             "process_name": conn.get("process_label"),

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -1,7 +1,8 @@
 """Analyze connections and route them to state: mapped, unmapped, insights, significant.
 
-Mapped PUBLIC connections update ConnectionState; PUBLIC connections without
-usable GeoIP update UnmappedState.
+Mapped PUBLIC connections update ConnectionState and feed Insights. PUBLIC
+connections without usable GeoIP update UnmappedState and remain eligible
+for Significant Connections, but do not contribute to Insights.
 """
 
 from __future__ import annotations
@@ -37,7 +38,8 @@ class ConnectionAnalyzer:
     def analyze(self, connections: list[dict[str, Any]]) -> dict[str, Any]:
         """Update ConnectionState, UnmappedState, Significant Connections, and Insights.
 
-        Returns the Insights result ({new, top}).
+        Insights is derived only from mapped PUBLIC connections. Returns the
+        Insights result ({new, top}).
         """
         now = datetime.now()
         mapped: list[dict[str, Any]] = []
@@ -61,4 +63,4 @@ class ConnectionAnalyzer:
         self.connection_state.merge(mapped)
         self.unmapped_state.merge(unmapped)
 
-        return process_insights(connections, self.insights, now)
+        return process_insights(mapped, self.insights, now)

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -17,7 +17,7 @@ from .unmapped_state import UnmappedState
 
 
 class ConnectionAnalyzer:
-    """Process a snapshot's cache_items: connection, unmapped, insights, and significant state."""
+    """Process a snapshot's connections: connection, unmapped, insights, and significant state."""
 
     def __init__(
         self,
@@ -34,7 +34,7 @@ class ConnectionAnalyzer:
         self.significant_connections = significant_connections
         self.significance_history = significance_history
 
-    def analyze(self, cache_items: list[dict[str, Any]]) -> dict[str, Any]:
+    def analyze(self, connections: list[dict[str, Any]]) -> dict[str, Any]:
         """Update ConnectionState, UnmappedState, Significant Connections, and Insights.
 
         Returns the Insights result ({new, top}).
@@ -43,7 +43,7 @@ class ConnectionAnalyzer:
         mapped: list[dict[str, Any]] = []
         unmapped: list[dict[str, Any]] = []
 
-        for item in cache_items:
+        for item in connections:
             if item.get("service_scope") != "PUBLIC":
                 continue
 
@@ -61,4 +61,4 @@ class ConnectionAnalyzer:
         self.connection_state.merge(mapped)
         self.unmapped_state.merge(unmapped)
 
-        return process_insights(cache_items, self.insights, now)
+        return process_insights(connections, self.insights, now)

--- a/src/tapmap/state/connection_state.py
+++ b/src/tapmap/state/connection_state.py
@@ -1,8 +1,8 @@
 """Own the accumulated per-service connection cache for the TapMap state layer.
 
-Merge Model.snapshot() map candidates into a per-service cache, prune
-entries past the configured retention window, and backfill deferred
-AppInfo verification results into retained entries.
+Merge mapped connections into a per-service cache, prune entries past the
+configured retention window, and backfill deferred AppInfo verification
+results into retained entries.
 """
 
 from __future__ import annotations
@@ -37,12 +37,12 @@ class ConnectionState:
     def _now_text() -> str:
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    def merge(self, map_candidates: list[dict[str, Any]]) -> dict[str, Any]:
-        """Merge map candidates into the cache, prune stale entries, and return the cache."""
+    def merge(self, mapped_connections: list[dict[str, Any]]) -> dict[str, Any]:
+        """Merge mapped connections into the cache, prune stale entries, and return the cache."""
         now = datetime.now().timestamp()
         cache = self._cache
 
-        for candidate in map_candidates:
+        for candidate in mapped_connections:
             if not isinstance(candidate, dict):
                 continue
 

--- a/src/tapmap/state/insights.py
+++ b/src/tapmap/state/insights.py
@@ -46,7 +46,11 @@ def process_insights(
     insights: dict[str, Any],
     now: datetime,
 ) -> dict[str, Any]:
-    """Process snapshot and return new insights entries."""
+    """Process items and return new insights entries.
+
+    Caller must supply only mapped PUBLIC connections; no scope filtering is
+    applied here.
+    """
 
     def update_dimension(
         values: set[str],
@@ -98,9 +102,6 @@ def process_insights(
 
     for item in items:
         if not isinstance(item, dict):
-            continue
-
-        if item.get("service_scope") != "PUBLIC":
             continue
 
         cc = item.get("country_code")

--- a/src/tapmap/state/status_cache.py
+++ b/src/tapmap/state/status_cache.py
@@ -61,8 +61,8 @@ class StatusCache:
         self.unm.clear()
         self.loc.clear()
 
-    def update(self, cache_items: Sequence[StatusCacheItem]) -> None:
-        """Merge snapshot cache_items into the cache.
+    def update(self, connections: Sequence[StatusCacheItem]) -> None:
+        """Merge snapshot connections into the cache.
 
         Required keys:
             ip: str
@@ -75,7 +75,7 @@ class StatusCache:
             service_scope: 'PUBLIC', 'LAN', 'LOCAL', or 'UNKNOWN'
             lat, lon: numeric coordinates for PUBLIC services
         """
-        for item in cache_items:
+        for item in connections:
             ip = item.get("ip")
             if not isinstance(ip, str) or not ip:
                 continue

--- a/src/tapmap/ui/help_view.py
+++ b/src/tapmap/ui/help_view.py
@@ -387,7 +387,10 @@ def render_help() -> list[Any]:
             ]
         ),
         html.H2("Insights"),
-        html.P("The Insights panel highlights activity observed during the last 30 days."),
+        html.P(
+            "The Insights panel highlights mapped public activity observed during "
+            "the last 30 days."
+        ),
         html.Ul(
             [
                 html.Li(
@@ -402,16 +405,13 @@ def render_help() -> list[Any]:
             ]
         ),
         html.P(
-            "Insights may include activity that is not currently visible on the map."
-        ),
-        html.P(
-            "The map is limited to activity observed during the current session, "
-            "while Insights use activity observed during the last 30 days."
+            "Insights may include mapped activity that is no longer visible on the map because "
+            "the map covers the current session, while Insights retain activity for 30 days."
         ),
         html.H2("Daily Activity Report"),
         html.P(
-            "The Daily Activity Report analyzes historical activity observed during "
-            "the last 30 days."
+            "The Daily Activity Report analyzes mapped public activity observed "
+            "during the last 30 days."
         ),
         html.Ul(
             [

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -461,13 +461,13 @@ class ModalTextBuilder:
     def _render_lan_local(cls, snapshot: Any | None) -> list[Any]:
         """Render LAN and LOCAL established services."""
         snap = snapshot if isinstance(snapshot, dict) else {}
-        items = snap.get("cache_items")
+        items = snap.get("connections")
         rows = items if isinstance(items, list) else []
 
         cleaned: list[dict[str, Any]] = [r for r in rows if isinstance(r, dict)]
 
         def is_established_tcp(row: dict[str, Any]) -> bool:
-            # CacheItem rows only contain ESTABLISHED TCP or remote UDP endpoints.
+            # Connection rows only contain ESTABLISHED TCP or remote UDP endpoints.
             # The model pre-filters all other TCP states, so no explicit state check is needed here.
             proto = row.get("proto")
             return not (isinstance(proto, str) and proto.strip() and proto.strip().lower() != "tcp")

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -12,8 +12,8 @@ from tapmap.state.significant_connections import SignificantConnections
 from tapmap.state.unmapped_state import UnmappedState
 
 
-def _cache_item(**overrides: Any) -> dict[str, Any]:
-    """Return a minimal cache_items-shaped dict (as produced by Model.snapshot())."""
+def _connection(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal connection dict (as produced by Model.snapshot())."""
     item = {
         "ip": "8.8.8.8",
         "port": 443,
@@ -68,7 +68,7 @@ def test_analyze_merges_public_connection_with_coordinates() -> None:
     connection_state = ConnectionState()
     analyzer = _analyzer(connection_state)
 
-    analyzer.analyze([_cache_item()])
+    analyzer.analyze([_connection()])
 
     assert "8.8.8.8|443" in connection_state.cache
 
@@ -78,7 +78,7 @@ def test_analyze_excludes_public_connection_without_coordinates() -> None:
     connection_state = ConnectionState()
     analyzer = _analyzer(connection_state)
 
-    analyzer.analyze([_cache_item(lat=None, lon=None)])
+    analyzer.analyze([_connection(lat=None, lon=None)])
 
     assert connection_state.cache == {}
 
@@ -90,9 +90,9 @@ def test_analyze_excludes_non_public_scopes() -> None:
 
     analyzer.analyze(
         [
-            _cache_item(ip="192.168.1.1", service_scope="LAN"),
-            _cache_item(ip="127.0.0.1", service_scope="LOCAL"),
-            _cache_item(ip="10.0.0.1", service_scope="UNKNOWN"),
+            _connection(ip="192.168.1.1", service_scope="LAN"),
+            _connection(ip="127.0.0.1", service_scope="LOCAL"),
+            _connection(ip="10.0.0.1", service_scope="UNKNOWN"),
         ]
     )
 
@@ -102,12 +102,12 @@ def test_analyze_excludes_non_public_scopes() -> None:
 # --- insights: updated from the full connection set, not just mapped ---
 
 
-def test_analyze_feeds_full_cache_items_to_insights_not_just_mapped() -> None:
+def test_analyze_feeds_full_connections_to_insights_not_just_mapped() -> None:
     """Insights are updated from every PUBLIC connection, including unmapped ones."""
     insights: dict[str, Any] = {}
     analyzer = _analyzer(insights=insights)
 
-    analyzer.analyze([_cache_item(lat=None, lon=None, country_code="NO")])
+    analyzer.analyze([_connection(lat=None, lon=None, country_code="NO")])
 
     assert "NO" in insights["countries"]
 
@@ -117,7 +117,7 @@ def test_analyze_excludes_non_public_connections_from_insights() -> None:
     insights: dict[str, Any] = {}
     analyzer = _analyzer(insights=insights)
 
-    analyzer.analyze([_cache_item(ip="192.168.1.1", service_scope="LAN", country_code="NO")])
+    analyzer.analyze([_connection(ip="192.168.1.1", service_scope="LAN", country_code="NO")])
 
     assert insights.get("countries", {}) == {}
 
@@ -126,7 +126,7 @@ def test_analyze_returns_process_insights_result() -> None:
     """analyze() returns the same {new, top} shape process_insights() produces."""
     analyzer = _analyzer()
 
-    result = analyzer.analyze([_cache_item()])
+    result = analyzer.analyze([_connection()])
 
     assert set(result.keys()) == {"new", "top"}
     assert result["new"]["countries"][0]["value"] == "US"
@@ -152,7 +152,7 @@ def test_analyze_records_significant_event_for_novel_public_connection() -> None
         ),
     )
 
-    analyzer.analyze([_cache_item(country_code="US")])
+    analyzer.analyze([_connection(country_code="US")])
 
     assert len(significant_connections.items) == 1
     event = significant_connections.items[0]
@@ -178,7 +178,7 @@ def test_analyze_does_not_evaluate_significance_for_non_public_connections() -> 
     )
 
     analyzer.analyze(
-        [_cache_item(ip="192.168.1.1", service_scope="LAN", country_code="NO", port=9999)]
+        [_connection(ip="192.168.1.1", service_scope="LAN", country_code="NO", port=9999)]
     )
 
     assert significant_connections.items == []
@@ -198,8 +198,8 @@ def test_analyze_does_not_repeat_significant_event_for_same_snapshot_repeat() ->
         ConnectionState(), UnmappedState(), {}, significant_connections, history
     )
 
-    analyzer.analyze([_cache_item(country_code="US")])
-    analyzer.analyze([_cache_item(country_code="US")])
+    analyzer.analyze([_connection(country_code="US")])
+    analyzer.analyze([_connection(country_code="US")])
 
     assert len(significant_connections.items) == 1
 
@@ -213,7 +213,7 @@ def test_analyze_routes_public_without_geo_to_unmapped_state() -> None:
     unmapped_state = UnmappedState()
     analyzer = _analyzer(connection_state, unmapped_state)
 
-    analyzer.analyze([_cache_item(lat=None, lon=None)])
+    analyzer.analyze([_connection(lat=None, lon=None)])
 
     assert connection_state.cache == {}
     assert "8.8.8.8|443" in unmapped_state.cache
@@ -225,7 +225,7 @@ def test_analyze_routes_public_with_geo_to_connection_state_only() -> None:
     unmapped_state = UnmappedState()
     analyzer = _analyzer(connection_state, unmapped_state)
 
-    analyzer.analyze([_cache_item()])
+    analyzer.analyze([_connection()])
 
     assert "8.8.8.8|443" in connection_state.cache
     assert unmapped_state.cache == {}

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -99,17 +99,27 @@ def test_analyze_excludes_non_public_scopes() -> None:
     assert connection_state.cache == {}
 
 
-# --- insights: updated from the full connection set, not just mapped ---
+# --- insights: updated only from mapped PUBLIC connections ---
 
 
-def test_analyze_feeds_full_connections_to_insights_not_just_mapped() -> None:
-    """Insights are updated from every PUBLIC connection, including unmapped ones."""
+def test_analyze_feeds_mapped_public_connections_to_insights() -> None:
+    """Insights are updated from mapped PUBLIC connections (valid lat/lon)."""
+    insights: dict[str, Any] = {}
+    analyzer = _analyzer(insights=insights)
+
+    analyzer.analyze([_connection(country_code="NO")])
+
+    assert "NO" in insights["countries"]
+
+
+def test_analyze_excludes_unmapped_public_connections_from_insights() -> None:
+    """A PUBLIC connection without usable GeoIP does not contribute to Insights."""
     insights: dict[str, Any] = {}
     analyzer = _analyzer(insights=insights)
 
     analyzer.analyze([_connection(lat=None, lon=None, country_code="NO")])
 
-    assert "NO" in insights["countries"]
+    assert insights.get("countries", {}) == {}
 
 
 def test_analyze_excludes_non_public_connections_from_insights() -> None:

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -486,12 +486,18 @@ class TestBuildTop:
 class TestInputFiltering:
     """process_insights correctly classifies and filters snapshot items."""
 
-    def test_private_scope_item_is_ignored(self) -> None:
-        """Items with service_scope != 'PUBLIC' are not counted in any dimension."""
+    def test_does_not_filter_by_service_scope(self) -> None:
+        """process_insights trusts its caller and applies no scope filtering itself.
+
+        PUBLIC-eligibility is ConnectionAnalyzer's responsibility: it filters
+        and routes connections before calling process_insights(). This item
+        would never reach process_insights() in production, but the function
+        itself does not re-check service_scope.
+        """
         items = [{"service_scope": "PRIVATE", "country_code": "US"}]
         insights: dict[str, Any] = {}
         process_insights(items, insights, _now(1))
-        assert insights.get("countries", {}) == {}
+        assert "US" in insights["countries"]
 
     def test_none_country_code_is_not_added(self) -> None:
         """country_code=None is skipped."""
@@ -571,11 +577,3 @@ class TestInputFiltering:
         insights: dict[str, Any] = {}
         process_insights(items, insights, _now(1))
         assert insights.get("applications", {}) == {}
-
-    def test_missing_service_scope_field_is_not_treated_as_public(self) -> None:
-        """Item with no service_scope key is not counted (treated as non-PUBLIC)."""
-        items = [{"country_code": "US", "port": 80}]
-        insights: dict[str, Any] = {}
-        process_insights(items, insights, _now(1))
-        assert insights.get("countries", {}) == {}
-        assert insights.get("ports", {}) == {}

--- a/tests/test_modal_view.py
+++ b/tests/test_modal_view.py
@@ -128,7 +128,7 @@ def test_for_action_menu_unmapped_routes_to_unmapped_view() -> None:
 
     result = _builder().for_action(
         "menu_unmapped",
-        snapshot={"cache_items": []},
+        snapshot={"connections": []},
         is_docker=False,
         unmapped_cache=unmapped_cache,
         technical_details_enabled=True,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from tapmap.model.model import CacheItem, Model
+from tapmap.model.model import Connection, Model
 
-_APP_CACHE_ITEM_FIELDS = {
+_APP_CONNECTION_FIELDS = {
     "app_name",
     "app_creator",
     "app_verification_status",
@@ -35,64 +35,6 @@ def test_bind_scope_classifies_addresses() -> None:
     assert Model._bind_scope("::") == "PUBLIC"
     assert Model._bind_scope(None) == "UNKNOWN"
     assert Model._bind_scope("bad-ip") == "UNKNOWN"
-
-
-def test_is_map_candidate_requires_public_scope_and_coordinates() -> None:
-    """Verify map candidate classification requires PUBLIC scope and coordinates."""
-    assert (
-        Model._is_map_candidate(
-            {
-                "service_scope": "PUBLIC",
-                "lat": 59.91,
-                "lon": 10.75,
-            }
-        )
-        is True
-    )
-
-    assert (
-        Model._is_map_candidate(
-            {
-                "service_scope": "LAN",
-                "lat": 59.91,
-                "lon": 10.75,
-            }
-        )
-        is False
-    )
-
-    assert (
-        Model._is_map_candidate(
-            {
-                "service_scope": "PUBLIC",
-                "lat": None,
-                "lon": 10.75,
-            }
-        )
-        is False
-    )
-
-    assert (
-        Model._is_map_candidate(
-            {
-                "service_scope": "PUBLIC",
-                "lat": 59.91,
-                "lon": None,
-            }
-        )
-        is False
-    )
-
-    assert (
-        Model._is_map_candidate(
-            {
-                "service_scope": "UNKNOWN",
-                "lat": 59.91,
-                "lon": 10.75,
-            }
-        )
-        is False
-    )
 
 
 # --- snapshot() / AppInfo integration ---
@@ -158,9 +100,9 @@ def _set_app_fields(connections: list[dict[str, Any]]) -> None:
         conn["app_signature_state_details"] = "None"
 
 
-def test_cache_item_key_set_matches_contract() -> None:
-    """Pin the full CacheItem key set so an accidental rename fails a test, not the UI."""
-    assert set(CacheItem.__annotations__) == {
+def test_connection_key_set_matches_contract() -> None:
+    """Pin the full Connection key set so an accidental rename fails a test, not the UI."""
+    assert set(Connection.__annotations__) == {
         "proto",
         "ip",
         "port",
@@ -179,12 +121,12 @@ def test_cache_item_key_set_matches_contract() -> None:
         "country_code",
         "asn",
         "asn_org",
-        *_APP_CACHE_ITEM_FIELDS,
+        *_APP_CONNECTION_FIELDS,
     }
 
 
-def test_snapshot_copies_app_fields_into_cache_item() -> None:
-    """CacheItem carries all app_* fields set by AppInfo.enrich()."""
+def test_snapshot_copies_app_fields_into_connection() -> None:
+    """Connection carries all app_* fields set by AppInfo.enrich()."""
     model = Model(
         netinfo=FakeNetInfo([_established_tcp_connection()]),
         geoinfo=FakeGeoInfo(),
@@ -194,8 +136,8 @@ def test_snapshot_copies_app_fields_into_cache_item() -> None:
     snap = model.snapshot()
 
     assert snap["error"] is False
-    assert len(snap["cache_items"]) == 1
-    item = snap["cache_items"][0]
+    assert len(snap["connections"]) == 1
+    item = snap["connections"][0]
     assert item["app_name"] == "Firefox"
     assert item["app_creator"] == "Mozilla Corporation"
     assert item["app_verification_status"] == "verified"
@@ -229,17 +171,17 @@ def test_snapshot_does_not_call_enrich_when_appinfo_disabled() -> None:
     snap = model.snapshot()
 
     assert appinfo.enrich_calls == 0
-    item = snap["cache_items"][0]
-    for field in _APP_CACHE_ITEM_FIELDS:
+    item = snap["connections"][0]
+    for field in _APP_CONNECTION_FIELDS:
         assert item[field] is None
 
 
 def test_snapshot_app_fields_default_to_none_when_unset() -> None:
-    """CacheItem app_* fields fall back to None when AppInfo does not set them.
+    """Connection app_* fields fall back to None when AppInfo does not set them.
 
     This covers any reason a connection ends up without app data (AppInfo
     could not resolve it, chose to skip it, etc.) - Model's own contract is
-    only to surface whatever AppInfo did or didn't provide, via CacheItem's
+    only to surface whatever AppInfo did or didn't provide, via Connection's
     established conn.get(...) defaulting pattern already used for geo fields.
     """
     model = Model(
@@ -250,30 +192,6 @@ def test_snapshot_app_fields_default_to_none_when_unset() -> None:
 
     snap = model.snapshot()
 
-    item = snap["cache_items"][0]
-    for field in _APP_CACHE_ITEM_FIELDS:
+    item = snap["connections"][0]
+    for field in _APP_CONNECTION_FIELDS:
         assert item[field] is None
-
-
-def test_snapshot_map_candidate_shares_app_fields_with_cache_item() -> None:
-    """A map candidate is the same object as its cache_items entry, app fields included."""
-
-    def _set_app_and_geo_fields(connections: list[dict[str, Any]]) -> None:
-        # A public IP with no lat/lon is not a map candidate; add coordinates
-        # directly, since GeoInfo enrichment itself is out of scope here.
-        _set_app_fields(connections)
-        for conn in connections:
-            conn["lat"] = 37.4
-            conn["lon"] = -122.1
-
-    model = Model(
-        netinfo=FakeNetInfo([_established_tcp_connection()]),
-        geoinfo=FakeGeoInfo(),
-        appinfo=FakeAppInfo(enabled=True, enrich_fn=_set_app_and_geo_fields),
-    )
-
-    snap = model.snapshot()
-
-    assert len(snap["map_candidates"]) == 1
-    assert snap["map_candidates"][0] is snap["cache_items"][0]
-    assert snap["map_candidates"][0]["app_name"] == "Firefox"

--- a/tests/test_significance.py
+++ b/tests/test_significance.py
@@ -19,7 +19,7 @@ from tapmap.state.significance import (
 )
 
 
-def _cache_item(**overrides: Any) -> dict[str, Any]:
+def _connection(**overrides: Any) -> dict[str, Any]:
     item = {
         "proto": "tcp",
         "ip": "8.8.8.8",
@@ -154,7 +154,7 @@ def test_get_significant_returns_none_when_nothing_is_new() -> None:
         verification_failed={},
     )
 
-    result = get_significant(_cache_item(), history, datetime.fromordinal(today))
+    result = get_significant(_connection(), history, datetime.fromordinal(today))
 
     assert result is None
 
@@ -163,7 +163,7 @@ def test_get_significant_new_connection_reports_all_four_new_reasons() -> None:
     """A connection novel in all four dimensions produces one event with all four reasons."""
     history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
 
-    result = get_significant(_cache_item(), history, datetime(2026, 8, 22))
+    result = get_significant(_connection(), history, datetime(2026, 8, 22))
 
     assert result is not None
     assert set(result["reasons"]) == {
@@ -179,7 +179,7 @@ def test_get_significant_event_preserves_full_connection_detail() -> None:
     history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
     now = datetime(2026, 8, 22, 10, 30, 0)
 
-    result = get_significant(_cache_item(), history, now)
+    result = get_significant(_connection(), history, now)
 
     assert result is not None
     assert result["timestamp"] == now.isoformat()
@@ -207,7 +207,7 @@ def test_get_significant_verification_failed_reason() -> None:
         verification_failed={},
     )
 
-    result = get_significant(_cache_item(app_verification_status="failed"), history, today_dt)
+    result = get_significant(_connection(app_verification_status="failed"), history, today_dt)
 
     assert result is not None
     assert result["reasons"] == [REASON_VERIFICATION_FAILED]
@@ -218,7 +218,7 @@ def test_get_significant_missing_app_name_excludes_new_app_and_verification_fail
     history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
 
     result = get_significant(
-        _cache_item(app_name=None, app_verification_status="failed"),
+        _connection(app_name=None, app_verification_status="failed"),
         history,
         datetime(2026, 8, 22),
     )
@@ -237,8 +237,8 @@ def test_first_connection_owns_new_reason_within_one_poll() -> None:
     history = SignificanceHistory(last_seen=_empty_last_seen(), verification_failed={})
     now = datetime(2026, 8, 22)
 
-    first = get_significant(_cache_item(ip="1.1.1.1", port=80), history, now)
-    second = get_significant(_cache_item(ip="2.2.2.2", port=80), history, now)
+    first = get_significant(_connection(ip="1.1.1.1", port=80), history, now)
+    second = get_significant(_connection(ip="2.2.2.2", port=80), history, now)
 
     assert first is not None
     assert REASON_NEW_COUNTRY in first["reasons"]
@@ -257,9 +257,9 @@ def test_significance_across_polls_deduplicates_then_becomes_new_again_after_30_
     day2 = datetime(2026, 1, 2)
     day_after_30_more = datetime(2026, 2, 1)
 
-    poll1 = get_significant(_cache_item(), history, day1)
-    poll2 = get_significant(_cache_item(), history, day2)
-    poll3 = get_significant(_cache_item(), history, day_after_30_more)
+    poll1 = get_significant(_connection(), history, day1)
+    poll2 = get_significant(_connection(), history, day2)
+    poll3 = get_significant(_connection(), history, day_after_30_more)
 
     assert poll1 is not None
     assert REASON_NEW_COUNTRY in poll1["reasons"]


### PR DESCRIPTION
## Summary

- clarify snapshot connection terminology
- align Insights with mapped public connections
- update connection and Insights architecture documentation
- update Help to clarify mapped activity in Insights and Daily Activity Report

## Details

- remove obsolete `cache_items` and `map_candidates` terminology
- keep mapped and unmapped PUBLIC connections in their respective session state
- evaluate significance for both mapped and unmapped PUBLIC connections
- build Insights only from mapped PUBLIC connections
- keep Insights processing after the per-connection analysis loop
- document ConnectionState, UnmappedState, SignificanceHistory and SignificantConnections

## Testing

- `ruff check .`
- `python -m pytest -q` — 612 passed, 2 skipped
- `git diff --check`
- manual Windows test
