### PR TITLE
fix: handle missing PID in Significant Connections

### DIFF
--- a/src/tapmap/state/modal.py
+++ b/src/tapmap/state/modal.py
@@ -141,12 +141,17 @@ def _decide_row_click(
         "t": now_iso,
         "payload": {
             "timestamp": trigger.get("timestamp"),
-            "pid": trigger.get("pid"),
+            "pid": _decode_row_id_pid(trigger.get("pid")),
             "ip": trigger.get("ip"),
             "port": trigger.get("port"),
             "proto": trigger.get("proto"),
         },
     }
+
+
+def _decode_row_id_pid(pid: Any) -> int | None:
+    """Decode a row ID PID to its domain value."""
+    return None if pid == "" else int(pid)
 
 def decide_modal_route(
     *,

--- a/src/tapmap/ui/significant_connections_view.py
+++ b/src/tapmap/ui/significant_connections_view.py
@@ -70,13 +70,18 @@ def _build_row(event: dict[str, Any]) -> html.Tr:
         id={
             "type": "sc_row",
             "timestamp": event.get("timestamp"),
-            "pid": event.get("pid"),
+            "pid": _encode_row_id_pid(event.get("pid")),
             "ip": event.get("ip"),
             "port": event.get("port"),
             "proto": event.get("proto"),
         },
         n_clicks=0,
     )
+
+
+def _encode_row_id_pid(pid: Any) -> str:
+    """Encode a PID for a Dash row ID. Dash does not accept None as an ID value."""
+    return "" if pid is None else str(pid)
 
 
 def _format_timestamp(timestamp: Any) -> str:

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -217,6 +217,44 @@ def test_decide_row_click_returns_modal_state_for_a_row_click() -> None:
     }
 
 
+def test_decide_row_click_decodes_a_present_pid_from_its_string_row_id() -> None:
+    """Decode a present row ID PID to an integer."""
+    trigger = {
+        "type": "sc_row",
+        "timestamp": "2026-08-23T18:42:16.013313",
+        "pid": "7920",
+        "ip": "8.8.8.8",
+        "port": 443,
+        "proto": "tcp",
+    }
+
+    result = _decide_row_click(
+        trigger=trigger,
+        now_iso="2026-03-10T10:00:00",
+    )
+
+    assert result["payload"]["pid"] == 7920
+
+
+def test_decide_row_click_decodes_an_absent_pid_back_to_none() -> None:
+    """Decode an absent row ID PID to None."""
+    trigger = {
+        "type": "sc_row",
+        "timestamp": "2026-09-09T10:47:48.786605",
+        "pid": "",
+        "ip": "2620:2d:4002:1::1061",
+        "port": 80,
+        "proto": "tcp",
+    }
+
+    result = _decide_row_click(
+        trigger=trigger,
+        now_iso="2026-03-10T10:00:00",
+    )
+
+    assert result["payload"]["pid"] is None
+
+
 def test_decide_map_click_returns_none_for_non_map_trigger() -> None:
     """Ignore non-map triggers."""
     result = _decide_map_click(

--- a/tests/test_significant_connections_view.py
+++ b/tests/test_significant_connections_view.py
@@ -184,6 +184,13 @@ def test_location_with_neither_shows_globe_and_unknown_place_name() -> None:
     assert _cell_text(_rows(table)[0].children[2]) == "🌐 Unknown place name"
 
 
+def test_row_id_encodes_a_missing_pid_as_empty_string_not_none() -> None:
+    """Encode a missing PID as an empty string."""
+    table = _table([_event(pid=None)])
+
+    assert _rows(table)[0].id["pid"] == ""
+
+
 def test_network_operator_and_application_show_persisted_values() -> None:
     """Network operator and Application cells show asn_org and app_name verbatim."""
     table = _table([_event(asn_org="Google LLC", app_name="Chrome")])


### PR DESCRIPTION
## Summary

- handle Significant Connections where the process PID is unavailable
- keep Dash row IDs valid when `pid` is `None`
- restore the original PID value when opening connection details
- add regression tests for missing PID handling

## Testing

- `ruff check .`
- `pytest` — 817 passed, 6 skipped
