### PR TITLE
fix: pin Dash to avoid renderer regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ MIT License
 
 Many thanks to the community members who reported bugs, tested pre-release builds, and suggested improvements.
 
+- @sersora0986 for reporting the Dash renderer performance issue and testing diagnostic builds to help identify the cause.
+
 - @faxotherapy for reporting macOS compatibility issues and testing Intel builds.  
 - @nafarinha for confirming architecture support and validating macOS behavior.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2026.7.22
-dash==4.4.1
+dash==4.1.0
 keyring==25.7.0
 maxminddb==3.1.1
 Pillow==12.3.0


### PR DESCRIPTION
## Summary

- Pin Dash to 4.1.0 to avoid the renderer performance regression introduced in Dash 4.2.0.
- Thank @sersora0986 for reporting the issue and testing diagnostic builds.

## Details

Issue #183 was reproduced with Dash 4.2.0 and 4.4.1, where the browser renderer can saturate one CPU core and become unresponsive.

A diagnostic build with Dash 4.0.0 did not reproduce the problem. Upstream source changes place the relevant behavior change between Dash 4.1.0 and 4.2.0.

Dash 4.1.0 is pinned until an upstream release containing the renderer fix is available and verified.

## Testing

- `pytest` — 814 passed, 6 skipped
- `ruff check .`
- Manual Windows test with Dash 4.1.0