### PR TITLE
fix: add modal loading state

### DIFF
--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -1346,23 +1346,68 @@ class TapMap:
             Output("modal_overlay", "className"),
             Output("modal_body", "children"),
             Output("modal_body", "className"),
+            Output("modal_content_request", "data"),
             Input("modal_state", "data"),
             Input("geodb_event", "data"),
+            prevent_initial_call=False,
+        )
+        def modal_shell(
+            modal_state_data: Any,
+            geodb_event_data: Any,
+        ):
+            """Open or close the modal and show its loading state."""
+            is_open = isinstance(modal_state_data, dict)
+            overlay_class = self._modal_overlay_class(is_open)
+
+            if not is_open:
+                return overlay_class, [], "modal-body", no_update
+
+            screen = modal_state_data.get("screen")
+            if screen == "menu_exit":
+                body_class = "modal-body no-close"
+            else:
+                body_class = (
+                    self._class_for_modal_screen(screen)
+                    if isinstance(screen, str)
+                    else "modal-body"
+                )
+
+            placeholder = html.Div(
+                html.Div(className="mx-spinner"),
+                className="mx-modal-loading",
+            )
+
+            content_request = {
+                "modal_state": modal_state_data,
+                "geodb_event": geodb_event_data,
+            }
+
+            return overlay_class, [placeholder], body_class, content_request
+
+        @self.app.callback(
+            # Replace the loading placeholder with the rendered content.
+            Output("modal_body", "children", allow_duplicate=True),
+            Input("modal_content_request", "data"),
             State("ui_view", "data"),
             State("model_snapshot", "data"),
             State("technical_details_on", "data"),
-            prevent_initial_call=False,
+            prevent_initial_call=True,
         )
-        def modal_renderer(
-            modal_state_data: Any,
-            geodb_event_data: Any,
+        def modal_content_renderer(
+            content_request: Any,
             ui_view: Any,
             snapshot: Any,
             technical_details_data: Any,
         ):
+            """Render the current modal screen's real content into modal_body."""
+            if not isinstance(content_request, dict):
+                raise PreventUpdate
+
+            modal_state_data = content_request.get("modal_state")
+            geodb_event_data = content_request.get("geodb_event")
             geo_path = str(self.runtime.geo_data_dir)
 
-            children, body_class = self._render_modal(
+            children, _body_class = self._render_modal(
                 modal_state_data,
                 snapshot,
                 ui_view,
@@ -1371,11 +1416,7 @@ class TapMap:
                 bool(technical_details_data),
             )
 
-            overlay_class = self._modal_overlay_class(
-                isinstance(modal_state_data, dict)
-            )
-
-            return overlay_class, children, body_class
+            return children
         
     def _register_modal_callbacks(self) -> None:
         @self.app.callback(

--- a/src/tapmap/assets/styles.css
+++ b/src/tapmap/assets/styles.css
@@ -878,6 +878,30 @@ summary.mx-acc-header:hover {
   opacity: 0.8;
 }
 
+/* Modal loading placeholder */
+
+.mx-modal-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.mx-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(0, 255, 102, 0.25);
+  border-top-color: var(--mx-green);
+  border-radius: 50%;
+  animation: mx-spin 0.7s linear infinite;
+}
+
+@keyframes mx-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Status bar */
 
 .status-bar {

--- a/src/tapmap/ui/layout_view.py
+++ b/src/tapmap/ui/layout_view.py
@@ -53,6 +53,8 @@ def render_layout(
             dcc.Store(id="status_cache", data=status_cache_store),
             dcc.Store(id="ui_view", data={"points": [], "summaries": {}, "details": {}}),
             dcc.Store(id="modal_state", data=initial_modal_state),
+            # Triggers modal content rendering after the loading state is shown.
+            dcc.Store(id="modal_content_request", data=None),
             dcc.Store(id="open_ports_prefs", data={"show_system": False}),
             dcc.Download(id="cache_download"),
             html.Div(


### PR DESCRIPTION
## Summary

- show modal windows immediately with a loading spinner
- render modal content after the loading state is visible
- replace the loading state completely when content is ready
- keep existing GeoIP operation loading indicators unchanged

## Testing

- `ruff check .`
- `pytest` — 808 passed, 6 skipped
- manually verified modal loading behavior on Windows