### PR TITLE
fix: make toggle menu behavior consistent

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -143,7 +143,7 @@ class TapMap:
         }
     )
     MENU_COMMANDS: ClassVar[frozenset[str]] = frozenset(
-        {"menu_clear_cache", "menu_export_cache", "menu_autostart"}
+        {"menu_clear_cache", "menu_export_cache"}
     )
 
     MIN_FLASH_S = 3.0
@@ -928,7 +928,7 @@ class TapMap:
                 new_value = not bool(insights_on)
                 self.settings = replace(self.settings, insights_panel=new_value)
                 self._save_settings()
-                return False, new_value, no_update
+                return no_update, new_value, no_update
 
             if trigger == "menu_technical_details" or (
                 trigger == "key_action"
@@ -938,7 +938,7 @@ class TapMap:
                 new_value = not bool(technical_details_on)
                 self.settings = replace(self.settings, technical_details=new_value)
                 self._save_settings()
-                return False, no_update, new_value
+                return no_update, no_update, new_value
 
             next_state = compute_menu_open_state(
                 trigger=trigger,
@@ -1301,7 +1301,11 @@ class TapMap:
             return "act" if n_clicks else "ignore"
 
         if trigger == "key_action":
-            if isinstance(key_action, dict) and key_action.get("action") == "menu_autostart":
+            if (
+                menu_open
+                and isinstance(key_action, dict)
+                and key_action.get("action") == "menu_autostart"
+            ):
                 return "act"
             return "ignore"
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -525,15 +525,26 @@ def test_autostart_trigger_kind_button_click_is_act() -> None:
     )
 
 
-def test_autostart_trigger_kind_r_keyboard_mnemonic_is_act() -> None:
-    """Treat the R shortcut as an autostart action."""
+def test_autostart_trigger_kind_r_keyboard_mnemonic_is_act_when_menu_open() -> None:
+    """Treat the R shortcut as an autostart action while the menu is open."""
+    kind = TapMap._autostart_trigger_kind(
+        trigger="key_action",
+        menu_open=True,
+        n_clicks=None,
+        key_action={"action": "menu_autostart", "t": "2026-01-01T00:00:00"},
+    )
+    assert kind == "act"
+
+
+def test_autostart_trigger_kind_r_keyboard_ignored_when_menu_closed() -> None:
+    """Ignore the R shortcut while the menu is closed."""
     kind = TapMap._autostart_trigger_kind(
         trigger="key_action",
         menu_open=False,
         n_clicks=None,
         key_action={"action": "menu_autostart", "t": "2026-01-01T00:00:00"},
     )
-    assert kind == "act"
+    assert kind == "ignore"
 
 
 def test_autostart_trigger_kind_unrelated_key_action_is_ignored() -> None:
@@ -545,6 +556,13 @@ def test_autostart_trigger_kind_unrelated_key_action_is_ignored() -> None:
         key_action={"action": "menu_help", "t": "2026-01-01T00:00:00"},
     )
     assert kind == "ignore"
+
+
+def test_autostart_is_not_a_menu_closing_command() -> None:
+    """Do not close the menu when autostart is toggled, unlike one-shot commands."""
+    assert "menu_autostart" not in TapMap.MENU_COMMANDS
+    assert "menu_clear_cache" in TapMap.MENU_COMMANDS
+    assert "menu_export_cache" in TapMap.MENU_COMMANDS
 
 
 def test_autostart_trigger_kind_menu_opening_is_refresh() -> None:


### PR DESCRIPTION
## Summary

- Keep the menu open when toggling Insights or Technical details
- Keep the menu open when toggling autostart
- Ignore the R shortcut when the menu is closed

## Testing

- `ruff check .`
- `pytest` — 808 passed, 6 skipped
- Manual verification of I, T, and R behavior on Windows