### PR TITLE
feat: add MQTT notifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The map is the primary user experience. Additional functionality is exposed thro
 
 TapMap runs entirely on the local machine.
 
-Network activity data is not sent to external services.
+Network activity data is processed locally unless the user explicitly configures an external integration such as MQTT.
 
 GeoIP lookups use local databases.
 
@@ -294,6 +294,15 @@ ConnectionAnalyzer
        │      │
        │      ▼
        │   significant? ──▶ SignificantConnections ──▶ significant_connections.json
+       │                         │
+       │                         ▼
+       │                  notification policy
+       │                         │
+       │                         ▼
+       │                dispatch_notification()
+       │                         │
+       │                         ▼
+       │                notification channels
        │
        ▼  (after the loop; mapped PUBLIC connections only)
 
@@ -318,6 +327,10 @@ Significant Connections evaluation runs per connection, inside the same loop tha
 Insights is a separate, batch-updated structure: after the per-connection loop completes, process_insights() updates the rolling 30-day Insights history using only the mapped PUBLIC connections observed in that poll. Unmapped PUBLIC connections are evaluated for significance but do not contribute to Insights.
 
 Historical state survives application restarts.
+
+Notification handling is separate from Significant Connections history. A newly accepted Significant Connection is stored first, then evaluated against the notification policy. Eligible events are passed to `dispatch_notification()`, which sends them independently to the configured notification channels. Significant Connections history is not a notification queue, and notification failures do not affect event storage or other channels.
+
+`MqttChannel` owns the MQTT client and its network lifecycle, including connection and reconnection. MQTT callbacks do not modify ConnectionAnalyzer, SignificantConnections, Insights, or UI state.
 
 ---
 
@@ -404,6 +417,7 @@ The following boundaries should be preserved:
 - GeoIP database management remains isolated in geodb
 - historical state remains separate from session state
 - tray/lifecycle code does not directly access or manipulate model/state-owned application state
+- notification channels do not modify analyzer, historical, or UI state
 
 ---
 
@@ -416,11 +430,14 @@ src/tapmap/
 ├── runtime.py      Runtime initialization
 ├── lifecycle.py    Shutdown coordination and the tray run loop
 ├── tray.py         System tray icon and menu
+├── mqtt_cli.py     MQTT configuration CLI
+├── mqtt_config.py  MQTT configuration and persistence
 │
 ├── model/          Network collection and GeoIP enrichment
 ├── state/          Application state and decision logic
 ├── ui/             Dash and Plotly rendering
 ├── geodb/          GeoIP database management
+├── notifications/  Notification channels and dispatch
 ├── autostart/      Per-platform login autostart integration
 │
 └── assets/         Static Dash assets
@@ -462,6 +479,7 @@ During startup:
 - [Docker](docs/docker.md)
 - [GeoIP Database Management](docs/geodb-management.md)
 - [Environment Variables](docs/environment-variables.md)
+- [MQTT](docs/mqtt.md)
 - [Backend Testing](docs/backend-testing.md)
 - [Application Information](docs/application-information.md)
 - [AppInfo Performance](docs/appinfo-performance.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### Features
+
+- Add MQTT notifications for Significant Connections
+  - Configure MQTT with `tapmap --configure-mqtt`
+  - Support TLS and optional authentication
+  - Delay notifications until the configurable Insights learning period is complete
+
 ### Fixes
 
 - Handle Significant Connections when the process PID is unavailable

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -3,12 +3,13 @@
 TapMap is designed to protect your privacy.
 
 - TapMap processes network connection data locally on your computer.
-- No connection data, analytics, telemetry, or personal information is transmitted to the developer or any third party.
+- TapMap does not transmit connection data unless explicitly configured by the user. TapMap does not send analytics or telemetry.
 - Geolocation is performed using local GeoIP databases stored on your computer.
 - By default, TapMap queries a public IP lookup service to obtain your public IP address and estimate your location. This is used only to display the approximate origin of connections on the map. This request can be disabled by specifying your location manually.
 - GeoIP databases are downloaded or updated only when explicitly requested by the user.
 - TapMap stores a local `insights.json` file containing a rolling 30-day aggregate history of countries, autonomous systems (ASNs), ports, and application names. It does not contain IP addresses, process IDs, or executable paths.
 - TapMap stores a local `significant_connections.json` file containing the most recent 500 individual connection events judged significant. These events include connection, process, application, verification, geographic, and network provider information, including remote IP addresses and executable paths.
 - These files are stored only on your computer and are never transmitted or shared by TapMap.
+- If MQTT notifications are configured, TapMap publishes new notification-eligible Significant Connection data to the MQTT broker configured by the user. The executable path is not included.
 
-TapMap does not collect, sell, or share user data.
+TapMap does not collect or sell user data.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ TapMap makes this visible so you can:
 - Nearby locations highlighted when multiple connections overlap
 - Insights panel showing new and frequent activity over time
 - Significant Connections history of new applications, countries, network operators, ports, and failed verification
+- MQTT notifications for new Significant Connections
 - Daily Activity Report with application patterns, provider analysis, and activity timelines
 - Unmapped public services with missing geolocation
 - Established LAN and LOCAL services
@@ -129,9 +130,23 @@ To build a complete activity history, keep TapMap running while your system is i
 
 ---
 
+## Significant Connections and notifications
+
+Significant Connections records new applications, countries, network operators, remote ports, and failed application verification.
+
+Open **Significant Connections** from the **INSIGHTS** menu or press **S** to view up to 500 recent events.
+
+TapMap can publish new Significant Connections to an MQTT broker. Run the configuration wizard to set up the connection:
+
+    tapmap --configure-mqtt
+
+See [MQTT](https://olalie.github.io/tapmap/mqtt/) for details.
+
+---
+
 ## How it works
 
-TapMap follows a simple local pipeline:
+TapMap's live map follows a simple local pipeline:
 
     socket scan → IP extraction → GeoIP lookup → map rendering
 
@@ -183,6 +198,7 @@ Additional documentation:
 - [Application Information](https://olalie.github.io/tapmap/application-information/)
 - [GeoIP Database Management](https://olalie.github.io/tapmap/geodb-management/)
 - [Environment Variables](https://olalie.github.io/tapmap/environment-variables/)
+- [MQTT](https://olalie.github.io/tapmap/mqtt/)
 - [Docker](https://olalie.github.io/tapmap/docker/)
 - [Backend Testing](https://olalie.github.io/tapmap/backend-testing/)
 - [Privacy Policy](https://olalie.github.io/tapmap/privacy/)
@@ -252,7 +268,7 @@ Inspect connections that could not be geolocated and therefore do not appear on 
 
 ## Privacy
 
-TapMap is designed to protect your privacy. It processes network connection data locally, does not transmit connection data, telemetry, analytics, or personal information, and performs geolocation using local GeoIP databases.
+TapMap is designed to protect your privacy. It processes network connection data locally, does not send telemetry or analytics, and performs geolocation using local GeoIP databases. If MQTT notifications are configured, Significant Connection data is published to the configured MQTT broker.
 
 For details, see [PRIVACY.md](PRIVACY.md).
 
@@ -285,6 +301,8 @@ Command-line options:
     tapmap -v
 
     tapmap --no-browser
+
+    tapmap --configure-mqtt
 
 ---
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -75,6 +75,27 @@ A common example is changing the default port:
 
 See [Environment Variables](environment-variables.md) for details.
 
+## MQTT
+
+To configure MQTT, run the configuration wizard with the same data directory mounted to `/data`:
+
+```bash
+docker run --rm -it \
+  --network host \
+  -v ~/tapmap-data:/data \
+  -e TAPMAP_IN_DOCKER=1 \
+  olalie/tapmap:latest \
+  tapmap --configure-mqtt
+```
+
+The MQTT configuration is stored in `/data/mqtt.json` and persists in the mounted host directory.
+
+Unlike desktop installations, Docker stores MQTT credentials in `mqtt.json`. The file is created with permissions `0600`.
+
+The broker must be specified by IPv4 or IPv6 address. Hostnames, including `localhost`, are not supported.
+
+See [MQTT](mqtt.md) for MQTT configuration and notification behavior.
+
 ## Process information
 
 TapMap always shows network activity.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -158,3 +158,29 @@ TAPMAP_CACHE_RETENTION_MIN=15 tapmap
 This setting affects only the map cache.
 
 It does not affect the current network snapshot, Open Ports, LAN/LOCAL Services, Unmapped Services, or the 30-day Insights history.
+
+## TAPMAP_NOTIFICATION_LEARNING_DAYS
+
+Control how many active Insights days TapMap waits before sending notifications.
+
+Default:
+
+```text
+7
+```
+
+Values:
+
+```text
+0–30
+```
+
+A value of `0` enables notifications immediately.
+
+Example:
+
+```bash
+TAPMAP_NOTIFICATION_LEARNING_DAYS=0 tapmap
+```
+
+The learning period affects notifications only. Significant Connections are recorded during the learning period.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -20,6 +20,8 @@ The wizard configures:
 - TLS
 - Optional username and password
 
+The broker address must be an IPv4 or IPv6 address. Hostnames, including `localhost`, are not supported so TapMap does not perform DNS lookups when connecting to the broker. The same restriction applies to manually edited `mqtt.json` files.
+
 The default port is `1883` without TLS and `8883` with TLS.
 
 The default topic is:

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -14,7 +14,7 @@ tapmap --configure-mqtt
 
 The wizard configures:
 
-- Broker hostname
+- Broker IP address
 - Port
 - Topic
 - TLS

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1,0 +1,86 @@
+# MQTT
+
+TapMap can publish new Significant Connections to an MQTT broker.
+
+MQTT notifications are optional and are enabled when an MQTT connection is configured.
+
+## Configure MQTT
+
+Run the configuration wizard:
+
+```text
+tapmap --configure-mqtt
+```
+
+The wizard configures:
+
+- Broker hostname
+- Port
+- Topic
+- TLS
+- Optional username and password
+
+The default port is `1883` without TLS and `8883` with TLS.
+
+The default topic is:
+
+```text
+tapmap/significant_connections
+```
+
+Using authentication without TLS sends the MQTT credentials without encryption. TapMap warns before saving this configuration.
+
+## Notification behavior
+
+Significant Connections are recorded independently of MQTT notifications.
+
+By default, notifications start after 7 active Insights days. Set `TAPMAP_NOTIFICATION_LEARNING_DAYS` to a value from `0` to `30` to change the learning period. A value of `0` enables notifications immediately.
+
+Each new notification-eligible Significant Connection is published as one MQTT message.
+
+Messages use QoS 0 and are not retained. Delivery is best effort; TapMap does not maintain a retry queue.
+
+TapMap reconnects automatically if the MQTT connection is interrupted.
+
+## Configuration and credentials
+
+MQTT settings are stored in `mqtt.json` in the TapMap application data directory.
+
+On desktop installations, MQTT credentials are stored separately in the operating system keyring and are not written to `mqtt.json`.
+
+Docker stores both the MQTT settings and credentials in `/data/mqtt.json`. See [Docker](docker.md) for Docker-specific configuration.
+
+## Message format
+
+Each MQTT message contains the Significant Connection data as JSON.
+
+The executable path is not included because it may contain the operating system username.
+
+Example:
+
+```json
+{
+  "timestamp": "2026-09-09T22:34:39.248916",
+  "reasons": ["new_country", "new_provider"],
+  "pid": 889,
+  "proto": "tcp",
+  "ip": "154.118.230.167",
+  "port": 443,
+  "service": "https",
+  "lat": -6.1749,
+  "lon": 35.7356,
+  "process_name": "firefox",
+  "city": "Dodoma",
+  "country": "Tanzania",
+  "country_code": "TZ",
+  "asn": 327795,
+  "asn_org": "e-Government Authority",
+  "app_name": "Firefox",
+  "app_creator": "Mozilla Corporation",
+  "app_verification_status": "verified",
+  "app_signature_state": "DeveloperSigned",
+  "app_signature_state_details": "Notarized"
+}
+```
+
+Fields without a value are published as JSON `null`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Application Information: application-information.md
       - GeoDB Management: geodb-management.md
       - Environment Variables: environment-variables.md
+      - MQTT: mqtt.md
       - Docker: docker.md
 
   - Developer Guide:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2026.7.22
 dash==4.1.0
 keyring==25.7.0
 maxminddb==3.1.1
+paho-mqtt==2.1.0
 Pillow==12.3.0
 plotly==6.9.0
 psutil==7.2.2

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -96,6 +96,7 @@ from .app_dirs import open_folder, reveal_in_file_manager
 from .config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
 from .lifecycle import LifecycleCoordinator, start_server_thread
 from .logging_config import configure_logging
+from .mqtt_cli import run_configure_mqtt
 from .runtime import AppMeta, RuntimeContext, build_runtime
 from .tray import create_tray_icon
 
@@ -1894,6 +1895,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Do not open the web browser automatically at startup.",
     )
+    parser.add_argument(
+        "--configure-mqtt",
+        action="store_true",
+        help="Interactively configure, update, or remove MQTT notifications, then exit.",
+    )
     return parser
 
 
@@ -1901,6 +1907,10 @@ def main(argv: list[str] | None = None) -> int:
     """Run application from the command line."""
     args = _build_arg_parser().parse_args(argv)
     runtime_ctx = build_runtime(APP_META, no_browser=args.no_browser)
+
+    if args.configure_mqtt:
+        return run_configure_mqtt(runtime_ctx)
+
     configure_logging(runtime_ctx)
     app = TapMap(runtime_ctx)
     try:

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -34,6 +34,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, TypedDict
 
+import dash
 import psutil
 from dash import ALL, Dash, Input, Output, State, ctx, dcc, html, no_update
 from dash.exceptions import PreventUpdate
@@ -97,6 +98,7 @@ from .config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
 from .lifecycle import LifecycleCoordinator, start_server_thread
 from .logging_config import configure_logging
 from .mqtt_cli import run_configure_mqtt
+from .mqtt_config import load_mqtt_config, mqtt_config_path
 from .notifications.mqtt import create_mqtt_channel
 from .runtime import AppMeta, RuntimeContext, build_runtime
 from .tray import create_tray_icon
@@ -379,8 +381,8 @@ class TapMap:
 
     def _build_runtime_info(self) -> dict[str, Any]:
         geo_status = self.geodb.local_status()
+        mqtt_config = load_mqtt_config(mqtt_config_path(self.runtime.app_data_dir))
         return {
-            "version": self.runtime.meta.version,
             "poll_interval_ms": POLL_INTERVAL_MS,
             "coord_precision": COORD_PRECISION,
             "zoom_near_km": ZOOM_NEAR_KM,
@@ -407,7 +409,14 @@ class TapMap:
             "cache_retention_min": self.runtime.cache_retention_min,
             "is_docker": self.runtime.is_docker,
             "geo_provider": geo_status["provider"],
-            "geo_database_date": geo_status["local_display_date"]
+            "geo_database_date": geo_status["local_display_date"],
+            "notification_learning_days": self.runtime.notification_learning_days,
+            "mqtt_configured": mqtt_config is not None,
+            "mqtt_host": mqtt_config.host if mqtt_config else None,
+            "mqtt_port": mqtt_config.port if mqtt_config else None,
+            "mqtt_topic": mqtt_config.topic if mqtt_config else None,
+            "mqtt_tls": mqtt_config.tls if mqtt_config else None,
+            "dash_version": getattr(dash, "__version__", "-"),
         }
 
     def _reload_geodb_runtime(self) -> bool:

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -97,6 +97,7 @@ from .config import COORD_PRECISION, MY_LOCATION, POLL_INTERVAL_MS, ZOOM_NEAR_KM
 from .lifecycle import LifecycleCoordinator, start_server_thread
 from .logging_config import configure_logging
 from .mqtt_cli import run_configure_mqtt
+from .notifications.mqtt import create_mqtt_channel
 from .runtime import AppMeta, RuntimeContext, build_runtime
 from .tray import create_tray_icon
 
@@ -223,12 +224,15 @@ class TapMap:
         # the loaded InsightsState, and ConnectionAnalyzer references the
         # already-loaded SignificantConnections.
         self.significance_history = SignificanceHistory.from_insights_state(self.insights_state)
+        self.mqtt_channel = create_mqtt_channel(self.runtime)
+        notification_channels = [self.mqtt_channel] if self.mqtt_channel is not None else []
         self.connection_analyzer = ConnectionAnalyzer(
             self.connection_state,
             self.unmapped_state,
             self.insights_state.insights,
             self.significant_connections,
             self.significance_history,
+            notification_channels=notification_channels,
             notification_learning_days=self.runtime.notification_learning_days,
         )
 
@@ -1875,6 +1879,8 @@ class TapMap:
         appinfo_close_fn = getattr(self.model.appinfo, "close", None)
         if callable(appinfo_close_fn):
             appinfo_close_fn()
+        if self.mqtt_channel is not None:
+            self.mqtt_channel.close()
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/src/tapmap/app.py
+++ b/src/tapmap/app.py
@@ -228,6 +228,7 @@ class TapMap:
             self.insights_state.insights,
             self.significant_connections,
             self.significance_history,
+            notification_learning_days=self.runtime.notification_learning_days,
         )
 
         self.settings_path = self.runtime.app_data_dir / "settings.json"

--- a/src/tapmap/config.py
+++ b/src/tapmap/config.py
@@ -42,3 +42,10 @@ ZOOM_NEAR_KM: Final[float] = 25.0
 
 Locations within this distance are shown in yellow.
 """
+
+NOTIFICATION_LEARNING_DAYS: Final[int] = 7
+"""Distinct active Insights days required before Significant Connections notify.
+
+Counted from the 30-day Insights history (distinct days with any observed
+activity), not calendar days elapsed.
+"""

--- a/src/tapmap/config.py
+++ b/src/tapmap/config.py
@@ -44,8 +44,4 @@ Locations within this distance are shown in yellow.
 """
 
 NOTIFICATION_LEARNING_DAYS: Final[int] = 7
-"""Distinct active Insights days required before Significant Connections notify.
-
-Counted from the 30-day Insights history (distinct days with any observed
-activity), not calendar days elapsed.
-"""
+"""Distinct active Insights days required before notifications begin."""

--- a/src/tapmap/mqtt_cli.py
+++ b/src/tapmap/mqtt_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import getpass
+import ipaddress
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -49,7 +50,7 @@ def run_configure_mqtt(
             output("MQTT disabled.")
             return 0
 
-    host = _prompt_required(prompt, output, "Host", default=existing.host if existing else None)
+    host = _prompt_host(prompt, output, default=existing.host if existing else None)
     tls = _prompt_yes_no(prompt, output, "Use TLS?", default=existing.tls if existing else False)
     port = _prompt_port(prompt, output, default=_derive_default_port(existing, tls))
     topic = _prompt_required(
@@ -190,6 +191,29 @@ def _prompt_required(
         if default:
             return default
         output(f"{label} is required.")
+
+
+def _prompt_host(
+    prompt: Callable[[str], str],
+    output: Callable[[str], None],
+    *,
+    default: str | None = None,
+) -> str:
+    """Prompt for a literal IP address; blank input accepts the default, if any."""
+    suffix = f" [{default}]" if default else ""
+    while True:
+        answer = prompt(f"Broker IP address{suffix}: ").strip()
+        if not answer:
+            if default:
+                return default
+            output("Broker IP address is required.")
+            continue
+        try:
+            ipaddress.ip_address(answer)
+        except ValueError:
+            output("Enter a literal IP address, not a hostname.")
+            continue
+        return answer
 
 
 def _prompt_port(

--- a/src/tapmap/mqtt_cli.py
+++ b/src/tapmap/mqtt_cli.py
@@ -1,9 +1,4 @@
-"""Interactive `tapmap --configure-mqtt` command.
-
-Single entry point for creating, updating, and removing the MQTT
-configuration. Never accepts credentials as command-line arguments - the
-password is always read through an interactive, non-echoing prompt.
-"""
+"""Configure MQTT notifications interactively."""
 
 from __future__ import annotations
 
@@ -37,7 +32,7 @@ def run_configure_mqtt(
     prompt_secret: Callable[[str], str] = getpass.getpass,
     output: Callable[[str], None] = print,
 ) -> int:
-    """Run the interactive MQTT configuration flow. Returns a process exit code."""
+    """Run interactive MQTT configuration and return the process exit code."""
     path = mqtt_config_path(runtime.app_data_dir)
     existing = load_mqtt_config(path)
 
@@ -109,16 +104,7 @@ def _prompt_credentials(
     runtime: RuntimeContext,
     existing: MqttConfig | None,
 ) -> tuple[str | None, str | None, bool, Callable[[], None] | None]:
-    """Run the auth yes/no gate and, if enabled, the keep/replace/collect flow.
-
-    Returns (username, password, use_auth, deferred_credential_action).
-    username/password are the values to embed in the saved MqttConfig -
-    always (None, None) on desktop, since desktop credentials live in the
-    OS keyring instead. deferred_credential_action, when not None, is the
-    keyring mutation (set or clear) the caller must run only after the
-    configuration has actually been saved - this function itself never
-    touches the keyring, so a failed or declined save leaves it untouched.
-    """
+    """Collect MQTT authentication settings and defer desktop credential changes."""
     if runtime.is_docker:
         existing_username = existing.username if existing else None
         existing_password = existing.password if existing else None
@@ -157,15 +143,7 @@ def _prompt_credentials(
 
 
 def _derive_default_port(existing: MqttConfig | None, tls: bool) -> int:
-    """Return the port to propose as the default for the given TLS answer.
-
-    Fresh setup: the standard port for tls (1883/8883). Reconfiguring:
-    the existing port is preserved, unless it exactly matches the standard
-    port for the *previous* TLS setting and TLS has just changed - in that
-    case the existing port was almost certainly never customized, so the
-    standard port for the new TLS setting is proposed instead. A genuinely
-    custom port (one that doesn't match the old standard) is always kept.
-    """
+    """Return the default port for the selected TLS setting and existing configuration."""
     if existing is None:
         return DEFAULT_PORT_TLS if tls else DEFAULT_PORT_PLAIN
 

--- a/src/tapmap/mqtt_cli.py
+++ b/src/tapmap/mqtt_cli.py
@@ -1,0 +1,235 @@
+"""Interactive `tapmap --configure-mqtt` command.
+
+Single entry point for creating, updating, and removing the MQTT
+configuration. Never accepts credentials as command-line arguments - the
+password is always read through an interactive, non-echoing prompt.
+"""
+
+from __future__ import annotations
+
+import getpass
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from .mqtt_config import (
+    MqttConfig,
+    clear_credentials,
+    delete_mqtt_config,
+    get_stored_credentials,
+    load_mqtt_config,
+    mqtt_config_path,
+    save_mqtt_config,
+    set_credentials,
+)
+
+if TYPE_CHECKING:
+    from .runtime import RuntimeContext
+
+DEFAULT_TOPIC = "tapmap/significant_connections"
+DEFAULT_PORT_PLAIN = 1883
+DEFAULT_PORT_TLS = 8883
+
+
+def run_configure_mqtt(
+    runtime: RuntimeContext,
+    *,
+    prompt: Callable[[str], str] = input,
+    prompt_secret: Callable[[str], str] = getpass.getpass,
+    output: Callable[[str], None] = print,
+) -> int:
+    """Run the interactive MQTT configuration flow. Returns a process exit code."""
+    path = mqtt_config_path(runtime.app_data_dir)
+    existing = load_mqtt_config(path)
+
+    if existing is not None:
+        output(
+            "MQTT is currently configured: "
+            f"host={existing.host}, port={existing.port}, "
+            f"topic={existing.topic}, tls={'on' if existing.tls else 'off'}"
+        )
+        if _prompt_yes_no(prompt, output, "Disable MQTT instead of reconfiguring?", default=False):
+            delete_mqtt_config(path)
+            if not runtime.is_docker:
+                clear_credentials()
+            output("MQTT disabled.")
+            return 0
+
+    host = _prompt_required(prompt, output, "Host", default=existing.host if existing else None)
+    tls = _prompt_yes_no(prompt, output, "Use TLS?", default=existing.tls if existing else False)
+    port = _prompt_port(prompt, output, default=_derive_default_port(existing, tls))
+    topic = _prompt_required(
+        prompt, output, "Topic", default=existing.topic if existing else DEFAULT_TOPIC
+    )
+
+    username, password, use_auth, deferred_credential_action = _prompt_credentials(
+        prompt, prompt_secret, output, runtime=runtime, existing=existing
+    )
+
+    if (
+        use_auth
+        and not tls
+        and not _prompt_yes_no(
+            prompt,
+            output,
+            "Username/password without TLS sends credentials in plaintext "
+            "over the network. Continue?",
+            default=False,
+        )
+    ):
+        output("Not saved.")
+        return 0
+
+    config = MqttConfig(
+        host=host, port=port, topic=topic, tls=tls, username=username, password=password
+    )
+
+    try:
+        save_mqtt_config(path, config)
+    except OSError as exc:
+        output(f"Unable to save MQTT configuration: {exc}")
+        return 1
+
+    # Only mutate the keyring once the configuration itself is confirmed
+    # saved, so a failed save never leaves credentials changed on their own.
+    if deferred_credential_action is not None:
+        deferred_credential_action()
+
+    output(
+        f"MQTT configuration saved: host={host}, port={port}, "
+        f"topic={topic}, tls={'on' if tls else 'off'}"
+    )
+    return 0
+
+
+def _prompt_credentials(
+    prompt: Callable[[str], str],
+    prompt_secret: Callable[[str], str],
+    output: Callable[[str], None],
+    *,
+    runtime: RuntimeContext,
+    existing: MqttConfig | None,
+) -> tuple[str | None, str | None, bool, Callable[[], None] | None]:
+    """Run the auth yes/no gate and, if enabled, the keep/replace/collect flow.
+
+    Returns (username, password, use_auth, deferred_credential_action).
+    username/password are the values to embed in the saved MqttConfig -
+    always (None, None) on desktop, since desktop credentials live in the
+    OS keyring instead. deferred_credential_action, when not None, is the
+    keyring mutation (set or clear) the caller must run only after the
+    configuration has actually been saved - this function itself never
+    touches the keyring, so a failed or declined save leaves it untouched.
+    """
+    if runtime.is_docker:
+        existing_username = existing.username if existing else None
+        existing_password = existing.password if existing else None
+    else:
+        existing_username, existing_password = get_stored_credentials()
+
+    has_existing = bool(existing_username)
+
+    use_auth = _prompt_yes_no(
+        prompt,
+        output,
+        "Use username/password authentication?"
+        + (" (currently configured)" if has_existing else ""),
+        default=has_existing,
+    )
+
+    if not use_auth:
+        if has_existing and not runtime.is_docker:
+            return None, None, False, clear_credentials
+        return None, None, False, None
+
+    if has_existing and _prompt_yes_no(prompt, output, "Keep existing credentials?", default=True):
+        if runtime.is_docker:
+            return existing_username, existing_password, True, None
+        return None, None, True, None
+
+    username = _prompt_required(prompt, output, "Username")
+    output("Input is hidden - nothing will appear as you type.")
+    entered_password = prompt_secret("Password (leave empty for none): ").strip()
+    password = entered_password or None
+
+    if runtime.is_docker:
+        return username, password, True, None
+
+    return None, None, True, lambda: set_credentials(username, password)
+
+
+def _derive_default_port(existing: MqttConfig | None, tls: bool) -> int:
+    """Return the port to propose as the default for the given TLS answer.
+
+    Fresh setup: the standard port for tls (1883/8883). Reconfiguring:
+    the existing port is preserved, unless it exactly matches the standard
+    port for the *previous* TLS setting and TLS has just changed - in that
+    case the existing port was almost certainly never customized, so the
+    standard port for the new TLS setting is proposed instead. A genuinely
+    custom port (one that doesn't match the old standard) is always kept.
+    """
+    if existing is None:
+        return DEFAULT_PORT_TLS if tls else DEFAULT_PORT_PLAIN
+
+    existing_standard_port = DEFAULT_PORT_TLS if existing.tls else DEFAULT_PORT_PLAIN
+    if tls != existing.tls and existing.port == existing_standard_port:
+        return DEFAULT_PORT_TLS if tls else DEFAULT_PORT_PLAIN
+
+    return existing.port
+
+
+def _prompt_yes_no(
+    prompt: Callable[[str], str],
+    output: Callable[[str], None],
+    question: str,
+    *,
+    default: bool,
+) -> bool:
+    """Prompt a yes/no question; blank input accepts the default."""
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        answer = prompt(f"{question} {suffix} ").strip().lower()
+        if not answer:
+            return default
+        if answer in ("y", "yes"):
+            return True
+        if answer in ("n", "no"):
+            return False
+        output("Please answer y or n.")
+
+
+def _prompt_required(
+    prompt: Callable[[str], str],
+    output: Callable[[str], None],
+    label: str,
+    *,
+    default: str | None = None,
+) -> str:
+    """Prompt for required, non-empty text; blank input accepts the default, if any."""
+    suffix = f" [{default}]" if default else ""
+    while True:
+        answer = prompt(f"{label}{suffix}: ").strip()
+        if answer:
+            return answer
+        if default:
+            return default
+        output(f"{label} is required.")
+
+
+def _prompt_port(
+    prompt: Callable[[str], str],
+    output: Callable[[str], None],
+    *,
+    default: int,
+) -> int:
+    """Prompt for a TCP port (1-65535); blank input accepts the default."""
+    while True:
+        answer = prompt(f"Port [{default}]: ").strip()
+        if not answer:
+            return default
+        try:
+            port = int(answer)
+        except ValueError:
+            output("Port must be a number.")
+            continue
+        if 1 <= port <= 65535:
+            return port
+        output("Port must be between 1 and 65535.")

--- a/src/tapmap/mqtt_config.py
+++ b/src/tapmap/mqtt_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import ipaddress
 import json
 import time
 from dataclasses import asdict, dataclass
@@ -49,6 +50,10 @@ def load_mqtt_config(path: Path) -> MqttConfig | None:
         tls = data.get("tls")
 
         if not isinstance(host, str) or not host:
+            return None
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
             return None
         if not isinstance(port, int):
             return None

--- a/src/tapmap/mqtt_config.py
+++ b/src/tapmap/mqtt_config.py
@@ -1,16 +1,4 @@
-"""MQTT configuration and credential storage.
-
-mqtt.json holds the connection settings (host, port, topic, TLS) for both
-desktop and Docker. On desktop, username/password are never written to that
-file - they live in the OS keyring, following the same approach as the
-existing MaxMind credentials (see geodb/maxmind.py). Docker has no usable OS
-keyring, so there username/password are stored in mqtt.json alongside the
-rest of the configuration, protected by file permissions.
-
-Absence of mqtt.json means MQTT is not configured. Nothing here creates it
-automatically; it is written only through the interactive --configure-mqtt
-command (mqtt_cli.py).
-"""
+"""Manage MQTT configuration and credentials."""
 
 from __future__ import annotations
 
@@ -31,12 +19,7 @@ PASSWORD_KEY = "password"
 
 @dataclass(frozen=True)
 class MqttConfig:
-    """Resolved MQTT connection configuration.
-
-    username/password are populated only for the Docker variant of this
-    config; on desktop they are always None here and are stored in the OS
-    keyring instead.
-    """
+    """Represent resolved MQTT connection settings."""
 
     host: str
     port: int
@@ -52,14 +35,7 @@ def mqtt_config_path(app_data_dir: Path) -> Path:
 
 
 def load_mqtt_config(path: Path) -> MqttConfig | None:
-    """Load MqttConfig from a JSON file.
-
-    Args:
-        path: Path to the mqtt.json file.
-
-    Returns:
-        MqttConfig, or None if the file is missing, corrupt, or malformed.
-    """
+    """Load MQTT configuration, or return None if it is missing or invalid."""
     try:
         with path.open(encoding="utf-8") as f:
             data = json.load(f)
@@ -97,19 +73,7 @@ def load_mqtt_config(path: Path) -> MqttConfig | None:
 
 
 def save_mqtt_config(path: Path, config: MqttConfig) -> None:
-    """Save MqttConfig to a JSON file atomically.
-
-    username/password are omitted from the file entirely when None, rather
-    than written as null, so a desktop config (which never sets them) never
-    contains those keys at all.
-
-    Args:
-        path: Path to the mqtt.json file.
-        config: MqttConfig to persist.
-
-    Raises:
-        OSError: If the file cannot be written or replaced.
-    """
+    """Save MQTT configuration atomically with restricted file permissions."""
     data = asdict(config)
     if data["username"] is None:
         del data["username"]
@@ -153,11 +117,7 @@ def get_stored_credentials() -> tuple[str | None, str | None]:
 
 
 def set_credentials(username: str, password: str | None) -> None:
-    """Store the desktop MQTT username/password in the OS keyring.
-
-    A missing/empty password clears any previously stored password rather
-    than storing an empty string, since MQTT allows username-only auth.
-    """
+    """Store desktop MQTT credentials, clearing an empty password."""
     keyring.set_password(KEYRING_SERVICE, USERNAME_KEY, username)
 
     if password:

--- a/src/tapmap/mqtt_config.py
+++ b/src/tapmap/mqtt_config.py
@@ -1,0 +1,178 @@
+"""MQTT configuration and credential storage.
+
+mqtt.json holds the connection settings (host, port, topic, TLS) for both
+desktop and Docker. On desktop, username/password are never written to that
+file - they live in the OS keyring, following the same approach as the
+existing MaxMind credentials (see geodb/maxmind.py). Docker has no usable OS
+keyring, so there username/password are stored in mqtt.json alongside the
+rest of the configuration, protected by file permissions.
+
+Absence of mqtt.json means MQTT is not configured. Nothing here creates it
+automatically; it is written only through the interactive --configure-mqtt
+command (mqtt_cli.py).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import keyring
+
+MQTT_CONFIG_FILENAME = "mqtt.json"
+
+KEYRING_SERVICE = "tapmap_mqtt"
+USERNAME_KEY = "username"
+PASSWORD_KEY = "password"
+
+
+@dataclass(frozen=True)
+class MqttConfig:
+    """Resolved MQTT connection configuration.
+
+    username/password are populated only for the Docker variant of this
+    config; on desktop they are always None here and are stored in the OS
+    keyring instead.
+    """
+
+    host: str
+    port: int
+    topic: str
+    tls: bool
+    username: str | None = None
+    password: str | None = None
+
+
+def mqtt_config_path(app_data_dir: Path) -> Path:
+    """Return the path to mqtt.json for the given app data directory."""
+    return app_data_dir / MQTT_CONFIG_FILENAME
+
+
+def load_mqtt_config(path: Path) -> MqttConfig | None:
+    """Load MqttConfig from a JSON file.
+
+    Args:
+        path: Path to the mqtt.json file.
+
+    Returns:
+        MqttConfig, or None if the file is missing, corrupt, or malformed.
+    """
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            return None
+
+        host = data.get("host")
+        port = data.get("port")
+        topic = data.get("topic")
+        tls = data.get("tls")
+
+        if not isinstance(host, str) or not host:
+            return None
+        if not isinstance(port, int):
+            return None
+        if not isinstance(topic, str) or not topic:
+            return None
+        if not isinstance(tls, bool):
+            return None
+
+        username = data.get("username")
+        password = data.get("password")
+
+        return MqttConfig(
+            host=host,
+            port=port,
+            topic=topic,
+            tls=tls,
+            username=username if isinstance(username, str) else None,
+            password=password if isinstance(password, str) else None,
+        )
+    except Exception:
+        return None
+
+
+def save_mqtt_config(path: Path, config: MqttConfig) -> None:
+    """Save MqttConfig to a JSON file atomically.
+
+    username/password are omitted from the file entirely when None, rather
+    than written as null, so a desktop config (which never sets them) never
+    contains those keys at all.
+
+    Args:
+        path: Path to the mqtt.json file.
+        config: MqttConfig to persist.
+
+    Raises:
+        OSError: If the file cannot be written or replaced.
+    """
+    data = asdict(config)
+    if data["username"] is None:
+        del data["username"]
+    if data["password"] is None:
+        del data["password"]
+
+    tmp_path = path.with_suffix(".tmp")
+
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.flush()
+
+    # Restrict permissions before the file becomes visible at its final path,
+    # since it may contain credentials (the Docker configuration variant).
+    tmp_path.chmod(0o600)
+
+    # The temporary file has been closed. Retry the atomic replace in
+    # case another process briefly locks the destination file.
+    for attempt in range(6):
+        try:
+            tmp_path.replace(path)
+            return
+
+        except OSError:
+            if attempt == 5:
+                raise
+
+            time.sleep(1)
+
+
+def delete_mqtt_config(path: Path) -> None:
+    """Delete mqtt.json if it exists. A no-op if it does not."""
+    path.unlink(missing_ok=True)
+
+
+def get_stored_credentials() -> tuple[str | None, str | None]:
+    """Return the desktop MQTT username/password stored in the OS keyring."""
+    username = keyring.get_password(KEYRING_SERVICE, USERNAME_KEY)
+    password = keyring.get_password(KEYRING_SERVICE, PASSWORD_KEY)
+    return username, password
+
+
+def set_credentials(username: str, password: str | None) -> None:
+    """Store the desktop MQTT username/password in the OS keyring.
+
+    A missing/empty password clears any previously stored password rather
+    than storing an empty string, since MQTT allows username-only auth.
+    """
+    keyring.set_password(KEYRING_SERVICE, USERNAME_KEY, username)
+
+    if password:
+        keyring.set_password(KEYRING_SERVICE, PASSWORD_KEY, password)
+    else:
+        _delete_password_if_present(PASSWORD_KEY)
+
+
+def clear_credentials() -> None:
+    """Remove any stored desktop MQTT username/password from the OS keyring."""
+    _delete_password_if_present(USERNAME_KEY)
+    _delete_password_if_present(PASSWORD_KEY)
+
+
+def _delete_password_if_present(key: str) -> None:
+    """Delete one keyring entry, tolerating it not being present."""
+    with contextlib.suppress(keyring.errors.PasswordDeleteError):
+        keyring.delete_password(KEYRING_SERVICE, key)

--- a/src/tapmap/notifications/__init__.py
+++ b/src/tapmap/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notification channels and dispatch for Significant Connections."""

--- a/src/tapmap/notifications/channel.py
+++ b/src/tapmap/notifications/channel.py
@@ -1,9 +1,4 @@
-"""Channel abstraction and dispatch for notification delivery.
-
-Each channel is an independent output: one channel's failure must never
-prevent another channel from being attempted, and must never propagate to the
-caller (the connection-analysis poll loop).
-"""
+"""Define notification channels and failure-isolated dispatch."""
 
 from __future__ import annotations
 
@@ -17,14 +12,14 @@ class NotificationChannel(Protocol):
     """A single notification output."""
 
     def send(self, event: dict[str, Any]) -> None:
-        """Deliver one Significant Connection event through this channel."""
+        """Send one Significant Connection event."""
 
 
 def dispatch_notification(
     event: dict[str, Any],
     channels: list[NotificationChannel],
 ) -> None:
-    """Send event to every channel independently; one failure never stops another."""
+    """Send an event to all channels without propagating channel failures."""
     for channel in channels:
         try:
             channel.send(event)

--- a/src/tapmap/notifications/channel.py
+++ b/src/tapmap/notifications/channel.py
@@ -1,0 +1,32 @@
+"""Channel abstraction and dispatch for notification delivery.
+
+Each channel is an independent output: one channel's failure must never
+prevent another channel from being attempted, and must never propagate to the
+caller (the connection-analysis poll loop).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationChannel(Protocol):
+    """A single notification output."""
+
+    def send(self, event: dict[str, Any]) -> None:
+        """Deliver one Significant Connection event through this channel."""
+
+
+def dispatch_notification(
+    event: dict[str, Any],
+    channels: list[NotificationChannel],
+) -> None:
+    """Send event to every channel independently; one failure never stops another."""
+    for channel in channels:
+        try:
+            channel.send(event)
+        except Exception:
+            logger.exception("Notification channel failed: %s", channel)

--- a/src/tapmap/notifications/mqtt.py
+++ b/src/tapmap/notifications/mqtt.py
@@ -1,0 +1,180 @@
+"""MQTT notification channel.
+
+Publishes one MQTT message per eligible, newly accepted Significant
+Connection. The paho-mqtt client and its background network thread live
+entirely inside this module. The MQTT callbacks (_on_connect/_on_disconnect/
+_on_connect_fail) handle connection lifecycle and logging only - they never
+touch ConnectionAnalyzer, Significant Connections, Insights, UI state, or any
+other TapMap application state. They track connection/failure state on the
+MqttChannel instance itself, so a broker that stays unavailable or keeps
+rejecting the same way does not re-log identical failures on every automatic
+retry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import ssl
+from typing import TYPE_CHECKING, Any
+
+import keyring.errors
+
+from ..mqtt_config import get_stored_credentials, load_mqtt_config, mqtt_config_path
+
+if TYPE_CHECKING:
+    import paho.mqtt.client as mqtt
+
+    from ..runtime import RuntimeContext
+
+logger = logging.getLogger(__name__)
+
+
+class MqttChannel:
+    """Publish Significant Connection events to a configured MQTT broker."""
+
+    def __init__(self, client: mqtt.Client, topic: str) -> None:
+        self._client = client
+        self._topic = topic
+        self._connected = False
+        self._last_reported_failure: str | None = None
+
+    def send(self, event: dict[str, Any]) -> None:
+        """Publish one Significant Connection event."""
+        payload = _build_payload(event)
+        info = self._client.publish(self._topic, json.dumps(payload), qos=0, retain=False)
+        if info.rc:
+            logger.debug("MQTT publish did not succeed immediately: %s", info.rc)
+
+    def close(self) -> None:
+        """Disconnect, then stop the network thread.
+
+        disconnect() only queues the DISCONNECT packet; the still-running
+        network thread is what flushes it and then exits on its own.
+        Calling loop_stop() first would join that thread before the packet
+        could ever be sent.
+        """
+        self._client.disconnect()
+        self._client.loop_stop()
+
+    def _on_connect(
+        self, client: Any, userdata: Any, connect_flags: Any, reason_code: Any, properties: Any
+    ) -> None:
+        """Log the connection result. MQTT lifecycle/logging only."""
+        if reason_code.is_failure:
+            self._report_failure(f"MQTT connection failed: {reason_code}")
+        else:
+            logger.info("MQTT connected.")
+            self._connected = True
+            self._last_reported_failure = None
+
+    def _on_disconnect(
+        self, client: Any, userdata: Any, disconnect_flags: Any, reason_code: Any, properties: Any
+    ) -> None:
+        """Log the disconnection. MQTT lifecycle/logging only.
+
+        A failure-flagged disconnect while _connected is already False is the
+        same-attempt echo paho raises right after a rejected CONNACK (always
+        reported as a generic "Unspecified error", carrying no information
+        _on_connect didn't already report) - it is not logged again.
+        """
+        if not reason_code.is_failure:
+            logger.info("MQTT disconnected: %s", reason_code)
+            self._connected = False
+            return
+
+        if not self._connected:
+            return
+
+        self._connected = False
+        self._report_failure(f"MQTT disconnected: {reason_code}")
+
+    def _on_connect_fail(self, client: Any, userdata: Any) -> None:
+        """Log a failed pre-CONNACK connection attempt. MQTT lifecycle/logging only.
+
+        paho calls this for any connection attempt that fails before a CONNACK
+        is exchanged (DNS, TCP, or TLS failures alike) and does not pass a
+        reason - on_connect/on_disconnect never fire for these attempts, so
+        without this callback they are silent.
+        """
+        self._report_failure("MQTT connection attempt failed.")
+
+    def _report_failure(self, message: str) -> None:
+        """Log message as WARNING unless it repeats the last reported failure.
+
+        Keeps a broker that stays down or keeps rejecting the same way from
+        producing one warning per automatic retry; a genuinely different
+        failure, or a fresh failure after a successful connection, still logs.
+        """
+        if message != self._last_reported_failure:
+            logger.warning(message)
+            self._last_reported_failure = message
+
+
+def create_mqtt_channel(runtime: RuntimeContext) -> MqttChannel | None:
+    """Build the MQTT channel from mqtt.json, or return None if unconfigured/unavailable."""
+    config = load_mqtt_config(mqtt_config_path(runtime.app_data_dir))
+    if config is None:
+        return None
+
+    try:
+        import paho.mqtt.client as mqtt
+    except ImportError:
+        logger.warning("paho-mqtt is not installed; MQTT notifications are unavailable.")
+        return None
+
+    if runtime.is_docker:
+        username, password = config.username, config.password
+    else:
+        try:
+            username, password = get_stored_credentials()
+        except keyring.errors.KeyringError:
+            logger.warning(
+                "Unable to read MQTT credentials from the OS keyring; "
+                "MQTT notifications are unavailable.",
+                exc_info=True,
+            )
+            return None
+
+    if username and not config.tls:
+        logger.warning(
+            "MQTT authentication is configured without TLS; credentials will be "
+            "sent in plaintext over the network."
+        )
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, protocol=mqtt.MQTTv311)
+
+    if username:
+        client.username_pw_set(username, password)
+
+    if config.tls:
+        try:
+            client.tls_set()
+        except (ssl.SSLError, ValueError):
+            logger.warning(
+                "Unable to configure MQTT TLS; MQTT notifications are unavailable.",
+                exc_info=True,
+            )
+            return None
+
+    channel = MqttChannel(client, config.topic)
+    client.on_connect = channel._on_connect
+    client.on_disconnect = channel._on_disconnect
+    client.on_connect_fail = channel._on_connect_fail
+
+    client.connect_async(config.host, config.port)
+    client.loop_start()
+
+    return channel
+
+
+def _build_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """Return the MQTT payload for one Significant Connection event.
+
+    The complete event, unchanged, except exe (a local filesystem path that
+    can embed the OS username) is excluded and hostname is added.
+    """
+    payload = {key: value for key, value in event.items() if key != "exe"}
+    payload["hostname"] = socket.gethostname()
+    return payload

--- a/src/tapmap/notifications/mqtt.py
+++ b/src/tapmap/notifications/mqtt.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import socket
 import ssl
 from typing import TYPE_CHECKING, Any
 
@@ -144,8 +143,6 @@ def create_mqtt_channel(runtime: RuntimeContext) -> MqttChannel | None:
 
 
 def _build_payload(event: dict[str, Any]) -> dict[str, Any]:
-    """Build an MQTT payload without the executable path and with the hostname."""
+    """Build an MQTT payload without the executable path."""
     # exe can embed the OS username, so it is excluded from the payload.
-    payload = {key: value for key, value in event.items() if key != "exe"}
-    payload["hostname"] = socket.gethostname()
-    return payload
+    return {key: value for key, value in event.items() if key != "exe"}

--- a/src/tapmap/notifications/mqtt.py
+++ b/src/tapmap/notifications/mqtt.py
@@ -1,15 +1,4 @@
-"""MQTT notification channel.
-
-Publishes one MQTT message per eligible, newly accepted Significant
-Connection. The paho-mqtt client and its background network thread live
-entirely inside this module. The MQTT callbacks (_on_connect/_on_disconnect/
-_on_connect_fail) handle connection lifecycle and logging only - they never
-touch ConnectionAnalyzer, Significant Connections, Insights, UI state, or any
-other TapMap application state. They track connection/failure state on the
-MqttChannel instance itself, so a broker that stays unavailable or keeps
-rejecting the same way does not re-log identical failures on every automatic
-retry.
-"""
+"""Publish Significant Connection notifications over MQTT."""
 
 from __future__ import annotations
 
@@ -48,20 +37,19 @@ class MqttChannel:
             logger.debug("MQTT publish did not succeed immediately: %s", info.rc)
 
     def close(self) -> None:
-        """Disconnect, then stop the network thread.
-
-        disconnect() only queues the DISCONNECT packet; the still-running
-        network thread is what flushes it and then exits on its own.
-        Calling loop_stop() first would join that thread before the packet
-        could ever be sent.
-        """
+        """Disconnect from the broker and stop the MQTT network thread."""
+        # disconnect() only queues the packet; the network loop sends it,
+        # so it must run before loop_stop() stops that loop.
         self._client.disconnect()
         self._client.loop_stop()
+
+    # The callbacks below must not modify ConnectionAnalyzer, Significant
+    # Connections, Insights, UI, or other TapMap application state.
 
     def _on_connect(
         self, client: Any, userdata: Any, connect_flags: Any, reason_code: Any, properties: Any
     ) -> None:
-        """Log the connection result. MQTT lifecycle/logging only."""
+        """Handle an MQTT connection result."""
         if reason_code.is_failure:
             self._report_failure(f"MQTT connection failed: {reason_code}")
         else:
@@ -72,41 +60,27 @@ class MqttChannel:
     def _on_disconnect(
         self, client: Any, userdata: Any, disconnect_flags: Any, reason_code: Any, properties: Any
     ) -> None:
-        """Log the disconnection. MQTT lifecycle/logging only.
-
-        A failure-flagged disconnect while _connected is already False is the
-        same-attempt echo paho raises right after a rejected CONNACK (always
-        reported as a generic "Unspecified error", carrying no information
-        _on_connect didn't already report) - it is not logged again.
-        """
+        """Handle an MQTT disconnection."""
         if not reason_code.is_failure:
             logger.info("MQTT disconnected: %s", reason_code)
             self._connected = False
             return
 
         if not self._connected:
+            # A failure disconnect while already disconnected can be the echo
+            # of the same failed connection attempt - do not log it again.
             return
 
         self._connected = False
         self._report_failure(f"MQTT disconnected: {reason_code}")
 
     def _on_connect_fail(self, client: Any, userdata: Any) -> None:
-        """Log a failed pre-CONNACK connection attempt. MQTT lifecycle/logging only.
-
-        paho calls this for any connection attempt that fails before a CONNACK
-        is exchanged (DNS, TCP, or TLS failures alike) and does not pass a
-        reason - on_connect/on_disconnect never fire for these attempts, so
-        without this callback they are silent.
-        """
+        """Handle an MQTT connection failure before CONNACK."""
+        # paho provides no reason here - do not invent or imply one.
         self._report_failure("MQTT connection attempt failed.")
 
     def _report_failure(self, message: str) -> None:
-        """Log message as WARNING unless it repeats the last reported failure.
-
-        Keeps a broker that stays down or keeps rejecting the same way from
-        producing one warning per automatic retry; a genuinely different
-        failure, or a fresh failure after a successful connection, still logs.
-        """
+        """Log a changed MQTT failure without repeating identical failures."""
         if message != self._last_reported_failure:
             logger.warning(message)
             self._last_reported_failure = message
@@ -170,11 +144,8 @@ def create_mqtt_channel(runtime: RuntimeContext) -> MqttChannel | None:
 
 
 def _build_payload(event: dict[str, Any]) -> dict[str, Any]:
-    """Return the MQTT payload for one Significant Connection event.
-
-    The complete event, unchanged, except exe (a local filesystem path that
-    can embed the OS username) is excluded and hostname is added.
-    """
+    """Build an MQTT payload without the executable path and with the hostname."""
+    # exe can embed the OS username, so it is excluded from the payload.
     payload = {key: value for key, value in event.items() if key != "exe"}
     payload["hostname"] = socket.gethostname()
     return payload

--- a/src/tapmap/runtime.py
+++ b/src/tapmap/runtime.py
@@ -10,6 +10,7 @@ from .app_dirs import ensure_app_data_dir, ensure_native_app_data_dir
 from .config import (
     CACHE_RETENTION_MIN,
     LAUNCH_BROWSER,
+    NOTIFICATION_LEARNING_DAYS,
     SERVER_PORT,
 )
 
@@ -37,6 +38,8 @@ class RuntimeContext:
         security_extensions_dir: Directory containing the Microsoft Security
             Extensions wrapper DLLs (Windows only; may not exist on other OSes).
         tray_icon_path: Path to the tray icon image asset.
+        notification_learning_days: Distinct active Insights days required
+            before Significant Connections become eligible for notification.
     """
 
     meta: AppMeta
@@ -53,6 +56,7 @@ class RuntimeContext:
     location_override: tuple[float, float] | None
     security_extensions_dir: Path
     tray_icon_path: Path
+    notification_learning_days: int
 
     @property
     def geo_data_dir(self) -> Path:
@@ -144,6 +148,29 @@ def _get_cache_retention_min() -> int:
     except ValueError:
         return CACHE_RETENTION_MIN
 
+def _get_notification_learning_days() -> int:
+    """Return the notification learning-period threshold in distinct active days.
+
+    Valid range is 0-30 (0 disables the learning period; distinct_active_days()
+    can never exceed 30). Out-of-range or non-integer values fall back to the
+    config default, rather than being clamped, so an out-of-range value never
+    silently disables notifications.
+    """
+    value = os.environ.get("TAPMAP_NOTIFICATION_LEARNING_DAYS")
+
+    if value is None:
+        return NOTIFICATION_LEARNING_DAYS
+
+    try:
+        parsed = int(value)
+    except ValueError:
+        return NOTIFICATION_LEARNING_DAYS
+
+    if 0 <= parsed <= 30:
+        return parsed
+
+    return NOTIFICATION_LEARNING_DAYS
+
 def _detect_docker() -> bool:
     """Return True when running in Docker."""
     return os.environ.get("TAPMAP_IN_DOCKER") == "1"
@@ -190,6 +217,7 @@ def build_runtime(meta: AppMeta, *, no_browser: bool = False) -> RuntimeContext:
     location_override = _get_location_override()
     security_extensions_dir = _get_security_extensions_dir(is_frozen, run_dir)
     tray_icon_path = _get_tray_icon_path(is_frozen, run_dir)
+    notification_learning_days = _get_notification_learning_days()
 
     return RuntimeContext(
         meta=meta,
@@ -206,6 +234,7 @@ def build_runtime(meta: AppMeta, *, no_browser: bool = False) -> RuntimeContext:
         location_override=location_override,
         security_extensions_dir=security_extensions_dir,
         tray_icon_path=tray_icon_path,
+        notification_learning_days=notification_learning_days,
     )
 
 def _detect_network_backend() -> tuple[str, str]:

--- a/src/tapmap/runtime.py
+++ b/src/tapmap/runtime.py
@@ -38,8 +38,7 @@ class RuntimeContext:
         security_extensions_dir: Directory containing the Microsoft Security
             Extensions wrapper DLLs (Windows only; may not exist on other OSes).
         tray_icon_path: Path to the tray icon image asset.
-        notification_learning_days: Distinct active Insights days required
-            before Significant Connections become eligible for notification.
+        notification_learning_days: Active Insights days required before notifications begin.
     """
 
     meta: AppMeta
@@ -149,13 +148,7 @@ def _get_cache_retention_min() -> int:
         return CACHE_RETENTION_MIN
 
 def _get_notification_learning_days() -> int:
-    """Return the notification learning-period threshold in distinct active days.
-
-    Valid range is 0-30 (0 disables the learning period; distinct_active_days()
-    can never exceed 30). Out-of-range or non-integer values fall back to the
-    config default, rather than being clamped, so an out-of-range value never
-    silently disables notifications.
-    """
+    """Return the configured notification learning period in active days."""
     value = os.environ.get("TAPMAP_NOTIFICATION_LEARNING_DAYS")
 
     if value is None:

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -3,12 +3,6 @@
 Mapped PUBLIC connections update ConnectionState and feed Insights. PUBLIC
 connections without usable GeoIP update UnmappedState and remain eligible
 for Significant Connections, but do not contribute to Insights.
-
-A newly accepted Significant Connection is immediately evaluated against
-notification policy and, if eligible, dispatched - in the same per-connection
-pass that stores it, never by polling SignificantConnections history
-afterward. Significance detection and storage stay unaware of this: neither
-get_significant() nor SignificantConnections know notifications exist.
 """
 
 from __future__ import annotations
@@ -26,7 +20,7 @@ from .unmapped_state import UnmappedState
 
 
 class ConnectionAnalyzer:
-    """Process a snapshot's connections: connection, unmapped, insights, significant, notify."""
+    """Process a snapshot's connections and update derived state and notifications."""
 
     def __init__(
         self,

--- a/src/tapmap/state/connection_analyzer.py
+++ b/src/tapmap/state/connection_analyzer.py
@@ -3,6 +3,12 @@
 Mapped PUBLIC connections update ConnectionState and feed Insights. PUBLIC
 connections without usable GeoIP update UnmappedState and remain eligible
 for Significant Connections, but do not contribute to Insights.
+
+A newly accepted Significant Connection is immediately evaluated against
+notification policy and, if eligible, dispatched - in the same per-connection
+pass that stores it, never by polling SignificantConnections history
+afterward. Significance detection and storage stay unaware of this: neither
+get_significant() nor SignificantConnections know notifications exist.
 """
 
 from __future__ import annotations
@@ -10,15 +16,17 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+from ..notifications.channel import NotificationChannel, dispatch_notification
 from .connection_state import ConnectionState
 from .insights import process_insights
+from .notification_policy import is_learning_period_over
 from .significance import SignificanceHistory, get_significant
 from .significant_connections import SignificantConnections
 from .unmapped_state import UnmappedState
 
 
 class ConnectionAnalyzer:
-    """Process a snapshot's connections: connection, unmapped, insights, and significant state."""
+    """Process a snapshot's connections: connection, unmapped, insights, significant, notify."""
 
     def __init__(
         self,
@@ -27,6 +35,9 @@ class ConnectionAnalyzer:
         insights: dict[str, Any],
         significant_connections: SignificantConnections,
         significance_history: SignificanceHistory,
+        *,
+        notification_channels: list[NotificationChannel] | None = None,
+        notification_learning_days: int = 7,
     ) -> None:
         """Store references to the collaborating state and history objects."""
         self.connection_state = connection_state
@@ -34,6 +45,10 @@ class ConnectionAnalyzer:
         self.insights = insights
         self.significant_connections = significant_connections
         self.significance_history = significance_history
+        self.notification_channels = (
+            notification_channels if notification_channels is not None else []
+        )
+        self.notification_learning_days = notification_learning_days
 
     def analyze(self, connections: list[dict[str, Any]]) -> dict[str, Any]:
         """Update ConnectionState, UnmappedState, Significant Connections, and Insights.
@@ -59,6 +74,8 @@ class ConnectionAnalyzer:
             significant_connection = get_significant(item, self.significance_history, now)
             if significant_connection is not None:
                 self.significant_connections.add(significant_connection)
+                if is_learning_period_over(self.insights, self.notification_learning_days):
+                    dispatch_notification(significant_connection, self.notification_channels)
 
         self.connection_state.merge(mapped)
         self.unmapped_state.merge(unmapped)

--- a/src/tapmap/state/insights.py
+++ b/src/tapmap/state/insights.py
@@ -203,12 +203,7 @@ def process_insights(
 
 
 def distinct_active_days(insights: dict[str, Any]) -> int:
-    """Return the count of the last 30 days with activity in any dimension.
-
-    ORs the 30-day bitmask of every entry across all dimensions, then counts
-    the set bits: a day counts once if any country, provider, port, or
-    application was observed on it, regardless of how many.
-    """
+    """Return the number of distinct active days in the 30-day Insights history."""
     combined = 0
     for dimension in insights.values():
         if not isinstance(dimension, dict):

--- a/src/tapmap/state/insights.py
+++ b/src/tapmap/state/insights.py
@@ -200,3 +200,23 @@ def process_insights(
         "new": new,
         "top": top,
     }
+
+
+def distinct_active_days(insights: dict[str, Any]) -> int:
+    """Return the count of the last 30 days with activity in any dimension.
+
+    ORs the 30-day bitmask of every entry across all dimensions, then counts
+    the set bits: a day counts once if any country, provider, port, or
+    application was observed on it, regardless of how many.
+    """
+    combined = 0
+    for dimension in insights.values():
+        if not isinstance(dimension, dict):
+            continue
+        for entry in dimension.values():
+            if not isinstance(entry, dict):
+                continue
+            mask = entry.get("m")
+            if isinstance(mask, int):
+                combined |= mask
+    return combined.bit_count()

--- a/src/tapmap/state/notification_policy.py
+++ b/src/tapmap/state/notification_policy.py
@@ -1,0 +1,17 @@
+"""Decide whether the notification learning period has elapsed.
+
+Pure and read-only with respect to Insights: does not age, mutate, or persist
+anything. Reason-agnostic by design - no Significant Connection reason
+bypasses this check.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .insights import distinct_active_days
+
+
+def is_learning_period_over(insights: dict[str, Any], min_active_days: int) -> bool:
+    """Return whether at least min_active_days of Insights history exist."""
+    return distinct_active_days(insights) >= min_active_days

--- a/src/tapmap/state/notification_policy.py
+++ b/src/tapmap/state/notification_policy.py
@@ -1,9 +1,4 @@
-"""Decide whether the notification learning period has elapsed.
-
-Pure and read-only with respect to Insights: does not age, mutate, or persist
-anything. Reason-agnostic by design - no Significant Connection reason
-bypasses this check.
-"""
+"""Evaluate notification eligibility against Insights history."""
 
 from __future__ import annotations
 
@@ -13,5 +8,5 @@ from .insights import distinct_active_days
 
 
 def is_learning_period_over(insights: dict[str, Any], min_active_days: int) -> bool:
-    """Return whether at least min_active_days of Insights history exist."""
+    """Return whether the notification learning period has ended."""
     return distinct_active_days(insights) >= min_active_days

--- a/src/tapmap/ui/about_view.py
+++ b/src/tapmap/ui/about_view.py
@@ -19,7 +19,6 @@ def render_about(
     app_version: str,
     app_author: str,
     snapshot: Any | None = None,
-    is_docker: bool,
 ) -> list[Any]:
     """Render About view content.
 
@@ -75,6 +74,17 @@ def render_about(
         net_backend_version_val if isinstance(net_backend_version_val, str) else "-"
     )
 
+    is_docker = bool(runtime_info.get("is_docker", False))
+
+    notification_learning_days = runtime_info.get("notification_learning_days")
+    mqtt_configured = bool(runtime_info.get("mqtt_configured", False))
+    mqtt_host = runtime_info.get("mqtt_host")
+    mqtt_port = runtime_info.get("mqtt_port")
+    mqtt_topic = runtime_info.get("mqtt_topic")
+    mqtt_tls = runtime_info.get("mqtt_tls")
+
+    dash_version = str(runtime_info.get("dash_version") or "-")
+
     tapmap_rows: list[tuple[str, str]] = [
         ("Name", app_name),
         ("Version", app_version),
@@ -98,11 +108,32 @@ def render_about(
         auto_geo=auto_geo,
     )
 
+    notification_rows: list[tuple[str, str]] = [
+        (
+            "Learning period",
+            f"{notification_learning_days} days"
+            if isinstance(notification_learning_days, int)
+            else "-",
+        ),
+        ("MQTT configured", "Yes" if mqtt_configured else "No"),
+    ]
+    if mqtt_configured:
+        notification_rows.append(
+            (
+                "Broker",
+                f"{mqtt_host}:{mqtt_port}" if mqtt_host and mqtt_port is not None else "-",
+            )
+        )
+        notification_rows.append(("Topic", mqtt_topic if mqtt_topic else "-"))
+        notification_rows.append(("TLS", "On" if mqtt_tls else "Off"))
+
     runtime_rows: list[tuple[str, str]] = [
         ("OS", os_text),
         ("Python", py_text),
         ("Network backend", net_backend),
         ("Backend version", net_backend_version),
+        ("Frontend", "Dash"),
+        ("Frontend version", dash_version),
         ("Server host", server_host),
         ("Docker", "Yes" if is_docker else "No"),
         ("Browser launch", "Enabled" if launch_browser else "Disabled"),
@@ -134,10 +165,11 @@ def render_about(
         kv_table(tapmap_rows),
         html.H2("Command line"),
         html.Pre(
-            "tapmap                 Start application\n"
-            "tapmap --help          Show options\n"
-            "tapmap --version       Show version\n"
-            "tapmap --no-browser    Do not open the browser automatically"
+            "tapmap                       Start application\n"
+            "tapmap --help                Show options\n"
+            "tapmap --version             Show version\n"
+            "tapmap --no-browser          Do not open the browser automatically\n"
+            "tapmap --configure-mqtt      Configure MQTT notifications"
         ),
         html.H2("Geolocation"),
         html.P(
@@ -169,6 +201,8 @@ def render_about(
         ) if geo_provider == "maxmind" else None,
         html.H2("Location"),
         kv_table(location_rows),
+        html.H2("Notifications"),
+        kv_table(notification_rows),
         html.H2("Runtime"),
         kv_table(runtime_rows),
         html.H2("Project"),

--- a/src/tapmap/ui/help_view.py
+++ b/src/tapmap/ui/help_view.py
@@ -32,12 +32,8 @@ def render_help() -> list[Any]:
             [
                 html.Li("Start TapMap."),
                 html.Li("Hover map markers for a connection summary."),
-                html.Li(
-                    "Click map markers for connection details and application information."
-                ),
-                html.Li(
-                    "The Insights panel highlights new and frequent activity."
-                ),
+                html.Li("Click map markers for connection details and application information."),
+                html.Li("The Insights panel highlights new and frequent activity."),
                 html.Li(
                     "Open the Daily Activity Report (D) for deeper analysis of activity patterns."
                 ),
@@ -182,8 +178,7 @@ def render_help() -> list[Any]:
         ),
         html.H2("Menu"),
         html.P(
-            "The menu is organized into the expandable sections INSIGHTS, NETWORK, "
-            "TOOLS, and INFO."
+            "The menu is organized into the expandable sections INSIGHTS, NETWORK, TOOLS, and INFO."
         ),
         html.Table(
             className="mx-table mx-kv",
@@ -220,9 +215,7 @@ def render_help() -> list[Any]:
                         html.Tr(
                             [
                                 html.Td("INFO"),
-                                html.Td(
-                                    "Help and About windows."
-                                ),
+                                html.Td("Help and About windows."),
                             ]
                         ),
                     ]
@@ -318,8 +311,7 @@ def render_help() -> list[Any]:
                         html.Tr([html.Td("C"), html.Td("Clear cache"), html.Td("Status")]),
                         html.Tr([html.Td("H"), html.Td("Help"), html.Td("Window")]),
                         html.Tr([html.Td("A"), html.Td("About"), html.Td("Window")]),
-                        html.Tr([html.Td("Z"), html.Td("Fit mapped connections"),
-                                 html.Td("Map")]),
+                        html.Tr([html.Td("Z"), html.Td("Fit mapped connections"), html.Td("Map")]),
                         html.Tr([html.Td("X"), html.Td("Exit"), html.Td("Exit")]),
                         html.Tr([html.Td("ESC"), html.Td("Close window"), html.Td("Window")]),
                     ]
@@ -343,8 +335,7 @@ def render_help() -> list[Any]:
             ]
         ),
         html.P(
-            "The system tray and autostart are available for desktop installations, not "
-            "Docker."
+            "The system tray and autostart are available for desktop installations, not Docker."
         ),
         html.H2("Application information"),
         html.P(
@@ -376,25 +367,19 @@ def render_help() -> list[Any]:
                     [
                         html.Tr(
                             [
-                                html.Td(
-                                    html.Span("■", style={"color": "#00ff66"})
-                                ),
+                                html.Td(html.Span("■", style={"color": "#00ff66"})),
                                 html.Td("Verified: Verification succeeded."),
                             ]
                         ),
                         html.Tr(
                             [
-                                html.Td(
-                                    html.Span("■", style={"color": "#ff4444"})
-                                ),
+                                html.Td(html.Span("■", style={"color": "#ff4444"})),
                                 html.Td("Failed: Verification failed."),
                             ]
                         ),
                         html.Tr(
                             [
-                                html.Td(
-                                    html.Span("■", style={"color": "#ffff00"})
-                                ),
+                                html.Td(html.Span("■", style={"color": "#ffff00"})),
                                 html.Td(
                                     "Unknown or unavailable: Verification could not be completed."
                                 ),
@@ -402,12 +387,8 @@ def render_help() -> list[Any]:
                         ),
                         html.Tr(
                             [
-                                html.Td(
-                                    html.Span("■", style={"color": "#ffffff"})
-                                ),
-                                html.Td(
-                                    "Retrieving...: Verification is in progress."
-                                ),
+                                html.Td(html.Span("■", style={"color": "#ffffff"})),
+                                html.Td("Retrieving...: Verification is in progress."),
                             ]
                         ),
                     ]
@@ -429,20 +410,13 @@ def render_help() -> list[Any]:
         ),
         html.H2("Insights"),
         html.P(
-            "The Insights panel highlights mapped public activity observed during "
-            "the last 30 days."
+            "The Insights panel highlights mapped public activity observed during the last 30 days."
         ),
         html.Ul(
             [
-                html.Li(
-                    "New apps, providers (ASN), countries, and ports observed today."
-                ),
-                html.Li(
-                    "Top 5+ most frequently observed items over the last 30 days."
-                ),
-                html.Li(
-                    "Click countries to zoom to the selected country."
-                ),
+                html.Li("New apps, providers (ASN), countries, and ports observed today."),
+                html.Li("Top 5+ most frequently observed items over the last 30 days."),
+                html.Li("Click countries to zoom to the selected country."),
             ]
         ),
         html.P(
@@ -482,10 +456,17 @@ def render_help() -> list[Any]:
             "Click a row to view location, application, connection, and process "
             "details. Use Back to return to the list."
         ),
-        html.P(
-            "Missing historical verification status is shown as Unknown."
-        ),
+        html.P("Missing historical verification status is shown as Unknown."),
         html.P("TapMap keeps the most recent 500 Significant Connections."),
+        html.H3("MQTT notifications"),
+        html.P(
+            "TapMap can publish new Significant Connections to an MQTT broker. "
+            "Configure MQTT with tapmap --configure-mqtt."
+        ),
+        html.P(
+            "By default, notifications start after 7 active Insights days. "
+            "Significant Connections are recorded during the learning period."
+        ),
         html.H2("Unmapped public services (missing geolocation)"),
         html.P(
             "The Unmapped window lists PUBLIC services that are not shown on the map because "
@@ -530,9 +511,7 @@ def render_help() -> list[Any]:
         ),
         html.P("System processes are hidden by default. Use the toggle to include them."),
         html.H2("Status line"),
-        html.P(
-            "Short status messages may appear after commands such as Clear cache."
-        ),
+        html.P("Short status messages may appear after commands such as Clear cache."),
         html.H3("STATUS: WAIT | OK | ERROR"),
         html.Table(
             className="mx-table mx-kv",
@@ -676,10 +655,10 @@ def render_help() -> list[Any]:
             "GeoIP Database Management is used to install, update, verify, and manage "
             "supported databases."
         ),
-            html.P(
-                "When no supported databases are detected, GeoIP Database Management "
-                "provides installation options for supported providers."
-            ),
+        html.P(
+            "When no supported databases are detected, GeoIP Database Management "
+            "provides installation options for supported providers."
+        ),
         html.P(
             "Databases can be installed from GeoIP Database Management or managed "
             "manually using the data folder."
@@ -706,11 +685,17 @@ def render_help() -> list[Any]:
         html.Ul(
             [
                 html.Li("TapMap runs locally."),
-                html.Li("No connection data is sent anywhere."),
+                html.Li(
+                    "TapMap does not transmit connection data unless explicitly configured "
+                    "by the user."
+                ),
                 html.Li("Geolocation uses local GeoIP databases."),
                 html.Li(
-                    "TapMap stores activity history and significant connection events locally. "
-                    "This data is never transmitted or shared by TapMap."
+                    "TapMap stores activity history and significant connection events locally."
+                ),
+                html.Li(
+                    "If MQTT notifications are configured, new notification-eligible Significant "
+                    "Connection data is published to the configured MQTT broker."
                 ),
                 html.Li(
                     "If automatic local geolocation is enabled, TapMap contacts a public "

--- a/src/tapmap/ui/modal_view.py
+++ b/src/tapmap/ui/modal_view.py
@@ -98,7 +98,6 @@ class ModalTextBuilder:
                 app_version=self.app_version,
                 app_author=self.app_author,
                 snapshot=snapshot,
-                is_docker=is_docker,
             )
         label = self._label_map.get(action, action)
         return [self._h1("Details"), html.Pre(f"Menu selected: {label}")]

--- a/tests/test_about_view.py
+++ b/tests/test_about_view.py
@@ -1,0 +1,141 @@
+"""Test about_view's rendering of runtime, notification, and CLI information."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dash import html
+
+from tapmap.ui.about_view import render_about
+
+
+def _runtime_info(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal runtime_info dict as _build_runtime_info() would supply it."""
+    info: dict[str, Any] = {
+        "poll_interval_ms": 5000,
+        "coord_precision": 3,
+        "zoom_near_km": 25.0,
+        "geoinfo_enabled": False,
+        "geo_provider": "none",
+        "geo_database_date": "-",
+        "myloc_mode": "OFF",
+        "my_location": None,
+        "public_ip_cached": None,
+        "auto_geo_cached": {},
+        "os": "Windows 11",
+        "python": "3.12.0",
+        "net_backend": "psutil",
+        "net_backend_version": "7.2.2",
+        "server_host": "127.0.0.1",
+        "server_port": 8050,
+        "launch_browser": True,
+        "cache_retention_min": 0,
+        "is_docker": False,
+        "notification_learning_days": 7,
+        "mqtt_configured": False,
+        "mqtt_host": None,
+        "mqtt_port": None,
+        "mqtt_topic": None,
+        "mqtt_tls": None,
+        "dash_version": "4.1.0",
+    }
+    info.update(overrides)
+    return info
+
+
+def _render(**overrides: Any) -> list[Any]:
+    """Render About with a minimal snapshot built from the given runtime_info overrides."""
+    return render_about(
+        app_name="TapMap",
+        app_version="1.12.3",
+        app_author="Ola Lie",
+        snapshot={"runtime_info": _runtime_info(**overrides)},
+    )
+
+
+def _section_table(result: list[Any], heading: str) -> html.Table:
+    """Return the kv_table immediately following the H2 with the given text."""
+    idx = next(
+        i
+        for i, c in enumerate(result)
+        if isinstance(c, html.H2) and c.children == heading
+    )
+    table = result[idx + 1]
+    assert isinstance(table, html.Table)
+    return table
+
+
+def _kv_rows(table: html.Table) -> dict[str, str]:
+    """Return {label: value} for every row of a kv_table."""
+    tbody = next(c for c in table.children if isinstance(c, html.Tbody))
+    rows: dict[str, str] = {}
+    for tr in tbody.children:
+        key_cell, value_cell = tr.children
+        rows[key_cell.children] = value_cell.children.children
+    return rows
+
+
+def _command_line_text(result: list[Any]) -> str:
+    """Return the text content of the Command line Pre block."""
+    pre = next(c for c in result if isinstance(c, html.Pre))
+    return pre.children
+
+
+def test_notifications_section_shows_learning_period_and_unconfigured_mqtt() -> None:
+    """Verify the unconfigured MQTT display."""
+    result = _render(mqtt_configured=False)
+    rows = _kv_rows(_section_table(result, "Notifications"))
+
+    assert rows == {"Learning period": "7 days", "MQTT configured": "No"}
+
+
+def test_notifications_section_shows_broker_topic_and_tls_when_configured() -> None:
+    """Verify configured MQTT details."""
+    result = _render(
+        mqtt_configured=True,
+        mqtt_host="broker.example.com",
+        mqtt_port=8883,
+        mqtt_topic="tapmap/events",
+        mqtt_tls=True,
+    )
+    rows = _kv_rows(_section_table(result, "Notifications"))
+
+    assert rows["MQTT configured"] == "Yes"
+    assert rows["Broker"] == "broker.example.com:8883"
+    assert rows["Topic"] == "tapmap/events"
+    assert rows["TLS"] == "On"
+
+
+def test_notifications_section_falls_back_when_learning_period_missing() -> None:
+    """Verify the learning-period fallback."""
+    result = _render(notification_learning_days=None)
+    rows = _kv_rows(_section_table(result, "Notifications"))
+
+    assert rows["Learning period"] == "-"
+
+
+def test_runtime_section_shows_frontend_and_dash_version() -> None:
+    """Verify displayed frontend information."""
+    result = _render(dash_version="4.1.0")
+    rows = _kv_rows(_section_table(result, "Runtime"))
+
+    assert rows["Frontend"] == "Dash"
+    assert rows["Frontend version"] == "4.1.0"
+
+
+def test_runtime_section_docker_flag_comes_from_runtime_info() -> None:
+    """Verify Docker status from runtime information."""
+    result = _render(is_docker=True)
+    rows = _kv_rows(_section_table(result, "Runtime"))
+
+    assert rows["Docker"] == "Yes"
+
+
+def test_command_line_block_includes_configure_mqtt() -> None:
+    """Verify the MQTT configuration command."""
+    text = _command_line_text(_render())
+
+    assert "tapmap --configure-mqtt" in text
+    assert "tapmap --help" in text
+    assert "tapmap --version" in text
+    assert "tapmap --no-browser" in text

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -295,7 +295,7 @@ def test_build_runtime_info_reports_mqtt_config_without_leaking_credentials(
     save_mqtt_config(
         mqtt_config_path(tmp_path),
         MqttConfig(
-            host="broker.example.com",
+            host="192.0.2.1",
             port=8883,
             topic="tapmap/events",
             tls=True,
@@ -307,7 +307,7 @@ def test_build_runtime_info_reports_mqtt_config_without_leaking_credentials(
     info = app._build_runtime_info()
 
     assert info["mqtt_configured"] is True
-    assert info["mqtt_host"] == "broker.example.com"
+    assert info["mqtt_host"] == "192.0.2.1"
     assert info["mqtt_port"] == 8883
     assert info["mqtt_topic"] == "tapmap/events"
     assert info["mqtt_tls"] is True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,6 +36,7 @@ def _runtime_ctx(tmp_path: Path) -> RuntimeContext:
         location_override=None,
         security_extensions_dir=tmp_path,
         tray_icon_path=tmp_path / "tapmap.ico",
+        notification_learning_days=7,
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import dash
 from dash import html
 
 from tapmap.app import APP_META, TapMap
 from tapmap.model.appinfo import ApplicationMetadata, VerificationStatus
+from tapmap.mqtt_config import MqttConfig, mqtt_config_path, save_mqtt_config
 from tapmap.runtime import RuntimeContext
 from tapmap.significant_connections_persistence import load_significant_connections
 from tapmap.state.connection_state import ConnectionState
@@ -255,3 +257,69 @@ def test_render_modal_shows_unavailable_message_when_significant_connection_is_g
     assert any(
         isinstance(c, html.Pre) and "no longer available" in c.children for c in children
     )
+
+
+def _app_for_runtime_info(tmp_path: Path) -> TapMap:
+    """Build a minimal TapMap instance for runtime-info tests."""
+    app = object.__new__(TapMap)
+    app.runtime = _runtime_ctx(tmp_path)
+    app.geodb = MagicMock()
+    app.geodb.local_status.return_value = {"provider": "none", "local_display_date": "-"}
+    app.model = SimpleNamespace(geoinfo=SimpleNamespace(city_enabled=False))
+    app._public_ip_cached = None
+    app._auto_geo_cached = {}
+    app.my_location = []
+    return app
+
+
+def test_build_runtime_info_reports_mqtt_unconfigured_when_no_config_file(
+    tmp_path: Path,
+) -> None:
+    """With no mqtt.json in the app data directory, MQTT reads as unconfigured."""
+    app = _app_for_runtime_info(tmp_path)
+
+    info = app._build_runtime_info()
+
+    assert info["mqtt_configured"] is False
+    assert info["mqtt_host"] is None
+    assert info["mqtt_port"] is None
+    assert info["mqtt_topic"] is None
+    assert info["mqtt_tls"] is None
+
+
+def test_build_runtime_info_reports_mqtt_config_without_leaking_credentials(
+    tmp_path: Path,
+) -> None:
+    """A configured mqtt.json surfaces host/port/topic/tls but never the stored credentials."""
+    app = _app_for_runtime_info(tmp_path)
+    save_mqtt_config(
+        mqtt_config_path(tmp_path),
+        MqttConfig(
+            host="broker.example.com",
+            port=8883,
+            topic="tapmap/events",
+            tls=True,
+            username="secret-user",
+            password="secret-pass",
+        ),
+    )
+
+    info = app._build_runtime_info()
+
+    assert info["mqtt_configured"] is True
+    assert info["mqtt_host"] == "broker.example.com"
+    assert info["mqtt_port"] == 8883
+    assert info["mqtt_topic"] == "tapmap/events"
+    assert info["mqtt_tls"] is True
+    assert info["notification_learning_days"] == app.runtime.notification_learning_days
+    assert "secret-user" not in info.values()
+    assert "secret-pass" not in info.values()
+
+
+def test_build_runtime_info_reports_installed_dash_version(tmp_path: Path) -> None:
+    """Verify reported Dash version."""
+    app = _app_for_runtime_info(tmp_path)
+
+    info = app._build_runtime_info()
+
+    assert info["dash_version"] == dash.__version__

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -12,6 +12,27 @@ from tapmap.state.significant_connections import SignificantConnections
 from tapmap.state.unmapped_state import UnmappedState
 
 
+class _RecordingChannel:
+    """Test double that records every event handed to it."""
+
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    def send(self, event: dict[str, Any]) -> None:
+        self.received.append(event)
+
+
+def _empty_history() -> SignificanceHistory:
+    """Return a fresh SignificanceHistory derived from empty Insights."""
+    return SignificanceHistory.from_insights_state(
+        InsightsState(
+            version=2,
+            insights={"countries": {}, "providers": {}, "ports": {}, "applications": {}},
+            verification_failed={},
+        )
+    )
+
+
 def _connection(**overrides: Any) -> dict[str, Any]:
     """Return a minimal connection dict (as produced by Model.snapshot())."""
     item = {
@@ -284,3 +305,146 @@ def test_verification_backfill_does_not_suppress_a_later_verification_failed_eve
     assert significant_connections.items[0]["reasons"] == first_reasons
     assert significant_connections.items[1]["reasons"] == ["verification_failed"]
     assert significant_connections.items[1]["app_verification_status"] == "failed"
+
+
+# --- notification dispatch wiring ---
+
+
+def test_no_dispatch_during_learning_period() -> None:
+    """A Significant Connection is stored, but not dispatched, before the threshold is met."""
+    significant_connections = SignificantConnections([])
+    channel = _RecordingChannel()
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        {},  # no Insights history: 0 distinct active days
+        significant_connections,
+        _empty_history(),
+        notification_channels=[channel],
+        notification_learning_days=7,
+    )
+
+    analyzer.analyze([_connection(country_code="US")])
+
+    assert len(significant_connections.items) == 1
+    assert channel.received == []
+
+
+def test_dispatch_after_learning_period_is_over() -> None:
+    """Once enough Insights history exists, a newly accepted event is dispatched immediately."""
+    significant_connections = SignificantConnections([])
+    channel = _RecordingChannel()
+    # "l" (anchor day) is irrelevant here: distinct_active_days() only reads "m".
+    insights: dict[str, Any] = {
+        "countries": {"NO": {"l": 1, "m": (1 << 7) - 1}},  # 7 distinct active days already
+    }
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        insights,
+        significant_connections,
+        _empty_history(),
+        notification_channels=[channel],
+        notification_learning_days=7,
+    )
+
+    analyzer.analyze([_connection(country_code="US")])
+
+    assert len(significant_connections.items) == 1
+    assert channel.received == [significant_connections.items[0]]
+
+
+def test_dispatch_zero_threshold_is_immediately_eligible() -> None:
+    """A zero learning-period threshold dispatches from the very first Significant Connection."""
+    significant_connections = SignificantConnections([])
+    channel = _RecordingChannel()
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        {},
+        significant_connections,
+        _empty_history(),
+        notification_channels=[channel],
+        notification_learning_days=0,
+    )
+
+    analyzer.analyze([_connection(country_code="US")])
+
+    assert channel.received == significant_connections.items
+
+
+def test_current_poll_does_not_count_toward_its_own_eligibility() -> None:
+    """Eligibility is checked against Insights as of the previous poll, not this one.
+
+    Regression test for the established off-by-one behavior: process_insights()
+    (which would add today's day to the bitmask) only runs once, after the
+    entire per-connection loop - so a connection that would itself push the
+    active-day count over the threshold is not dispatched in the same poll
+    that creates it, even though it is still stored as usual.
+    """
+    significant_connections = SignificantConnections([])
+    channel = _RecordingChannel()
+    # 6 active days already recorded; today's observation would be the 7th,
+    # but only after process_insights() runs at the end of analyze().
+    insights: dict[str, Any] = {
+        "countries": {"NO": {"l": 1, "m": (1 << 6) - 1}},
+    }
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        insights,
+        significant_connections,
+        _empty_history(),
+        notification_channels=[channel],
+        notification_learning_days=7,
+    )
+
+    analyzer.analyze([_connection(country_code="US")])
+
+    assert len(significant_connections.items) == 1
+    assert channel.received == []
+
+
+def test_a_failing_channel_does_not_prevent_another_or_break_analyze() -> None:
+    """A channel that raises does not stop delivery to other channels or break analyze()."""
+    significant_connections = SignificantConnections([])
+    working_channel = _RecordingChannel()
+
+    class _FailingChannel:
+        def send(self, event: dict[str, Any]) -> None:
+            raise RuntimeError("channel unavailable")
+
+    insights: dict[str, Any] = {"countries": {"NO": {"l": 1, "m": (1 << 7) - 1}}}
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        insights,
+        significant_connections,
+        _empty_history(),
+        notification_channels=[_FailingChannel(), working_channel],
+        notification_learning_days=7,
+    )
+
+    result = analyzer.analyze([_connection(country_code="US")])
+
+    assert len(significant_connections.items) == 1
+    assert working_channel.received == [significant_connections.items[0]]
+    assert set(result.keys()) == {"new", "top"}
+
+
+def test_default_construction_has_no_channels_and_does_not_dispatch() -> None:
+    """Omitting notification_channels defaults to an empty list: storage only, no dispatch."""
+    significant_connections = SignificantConnections([])
+    insights: dict[str, Any] = {"countries": {"NO": {"l": 1, "m": (1 << 7) - 1}}}
+    analyzer = ConnectionAnalyzer(
+        ConnectionState(),
+        UnmappedState(),
+        insights,
+        significant_connections,
+        _empty_history(),
+        notification_learning_days=7,
+    )
+
+    analyzer.analyze([_connection(country_code="US")])
+
+    assert len(significant_connections.items) == 1

--- a/tests/test_connection_analyzer.py
+++ b/tests/test_connection_analyzer.py
@@ -13,7 +13,7 @@ from tapmap.state.unmapped_state import UnmappedState
 
 
 class _RecordingChannel:
-    """Test double that records every event handed to it."""
+    """Record events sent to the channel."""
 
     def __init__(self) -> None:
         self.received: list[dict[str, Any]] = []
@@ -311,13 +311,12 @@ def test_verification_backfill_does_not_suppress_a_later_verification_failed_eve
 
 
 def test_no_dispatch_during_learning_period() -> None:
-    """A Significant Connection is stored, but not dispatched, before the threshold is met."""
     significant_connections = SignificantConnections([])
     channel = _RecordingChannel()
     analyzer = ConnectionAnalyzer(
         ConnectionState(),
         UnmappedState(),
-        {},  # no Insights history: 0 distinct active days
+        {},
         significant_connections,
         _empty_history(),
         notification_channels=[channel],
@@ -331,12 +330,11 @@ def test_no_dispatch_during_learning_period() -> None:
 
 
 def test_dispatch_after_learning_period_is_over() -> None:
-    """Once enough Insights history exists, a newly accepted event is dispatched immediately."""
     significant_connections = SignificantConnections([])
     channel = _RecordingChannel()
     # "l" (anchor day) is irrelevant here: distinct_active_days() only reads "m".
     insights: dict[str, Any] = {
-        "countries": {"NO": {"l": 1, "m": (1 << 7) - 1}},  # 7 distinct active days already
+        "countries": {"NO": {"l": 1, "m": (1 << 7) - 1}},
     }
     analyzer = ConnectionAnalyzer(
         ConnectionState(),
@@ -354,34 +352,7 @@ def test_dispatch_after_learning_period_is_over() -> None:
     assert channel.received == [significant_connections.items[0]]
 
 
-def test_dispatch_zero_threshold_is_immediately_eligible() -> None:
-    """A zero learning-period threshold dispatches from the very first Significant Connection."""
-    significant_connections = SignificantConnections([])
-    channel = _RecordingChannel()
-    analyzer = ConnectionAnalyzer(
-        ConnectionState(),
-        UnmappedState(),
-        {},
-        significant_connections,
-        _empty_history(),
-        notification_channels=[channel],
-        notification_learning_days=0,
-    )
-
-    analyzer.analyze([_connection(country_code="US")])
-
-    assert channel.received == significant_connections.items
-
-
 def test_current_poll_does_not_count_toward_its_own_eligibility() -> None:
-    """Eligibility is checked against Insights as of the previous poll, not this one.
-
-    Regression test for the established off-by-one behavior: process_insights()
-    (which would add today's day to the bitmask) only runs once, after the
-    entire per-connection loop - so a connection that would itself push the
-    active-day count over the threshold is not dispatched in the same poll
-    that creates it, even though it is still stored as usual.
-    """
     significant_connections = SignificantConnections([])
     channel = _RecordingChannel()
     # 6 active days already recorded; today's observation would be the 7th,
@@ -403,48 +374,3 @@ def test_current_poll_does_not_count_toward_its_own_eligibility() -> None:
 
     assert len(significant_connections.items) == 1
     assert channel.received == []
-
-
-def test_a_failing_channel_does_not_prevent_another_or_break_analyze() -> None:
-    """A channel that raises does not stop delivery to other channels or break analyze()."""
-    significant_connections = SignificantConnections([])
-    working_channel = _RecordingChannel()
-
-    class _FailingChannel:
-        def send(self, event: dict[str, Any]) -> None:
-            raise RuntimeError("channel unavailable")
-
-    insights: dict[str, Any] = {"countries": {"NO": {"l": 1, "m": (1 << 7) - 1}}}
-    analyzer = ConnectionAnalyzer(
-        ConnectionState(),
-        UnmappedState(),
-        insights,
-        significant_connections,
-        _empty_history(),
-        notification_channels=[_FailingChannel(), working_channel],
-        notification_learning_days=7,
-    )
-
-    result = analyzer.analyze([_connection(country_code="US")])
-
-    assert len(significant_connections.items) == 1
-    assert working_channel.received == [significant_connections.items[0]]
-    assert set(result.keys()) == {"new", "top"}
-
-
-def test_default_construction_has_no_channels_and_does_not_dispatch() -> None:
-    """Omitting notification_channels defaults to an empty list: storage only, no dispatch."""
-    significant_connections = SignificantConnections([])
-    insights: dict[str, Any] = {"countries": {"NO": {"l": 1, "m": (1 << 7) - 1}}}
-    analyzer = ConnectionAnalyzer(
-        ConnectionState(),
-        UnmappedState(),
-        insights,
-        significant_connections,
-        _empty_history(),
-        notification_learning_days=7,
-    )
-
-    analyzer.analyze([_connection(country_code="US")])
-
-    assert len(significant_connections.items) == 1

--- a/tests/test_geodb_maxmind.py
+++ b/tests/test_geodb_maxmind.py
@@ -61,6 +61,7 @@ def _runtime_ctx(tmp_path: Path) -> RuntimeContext:
         location_override=None,
         security_extensions_dir=tmp_path,
         tray_icon_path=tmp_path / "tapmap.ico",
+        notification_learning_days=7,
     )
 
 

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -580,24 +580,20 @@ class TestInputFiltering:
 
 
 class TestDistinctActiveDays:
-    """Test distinct_active_days(): OR bitmasks across all dimensions, then bit_count()."""
+    """Test distinct active-day counting across Insights dimensions."""
 
     def test_empty_insights_returns_zero(self) -> None:
-        """No dimensions at all: zero active days."""
         assert distinct_active_days({}) == 0
 
     def test_empty_dimensions_return_zero(self) -> None:
-        """Dimensions present but with no entries: zero active days."""
         insights = {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
         assert distinct_active_days(insights) == 0
 
     def test_single_entry_single_bit(self) -> None:
-        """One entry observed only today contributes exactly one active day."""
         insights = {"countries": {"US": {"l": _day(1), "m": _bits(0)}}}
         assert distinct_active_days(insights) == 1
 
     def test_same_day_across_dimensions_counts_once(self) -> None:
-        """Two dimensions both active on the same day count as one active day, not two."""
         insights = {
             "countries": {"US": {"l": _day(1), "m": _bits(0)}},
             "providers": {"Acme Inc": {"l": _day(1), "m": _bits(0)}},
@@ -605,7 +601,6 @@ class TestDistinctActiveDays:
         assert distinct_active_days(insights) == 1
 
     def test_disjoint_days_across_dimensions_are_unioned(self) -> None:
-        """Different dimensions active on different days union to the total distinct count."""
         insights = {
             "countries": {"US": {"l": _day(1), "m": _bits(0)}},
             "providers": {"Acme Inc": {"l": _day(1), "m": _bits(1, 2)}},
@@ -613,7 +608,6 @@ class TestDistinctActiveDays:
         assert distinct_active_days(insights) == 3
 
     def test_multiple_entries_same_dimension_are_unioned(self) -> None:
-        """Two keys in one dimension, active on different days, union correctly."""
         insights = {
             "applications": {
                 "Firefox": {"l": _day(1), "m": _bits(0)},
@@ -623,7 +617,6 @@ class TestDistinctActiveDays:
         assert distinct_active_days(insights) == 2
 
     def test_malformed_entries_are_ignored(self) -> None:
-        """Non-dict dimensions/entries and a missing or non-int m are skipped, not raised."""
         insights: dict[str, Any] = {
             "countries": {"US": {"l": _day(1), "m": _bits(0)}, "NO": "not-a-dict"},
             "providers": "not-a-dict-either",

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tapmap.state.insights import process_insights
+from tapmap.state.insights import distinct_active_days, process_insights
 
 # Fixed base ordinal: avoids any dependency on the wall clock.
 _BASE = date(2000, 1, 1).toordinal()
@@ -577,3 +577,56 @@ class TestInputFiltering:
         insights: dict[str, Any] = {}
         process_insights(items, insights, _now(1))
         assert insights.get("applications", {}) == {}
+
+
+class TestDistinctActiveDays:
+    """Test distinct_active_days(): OR bitmasks across all dimensions, then bit_count()."""
+
+    def test_empty_insights_returns_zero(self) -> None:
+        """No dimensions at all: zero active days."""
+        assert distinct_active_days({}) == 0
+
+    def test_empty_dimensions_return_zero(self) -> None:
+        """Dimensions present but with no entries: zero active days."""
+        insights = {"countries": {}, "providers": {}, "ports": {}, "applications": {}}
+        assert distinct_active_days(insights) == 0
+
+    def test_single_entry_single_bit(self) -> None:
+        """One entry observed only today contributes exactly one active day."""
+        insights = {"countries": {"US": {"l": _day(1), "m": _bits(0)}}}
+        assert distinct_active_days(insights) == 1
+
+    def test_same_day_across_dimensions_counts_once(self) -> None:
+        """Two dimensions both active on the same day count as one active day, not two."""
+        insights = {
+            "countries": {"US": {"l": _day(1), "m": _bits(0)}},
+            "providers": {"Acme Inc": {"l": _day(1), "m": _bits(0)}},
+        }
+        assert distinct_active_days(insights) == 1
+
+    def test_disjoint_days_across_dimensions_are_unioned(self) -> None:
+        """Different dimensions active on different days union to the total distinct count."""
+        insights = {
+            "countries": {"US": {"l": _day(1), "m": _bits(0)}},
+            "providers": {"Acme Inc": {"l": _day(1), "m": _bits(1, 2)}},
+        }
+        assert distinct_active_days(insights) == 3
+
+    def test_multiple_entries_same_dimension_are_unioned(self) -> None:
+        """Two keys in one dimension, active on different days, union correctly."""
+        insights = {
+            "applications": {
+                "Firefox": {"l": _day(1), "m": _bits(0)},
+                "GIMP": {"l": _day(1), "m": _bits(5)},
+            }
+        }
+        assert distinct_active_days(insights) == 2
+
+    def test_malformed_entries_are_ignored(self) -> None:
+        """Non-dict dimensions/entries and a missing or non-int m are skipped, not raised."""
+        insights: dict[str, Any] = {
+            "countries": {"US": {"l": _day(1), "m": _bits(0)}, "NO": "not-a-dict"},
+            "providers": "not-a-dict-either",
+            "ports": {"443": {"l": _day(1)}},
+        }
+        assert distinct_active_days(insights) == 1

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -28,6 +28,7 @@ def _runtime_ctx(tmp_path: Path) -> RuntimeContext:
         location_override=None,
         security_extensions_dir=tmp_path,
         tray_icon_path=tmp_path,
+        notification_learning_days=7,
     )
 
 

--- a/tests/test_mqtt_cli.py
+++ b/tests/test_mqtt_cli.py
@@ -91,7 +91,7 @@ def _capturing() -> tuple[Any, list[str]]:
 
 def _existing_config(**overrides: object) -> MqttConfig:
     values: dict[str, object] = {
-        "host": "old.example.com",
+        "host": "198.51.100.10",
         "port": 1883,
         "topic": "old/topic",
         "tls": False,
@@ -110,7 +110,7 @@ def test_fresh_setup_without_auth(tmp_path: Path, fake_keyring: _FakeKeyring) ->
 
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "n"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "n"]),
         prompt_secret=lambda q: secret_calls.append(q) or "unused",
         output=output,
     )
@@ -118,7 +118,7 @@ def test_fresh_setup_without_auth(tmp_path: Path, fake_keyring: _FakeKeyring) ->
     assert result == 0
     config = load_mqtt_config(mqtt_config_path(tmp_path))
     assert config == MqttConfig(
-        host="broker.local",
+        host="192.0.2.1",
         port=1883,
         topic="tapmap/significant_connections",
         tls=False,
@@ -136,7 +136,7 @@ def test_fresh_setup_with_tls_derives_default_port(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "y", "", "", "n"]),
+        prompt=_scripted(["192.0.2.1", "y", "", "", "n"]),
         output=_capturing()[0],
     )
 
@@ -153,7 +153,7 @@ def test_fresh_setup_with_auth_desktop_stores_in_keyring(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "y"]),
         prompt_secret=lambda q: "secret1",
         output=_capturing()[0],
     )
@@ -173,7 +173,7 @@ def test_password_prompt_is_preceded_by_hidden_input_notice(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "y"]),
         prompt_secret=lambda q: "secret1",
         output=output,
     )
@@ -188,7 +188,7 @@ def test_fresh_setup_with_auth_docker_stores_in_file(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "y"]),
         prompt_secret=lambda q: "secret1",
         output=_capturing()[0],
     )
@@ -205,7 +205,7 @@ def test_username_without_password_is_allowed(tmp_path: Path, fake_keyring: _Fak
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "y"]),
         prompt_secret=lambda q: "",
         output=_capturing()[0],
     )
@@ -223,13 +223,41 @@ def test_host_is_required_and_reprompts_on_blank(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["", "", "broker.local", "n", "", "", "n"]),
+        prompt=_scripted(["", "", "192.0.2.1", "n", "", "", "n"]),
         output=_capturing()[0],
     )
 
     config = load_mqtt_config(mqtt_config_path(tmp_path))
     assert config is not None
-    assert config.host == "broker.local"
+    assert config.host == "192.0.2.1"
+
+
+def test_host_rejects_dns_name_and_reprompts(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "192.0.2.1", "n", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.host == "192.0.2.1"
+
+
+def test_host_accepts_ipv6(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["2001:db8::1", "n", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.host == "2001:db8::1"
 
 
 def test_invalid_port_reprompts(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
@@ -237,7 +265,7 @@ def test_invalid_port_reprompts(tmp_path: Path, fake_keyring: _FakeKeyring) -> N
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "abc", "70000", "9000", "", "n"]),
+        prompt=_scripted(["192.0.2.1", "n", "abc", "70000", "9000", "", "n"]),
         output=_capturing()[0],
     )
 
@@ -259,13 +287,13 @@ def test_reconfigure_keeps_existing_credentials_on_desktop(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["n", "new.example.com", "y", "", "", "y", "y"]),
+        prompt=_scripted(["n", "203.0.113.20", "y", "", "", "y", "y"]),
         output=_capturing()[0],
     )
 
     config = load_mqtt_config(mqtt_config_path(tmp_path))
     assert config is not None
-    assert config.host == "new.example.com"
+    assert config.host == "203.0.113.20"
     assert config.tls is True
     # Changing TLS updates an unchanged standard port to the new standard.
     assert config.port == 8883
@@ -281,7 +309,7 @@ def test_reconfigure_replaces_credentials_on_docker(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["n", "new.example.com", "n", "", "", "y", "n", "bob", "y"]),
+        prompt=_scripted(["n", "203.0.113.20", "n", "", "", "y", "n", "bob", "y"]),
         prompt_secret=lambda q: "newpass",
         output=_capturing()[0],
     )
@@ -302,7 +330,7 @@ def test_turning_auth_off_clears_desktop_keyring(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["n", "new.example.com", "n", "", "", "n"]),
+        prompt=_scripted(["n", "203.0.113.20", "n", "", "", "n"]),
         output=_capturing()[0],
     )
 
@@ -356,7 +384,7 @@ def test_save_failure_returns_nonzero_and_does_not_raise(
     output, lines = _capturing()
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "n"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "n"]),
         output=output,
     )
 
@@ -375,7 +403,7 @@ def test_plaintext_auth_warning_uses_exact_wording(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"], asked=asked),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "y"], asked=asked),
         prompt_secret=lambda q: "secret1",
         output=_capturing()[0],
     )
@@ -397,7 +425,7 @@ def test_declining_plaintext_auth_warning_saves_nothing(
 
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "n"]),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "y", "alice", "n"]),
         prompt_secret=lambda q: "secret1",
         output=output,
     )
@@ -417,7 +445,7 @@ def test_declining_plaintext_auth_warning_does_not_change_docker_config(
 
     run_configure_mqtt(
         runtime,
-        prompt=_scripted(["n", "new.example.com", "n", "", "", "y", "n", "bob", "n"]),
+        prompt=_scripted(["n", "203.0.113.20", "n", "", "", "y", "n", "bob", "n"]),
         prompt_secret=lambda q: "newpass",
         output=_capturing()[0],
     )
@@ -433,7 +461,7 @@ def test_no_warning_when_auth_is_off(tmp_path: Path, fake_keyring: _FakeKeyring)
 
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "n", "", "", "n"], asked=asked),
+        prompt=_scripted(["192.0.2.1", "n", "", "", "n"], asked=asked),
         output=_capturing()[0],
     )
 
@@ -456,7 +484,7 @@ def test_failed_save_does_not_set_desktop_keyring_credentials(
 
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["broker.local", "y", "", "", "y", "alice"]),
+        prompt=_scripted(["192.0.2.1", "y", "", "", "y", "alice"]),
         prompt_secret=lambda q: "secret1",
         output=_capturing()[0],
     )
@@ -480,7 +508,7 @@ def test_failed_save_does_not_clear_desktop_keyring_credentials(
 
     result = run_configure_mqtt(
         runtime,
-        prompt=_scripted(["n", "new.example.com", "n", "", "", "n"]),
+        prompt=_scripted(["n", "203.0.113.20", "n", "", "", "n"]),
         output=_capturing()[0],
     )
 

--- a/tests/test_mqtt_cli.py
+++ b/tests/test_mqtt_cli.py
@@ -22,7 +22,7 @@ from tapmap.runtime import RuntimeContext
 
 
 class _FakeKeyring:
-    """In-memory stand-in for the keyring backend."""
+    """Provide an in-memory keyring backend."""
 
     def __init__(self) -> None:
         self._store: dict[tuple[str, str], str] = {}
@@ -70,11 +70,7 @@ def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
 
 
 def _scripted(answers: list[str], *, asked: list[str] | None = None) -> Any:
-    """Return a callable that pops canned answers in order.
-
-    If asked is given, every question text passed to the callable is
-    recorded there, in order.
-    """
+    """Return a prompt callable that consumes scripted answers."""
     remaining = list(answers)
 
     def _prompt(question: str) -> str:
@@ -88,7 +84,7 @@ def _scripted(answers: list[str], *, asked: list[str] | None = None) -> Any:
 
 
 def _capturing() -> tuple[Any, list[str]]:
-    """Return an output callable and the list it appends printed lines to."""
+    """Return an output callable and its captured lines."""
     lines: list[str] = []
     return lines.append, lines
 
@@ -129,7 +125,7 @@ def test_fresh_setup_without_auth(tmp_path: Path, fake_keyring: _FakeKeyring) ->
         username=None,
         password=None,
     )
-    assert secret_calls == []  # never prompted for a password when auth is off
+    assert secret_calls == []
     assert any("saved" in line.lower() for line in lines)
 
 
@@ -201,7 +197,7 @@ def test_fresh_setup_with_auth_docker_stores_in_file(
     assert config is not None
     assert config.username == "alice"
     assert config.password == "secret1"
-    assert get_stored_credentials() == (None, None)  # keyring untouched in Docker
+    assert get_stored_credentials() == (None, None)
 
 
 def test_username_without_password_is_allowed(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
@@ -210,7 +206,7 @@ def test_username_without_password_is_allowed(tmp_path: Path, fake_keyring: _Fak
     run_configure_mqtt(
         runtime,
         prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
-        prompt_secret=lambda q: "",  # left empty
+        prompt_secret=lambda q: "",
         output=_capturing()[0],
     )
 
@@ -271,12 +267,10 @@ def test_reconfigure_keeps_existing_credentials_on_desktop(
     assert config is not None
     assert config.host == "new.example.com"
     assert config.tls is True
-    # existing port (1883) was the standard port for the old TLS=off setting,
-    # and TLS just changed to on, so the standard port for TLS=on is proposed
-    # and accepted here via the blank answer - see _derive_default_port.
+    # Changing TLS updates an unchanged standard port to the new standard.
     assert config.port == 8883
     assert config.username is None
-    assert get_stored_credentials() == ("alice", "secret1")  # untouched
+    assert get_stored_credentials() == ("alice", "secret1")
 
 
 def test_reconfigure_replaces_credentials_on_docker(
@@ -343,7 +337,7 @@ def test_disable_on_docker_does_not_touch_keyring(
     run_configure_mqtt(runtime, prompt=_scripted(["y"]), output=_capturing()[0])
 
     assert not path.exists()
-    assert get_stored_credentials() == (None, None)  # never touched keyring at all
+    assert get_stored_credentials() == (None, None)
 
 
 # --- failure handling ---
@@ -462,8 +456,6 @@ def test_failed_save_does_not_set_desktop_keyring_credentials(
 
     result = run_configure_mqtt(
         runtime,
-        # tls=y so this exercises point 4 in isolation, without the
-        # plaintext warning from point 3 also being in play.
         prompt=_scripted(["broker.local", "y", "", "", "y", "alice"]),
         prompt_secret=lambda q: "secret1",
         output=_capturing()[0],
@@ -547,7 +539,6 @@ def test_reconfigure_end_to_end_proposes_tls_standard_port(
 
     run_configure_mqtt(
         runtime,
-        # disable?no, host(""->keep old), tls=y, port(""->accept shown default), topic(""), auth off
         prompt=_scripted(["n", "", "y", "", "", "n"]),
         output=_capturing()[0],
     )

--- a/tests/test_mqtt_cli.py
+++ b/tests/test_mqtt_cli.py
@@ -1,0 +1,557 @@
+"""Tests for the interactive `tapmap --configure-mqtt` flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import keyring
+import keyring.errors
+import pytest
+
+from tapmap.app import APP_META
+from tapmap.mqtt_cli import _derive_default_port, run_configure_mqtt
+from tapmap.mqtt_config import (
+    MqttConfig,
+    get_stored_credentials,
+    load_mqtt_config,
+    mqtt_config_path,
+    save_mqtt_config,
+)
+from tapmap.runtime import RuntimeContext
+
+
+class _FakeKeyring:
+    """In-memory stand-in for the keyring backend."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, key: str) -> str | None:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        try:
+            del self._store[(service, key)]
+        except KeyError:
+            raise keyring.errors.PasswordDeleteError("not found") from None
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
+    fake = _FakeKeyring()
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    return fake
+
+
+def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
+    return RuntimeContext(
+        meta=APP_META,
+        app_data_dir=tmp_path,
+        run_dir=tmp_path,
+        is_frozen=False,
+        net_backend="psutil",
+        net_backend_version="test",
+        server_host="127.0.0.1",
+        server_port=8050,
+        launch_browser=True,
+        cache_retention_min=0,
+        is_docker=is_docker,
+        location_override=None,
+        security_extensions_dir=tmp_path,
+        tray_icon_path=tmp_path / "tapmap.ico",
+        notification_learning_days=7,
+    )
+
+
+def _scripted(answers: list[str], *, asked: list[str] | None = None) -> Any:
+    """Return a callable that pops canned answers in order.
+
+    If asked is given, every question text passed to the callable is
+    recorded there, in order.
+    """
+    remaining = list(answers)
+
+    def _prompt(question: str) -> str:
+        if asked is not None:
+            asked.append(question)
+        if not remaining:
+            raise AssertionError(f"No more scripted answers; unexpected prompt: {question!r}")
+        return remaining.pop(0)
+
+    return _prompt
+
+
+def _capturing() -> tuple[Any, list[str]]:
+    """Return an output callable and the list it appends printed lines to."""
+    lines: list[str] = []
+    return lines.append, lines
+
+
+def _existing_config(**overrides: object) -> MqttConfig:
+    values: dict[str, object] = {
+        "host": "old.example.com",
+        "port": 1883,
+        "topic": "old/topic",
+        "tls": False,
+    }
+    values.update(overrides)
+    return MqttConfig(**values)  # type: ignore[arg-type]
+
+
+# --- fresh setup ---
+
+
+def test_fresh_setup_without_auth(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    output, lines = _capturing()
+    secret_calls: list[str] = []
+
+    result = run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "n"]),
+        prompt_secret=lambda q: secret_calls.append(q) or "unused",
+        output=output,
+    )
+
+    assert result == 0
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config == MqttConfig(
+        host="broker.local",
+        port=1883,
+        topic="tapmap/significant_connections",
+        tls=False,
+        username=None,
+        password=None,
+    )
+    assert secret_calls == []  # never prompted for a password when auth is off
+    assert any("saved" in line.lower() for line in lines)
+
+
+def test_fresh_setup_with_tls_derives_default_port(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "y", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.tls is True
+    assert config.port == 8883
+
+
+def test_fresh_setup_with_auth_desktop_stores_in_keyring(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt_secret=lambda q: "secret1",
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.username is None
+    assert config.password is None
+    assert get_stored_credentials() == ("alice", "secret1")
+
+
+def test_password_prompt_is_preceded_by_hidden_input_notice(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    output, lines = _capturing()
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt_secret=lambda q: "secret1",
+        output=output,
+    )
+
+    assert "Input is hidden - nothing will appear as you type." in lines
+
+
+def test_fresh_setup_with_auth_docker_stores_in_file(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt_secret=lambda q: "secret1",
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.username == "alice"
+    assert config.password == "secret1"
+    assert get_stored_credentials() == (None, None)  # keyring untouched in Docker
+
+
+def test_username_without_password_is_allowed(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"]),
+        prompt_secret=lambda q: "",  # left empty
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.username == "alice"
+    assert config.password is None
+
+
+def test_host_is_required_and_reprompts_on_blank(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["", "", "broker.local", "n", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.host == "broker.local"
+
+
+def test_invalid_port_reprompts(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "abc", "70000", "9000", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.port == 9000
+
+
+# --- reconfigure / disable ---
+
+
+def test_reconfigure_keeps_existing_credentials_on_desktop(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _existing_config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["n", "new.example.com", "y", "", "", "y", "y"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.host == "new.example.com"
+    assert config.tls is True
+    # existing port (1883) was the standard port for the old TLS=off setting,
+    # and TLS just changed to on, so the standard port for TLS=on is proposed
+    # and accepted here via the blank answer - see _derive_default_port.
+    assert config.port == 8883
+    assert config.username is None
+    assert get_stored_credentials() == ("alice", "secret1")  # untouched
+
+
+def test_reconfigure_replaces_credentials_on_docker(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+    save_mqtt_config(mqtt_config_path(tmp_path), _existing_config(username="alice", password="old"))
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["n", "new.example.com", "n", "", "", "y", "n", "bob", "y"]),
+        prompt_secret=lambda q: "newpass",
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.username == "bob"
+    assert config.password == "newpass"
+
+
+def test_turning_auth_off_clears_desktop_keyring(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _existing_config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["n", "new.example.com", "n", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    assert get_stored_credentials() == (None, None)
+
+
+def test_disable_deletes_file_and_clears_desktop_credentials(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    path = mqtt_config_path(tmp_path)
+    save_mqtt_config(path, _existing_config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    output, lines = _capturing()
+    result = run_configure_mqtt(runtime, prompt=_scripted(["y"]), output=output)
+
+    assert result == 0
+    assert not path.exists()
+    assert get_stored_credentials() == (None, None)
+    assert any("disabled" in line.lower() for line in lines)
+
+
+def test_disable_on_docker_does_not_touch_keyring(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+    path = mqtt_config_path(tmp_path)
+    save_mqtt_config(path, _existing_config(username="alice", password="secret1"))
+
+    run_configure_mqtt(runtime, prompt=_scripted(["y"]), output=_capturing()[0])
+
+    assert not path.exists()
+    assert get_stored_credentials() == (None, None)  # never touched keyring at all
+
+
+# --- failure handling ---
+
+
+def test_save_failure_returns_nonzero_and_does_not_raise(
+    tmp_path: Path, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+
+    def _raise_oserror(path: Path, config: MqttConfig) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("tapmap.mqtt_cli.save_mqtt_config", _raise_oserror)
+
+    output, lines = _capturing()
+    result = run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "n"]),
+        output=output,
+    )
+
+    assert result == 1
+    assert any("unable to save" in line.lower() for line in lines)
+
+
+# --- plaintext-credentials-without-TLS warning ---
+
+
+def test_plaintext_auth_warning_uses_exact_wording(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    asked: list[str] = []
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "y"], asked=asked),
+        prompt_secret=lambda q: "secret1",
+        output=_capturing()[0],
+    )
+
+    assert any(
+        q.startswith(
+            "Username/password without TLS sends credentials in plaintext "
+            "over the network. Continue? [y/N] "
+        )
+        for q in asked
+    )
+
+
+def test_declining_plaintext_auth_warning_saves_nothing(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    output, lines = _capturing()
+
+    result = run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "y", "alice", "n"]),
+        prompt_secret=lambda q: "secret1",
+        output=output,
+    )
+
+    assert result == 0
+    assert not mqtt_config_path(tmp_path).exists()
+    assert get_stored_credentials() == (None, None)
+    assert any("not saved" in line.lower() for line in lines)
+
+
+def test_declining_plaintext_auth_warning_does_not_change_docker_config(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+    path = mqtt_config_path(tmp_path)
+    save_mqtt_config(path, _existing_config(username="alice", password="old"))
+
+    run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["n", "new.example.com", "n", "", "", "y", "n", "bob", "n"]),
+        prompt_secret=lambda q: "newpass",
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(path)
+    assert config == _existing_config(username="alice", password="old")
+
+
+def test_no_warning_when_auth_is_off(tmp_path: Path, fake_keyring: _FakeKeyring) -> None:
+    """TLS off with no auth requested never prompts the plaintext warning."""
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    asked: list[str] = []
+
+    result = run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["broker.local", "n", "", "", "n"], asked=asked),
+        output=_capturing()[0],
+    )
+
+    assert result == 0
+    assert not any("plaintext" in q.lower() for q in asked)
+
+
+# --- credential changes deferred until after a successful save ---
+
+
+def test_failed_save_does_not_set_desktop_keyring_credentials(
+    tmp_path: Path, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+
+    def _raise_oserror(path: Path, config: MqttConfig) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("tapmap.mqtt_cli.save_mqtt_config", _raise_oserror)
+
+    result = run_configure_mqtt(
+        runtime,
+        # tls=y so this exercises point 4 in isolation, without the
+        # plaintext warning from point 3 also being in play.
+        prompt=_scripted(["broker.local", "y", "", "", "y", "alice"]),
+        prompt_secret=lambda q: "secret1",
+        output=_capturing()[0],
+    )
+
+    assert result == 1
+    assert get_stored_credentials() == (None, None)
+
+
+def test_failed_save_does_not_clear_desktop_keyring_credentials(
+    tmp_path: Path, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _existing_config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    def _raise_oserror(path: Path, config: MqttConfig) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("tapmap.mqtt_cli.save_mqtt_config", _raise_oserror)
+
+    result = run_configure_mqtt(
+        runtime,
+        prompt=_scripted(["n", "new.example.com", "n", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    assert result == 1
+    assert get_stored_credentials() == ("alice", "secret1")
+
+
+# --- default port derivation when TLS changes on reconfigure ---
+
+
+def test_derive_default_port_fresh_setup_plain() -> None:
+    assert _derive_default_port(None, False) == 1883
+
+
+def test_derive_default_port_fresh_setup_tls() -> None:
+    assert _derive_default_port(None, True) == 8883
+
+
+def test_derive_default_port_standard_port_follows_tls_off_to_on() -> None:
+    existing = _existing_config(tls=False, port=1883)
+    assert _derive_default_port(existing, True) == 8883
+
+
+def test_derive_default_port_standard_port_follows_tls_on_to_off() -> None:
+    existing = _existing_config(tls=True, port=8883)
+    assert _derive_default_port(existing, False) == 1883
+
+
+def test_derive_default_port_unchanged_tls_keeps_existing_port() -> None:
+    existing = _existing_config(tls=False, port=1883)
+    assert _derive_default_port(existing, False) == 1883
+
+
+def test_derive_default_port_custom_port_preserved_off_to_on() -> None:
+    existing = _existing_config(tls=False, port=9000)
+    assert _derive_default_port(existing, True) == 9000
+
+
+def test_derive_default_port_custom_port_preserved_on_to_off() -> None:
+    existing = _existing_config(tls=True, port=9000)
+    assert _derive_default_port(existing, False) == 9000
+
+
+def test_derive_default_port_nonstandard_pairing_is_treated_as_custom() -> None:
+    """Port 1883 while TLS was already on doesn't match the old standard, so it's preserved."""
+    existing = _existing_config(tls=True, port=1883)
+    assert _derive_default_port(existing, False) == 1883
+
+
+def test_reconfigure_end_to_end_proposes_tls_standard_port(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
+    """The derived default is actually wired into the reconfigure prompt flow."""
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _existing_config(tls=False, port=1883))
+
+    run_configure_mqtt(
+        runtime,
+        # disable?no, host(""->keep old), tls=y, port(""->accept shown default), topic(""), auth off
+        prompt=_scripted(["n", "", "y", "", "", "n"]),
+        output=_capturing()[0],
+    )
+
+    config = load_mqtt_config(mqtt_config_path(tmp_path))
+    assert config is not None
+    assert config.port == 8883

--- a/tests/test_mqtt_config.py
+++ b/tests/test_mqtt_config.py
@@ -1,0 +1,257 @@
+"""Tests for MQTT configuration and credential persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import keyring
+import keyring.errors
+import pytest
+
+from tapmap.mqtt_config import (
+    KEYRING_SERVICE,
+    MqttConfig,
+    clear_credentials,
+    delete_mqtt_config,
+    get_stored_credentials,
+    load_mqtt_config,
+    mqtt_config_path,
+    save_mqtt_config,
+    set_credentials,
+)
+
+
+class _FakeKeyring:
+    """In-memory stand-in for the keyring backend, keyed like the real API."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, key: str) -> str | None:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        try:
+            del self._store[(service, key)]
+        except KeyError:
+            raise keyring.errors.PasswordDeleteError("not found") from None
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
+    """Replace the keyring module's functions with an in-memory fake."""
+    fake = _FakeKeyring()
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    return fake
+
+
+def _config(**overrides: object) -> MqttConfig:
+    values: dict[str, object] = {
+        "host": "192.168.1.50",
+        "port": 1883,
+        "topic": "tapmap/significant_connections",
+        "tls": False,
+    }
+    values.update(overrides)
+    return MqttConfig(**values)  # type: ignore[arg-type]
+
+
+# --- mqtt_config_path ---
+
+
+def test_mqtt_config_path_is_under_app_data_dir(tmp_path: Path) -> None:
+    assert mqtt_config_path(tmp_path) == tmp_path / "mqtt.json"
+
+
+# --- load/save/delete round-trip ---
+
+
+def test_missing_file_returns_none(tmp_path: Path) -> None:
+    assert load_mqtt_config(tmp_path / "mqtt.json") is None
+
+
+def test_round_trip_desktop_shape(tmp_path: Path) -> None:
+    """A config with no credentials round-trips exactly."""
+    path = tmp_path / "mqtt.json"
+    config = _config(host="mqtt.example.com", port=8883, tls=True)
+
+    save_mqtt_config(path, config)
+    loaded = load_mqtt_config(path)
+
+    assert loaded == config
+
+
+def test_round_trip_docker_shape_with_credentials(tmp_path: Path) -> None:
+    """A config with embedded credentials (the Docker shape) round-trips exactly."""
+    path = tmp_path / "mqtt.json"
+    config = _config(username="alice", password="secret")
+
+    save_mqtt_config(path, config)
+    loaded = load_mqtt_config(path)
+
+    assert loaded == config
+
+
+def test_round_trip_username_without_password(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    config = _config(username="alice", password=None)
+
+    save_mqtt_config(path, config)
+    loaded = load_mqtt_config(path)
+
+    assert loaded == config
+
+
+def test_save_omits_null_credential_fields_from_the_file(tmp_path: Path) -> None:
+    """The desktop shape (no credentials) never writes username/password keys, not even null."""
+    path = tmp_path / "mqtt.json"
+    save_mqtt_config(path, _config())
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert "username" not in raw
+    assert "password" not in raw
+
+
+def test_save_includes_credential_fields_when_present(tmp_path: Path) -> None:
+    """The Docker shape (credentials present) writes both fields."""
+    path = tmp_path / "mqtt.json"
+    save_mqtt_config(path, _config(username="alice", password="secret"))
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["username"] == "alice"
+    assert raw["password"] == "secret"
+
+
+def test_save_omits_password_key_when_only_username_is_set(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    save_mqtt_config(path, _config(username="alice", password=None))
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["username"] == "alice"
+    assert "password" not in raw
+
+
+def test_save_restricts_file_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """save_mqtt_config chmods the file to 0600, since it may hold credentials."""
+    chmod_calls: list[int] = []
+    original_chmod = Path.chmod
+
+    def _recording_chmod(self: Path, mode: int) -> None:
+        chmod_calls.append(mode)
+        original_chmod(self, mode)
+
+    monkeypatch.setattr(Path, "chmod", _recording_chmod)
+
+    save_mqtt_config(tmp_path / "mqtt.json", _config(username="alice", password="secret"))
+
+    assert 0o600 in chmod_calls
+
+
+def test_delete_removes_file(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    save_mqtt_config(path, _config())
+    assert path.exists()
+
+    delete_mqtt_config(path)
+
+    assert not path.exists()
+    assert load_mqtt_config(path) is None
+
+
+def test_delete_missing_file_is_a_no_op(tmp_path: Path) -> None:
+    delete_mqtt_config(tmp_path / "mqtt.json")  # must not raise
+
+
+# --- malformed/tolerant loading ---
+
+
+def test_malformed_json_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    assert load_mqtt_config(path) is None
+
+
+def test_json_not_an_object_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    path.write_text("[]", encoding="utf-8")
+    assert load_mqtt_config(path) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        '{"port": 1883, "topic": "t", "tls": false}',  # missing host
+        '{"host": "h", "topic": "t", "tls": false}',  # missing port
+        '{"host": "h", "port": "1883", "topic": "t", "tls": false}',  # port not an int
+        '{"host": "h", "port": 1883, "tls": false}',  # missing topic
+        '{"host": "h", "port": 1883, "topic": "t"}',  # missing tls
+        '{"host": "h", "port": 1883, "topic": "t", "tls": "false"}',  # tls not a bool
+        '{"host": "", "port": 1883, "topic": "t", "tls": false}',  # empty host
+    ],
+)
+def test_missing_or_invalid_required_fields_return_none(tmp_path: Path, data: str) -> None:
+    path = tmp_path / "mqtt.json"
+    path.write_text(data, encoding="utf-8")
+    assert load_mqtt_config(path) is None
+
+
+# --- keyring credential storage ---
+
+
+def test_get_stored_credentials_when_none_stored_returns_none_none(
+    fake_keyring: _FakeKeyring,
+) -> None:
+    assert get_stored_credentials() == (None, None)
+
+
+def test_set_and_get_credentials_with_password(fake_keyring: _FakeKeyring) -> None:
+    set_credentials("alice", "secret")
+    assert get_stored_credentials() == ("alice", "secret")
+
+
+def test_set_credentials_without_password_stores_username_only(
+    fake_keyring: _FakeKeyring,
+) -> None:
+    set_credentials("alice", None)
+    assert get_stored_credentials() == ("alice", None)
+
+
+def test_set_credentials_with_empty_password_is_treated_as_none(
+    fake_keyring: _FakeKeyring,
+) -> None:
+    set_credentials("alice", "")
+    assert get_stored_credentials() == ("alice", None)
+
+
+def test_replacing_password_with_none_clears_the_stored_password(
+    fake_keyring: _FakeKeyring,
+) -> None:
+    set_credentials("alice", "secret")
+    set_credentials("alice", None)
+    assert get_stored_credentials() == ("alice", None)
+
+
+def test_clear_credentials_removes_both(fake_keyring: _FakeKeyring) -> None:
+    set_credentials("alice", "secret")
+    clear_credentials()
+    assert get_stored_credentials() == (None, None)
+
+
+def test_clear_credentials_when_nothing_stored_does_not_raise(
+    fake_keyring: _FakeKeyring,
+) -> None:
+    clear_credentials()  # must not raise
+    assert get_stored_credentials() == (None, None)
+
+
+def test_credentials_use_dedicated_keyring_service(fake_keyring: _FakeKeyring) -> None:
+    """MQTT credentials are stored under their own service name, not MaxMind's."""
+    set_credentials("alice", "secret")
+    assert fake_keyring.get_password(KEYRING_SERVICE, "username") == "alice"
+    assert fake_keyring.get_password("tapmap_geolite2", "username") is None

--- a/tests/test_mqtt_config.py
+++ b/tests/test_mqtt_config.py
@@ -23,7 +23,7 @@ from tapmap.mqtt_config import (
 
 
 class _FakeKeyring:
-    """In-memory stand-in for the keyring backend, keyed like the real API."""
+    """Provide an in-memory keyring backend."""
 
     def __init__(self) -> None:
         self._store: dict[tuple[str, str], str] = {}
@@ -43,7 +43,7 @@ class _FakeKeyring:
 
 @pytest.fixture
 def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
-    """Replace the keyring module's functions with an in-memory fake."""
+    """Replace keyring access with an in-memory backend."""
     fake = _FakeKeyring()
     monkeypatch.setattr(keyring, "get_password", fake.get_password)
     monkeypatch.setattr(keyring, "set_password", fake.set_password)
@@ -77,7 +77,6 @@ def test_missing_file_returns_none(tmp_path: Path) -> None:
 
 
 def test_round_trip_desktop_shape(tmp_path: Path) -> None:
-    """A config with no credentials round-trips exactly."""
     path = tmp_path / "mqtt.json"
     config = _config(host="mqtt.example.com", port=8883, tls=True)
 
@@ -88,7 +87,6 @@ def test_round_trip_desktop_shape(tmp_path: Path) -> None:
 
 
 def test_round_trip_docker_shape_with_credentials(tmp_path: Path) -> None:
-    """A config with embedded credentials (the Docker shape) round-trips exactly."""
     path = tmp_path / "mqtt.json"
     config = _config(username="alice", password="secret")
 
@@ -109,7 +107,6 @@ def test_round_trip_username_without_password(tmp_path: Path) -> None:
 
 
 def test_save_omits_null_credential_fields_from_the_file(tmp_path: Path) -> None:
-    """The desktop shape (no credentials) never writes username/password keys, not even null."""
     path = tmp_path / "mqtt.json"
     save_mqtt_config(path, _config())
 
@@ -119,7 +116,6 @@ def test_save_omits_null_credential_fields_from_the_file(tmp_path: Path) -> None
 
 
 def test_save_includes_credential_fields_when_present(tmp_path: Path) -> None:
-    """The Docker shape (credentials present) writes both fields."""
     path = tmp_path / "mqtt.json"
     save_mqtt_config(path, _config(username="alice", password="secret"))
 
@@ -138,7 +134,6 @@ def test_save_omits_password_key_when_only_username_is_set(tmp_path: Path) -> No
 
 
 def test_save_restricts_file_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """save_mqtt_config chmods the file to 0600, since it may hold credentials."""
     chmod_calls: list[int] = []
     original_chmod = Path.chmod
 
@@ -165,7 +160,7 @@ def test_delete_removes_file(tmp_path: Path) -> None:
 
 
 def test_delete_missing_file_is_a_no_op(tmp_path: Path) -> None:
-    delete_mqtt_config(tmp_path / "mqtt.json")  # must not raise
+    delete_mqtt_config(tmp_path / "mqtt.json")
 
 
 # --- malformed/tolerant loading ---
@@ -186,13 +181,13 @@ def test_json_not_an_object_returns_none(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "data",
     [
-        '{"port": 1883, "topic": "t", "tls": false}',  # missing host
-        '{"host": "h", "topic": "t", "tls": false}',  # missing port
-        '{"host": "h", "port": "1883", "topic": "t", "tls": false}',  # port not an int
-        '{"host": "h", "port": 1883, "tls": false}',  # missing topic
-        '{"host": "h", "port": 1883, "topic": "t"}',  # missing tls
-        '{"host": "h", "port": 1883, "topic": "t", "tls": "false"}',  # tls not a bool
-        '{"host": "", "port": 1883, "topic": "t", "tls": false}',  # empty host
+        '{"port": 1883, "topic": "t", "tls": false}',
+        '{"host": "h", "topic": "t", "tls": false}',
+        '{"host": "h", "port": "1883", "topic": "t", "tls": false}',
+        '{"host": "h", "port": 1883, "tls": false}',
+        '{"host": "h", "port": 1883, "topic": "t"}',
+        '{"host": "h", "port": 1883, "topic": "t", "tls": "false"}',
+        '{"host": "", "port": 1883, "topic": "t", "tls": false}',
     ],
 )
 def test_missing_or_invalid_required_fields_return_none(tmp_path: Path, data: str) -> None:
@@ -246,12 +241,11 @@ def test_clear_credentials_removes_both(fake_keyring: _FakeKeyring) -> None:
 def test_clear_credentials_when_nothing_stored_does_not_raise(
     fake_keyring: _FakeKeyring,
 ) -> None:
-    clear_credentials()  # must not raise
+    clear_credentials()
     assert get_stored_credentials() == (None, None)
 
 
 def test_credentials_use_dedicated_keyring_service(fake_keyring: _FakeKeyring) -> None:
-    """MQTT credentials are stored under their own service name, not MaxMind's."""
     set_credentials("alice", "secret")
     assert fake_keyring.get_password(KEYRING_SERVICE, "username") == "alice"
     assert fake_keyring.get_password("tapmap_geolite2", "username") is None

--- a/tests/test_mqtt_config.py
+++ b/tests/test_mqtt_config.py
@@ -78,7 +78,17 @@ def test_missing_file_returns_none(tmp_path: Path) -> None:
 
 def test_round_trip_desktop_shape(tmp_path: Path) -> None:
     path = tmp_path / "mqtt.json"
-    config = _config(host="mqtt.example.com", port=8883, tls=True)
+    config = _config(host="203.0.113.5", port=8883, tls=True)
+
+    save_mqtt_config(path, config)
+    loaded = load_mqtt_config(path)
+
+    assert loaded == config
+
+
+def test_round_trip_ipv6_host(tmp_path: Path) -> None:
+    path = tmp_path / "mqtt.json"
+    config = _config(host="2001:db8::1")
 
     save_mqtt_config(path, config)
     loaded = load_mqtt_config(path)
@@ -182,12 +192,13 @@ def test_json_not_an_object_returns_none(tmp_path: Path) -> None:
     "data",
     [
         '{"port": 1883, "topic": "t", "tls": false}',
-        '{"host": "h", "topic": "t", "tls": false}',
-        '{"host": "h", "port": "1883", "topic": "t", "tls": false}',
-        '{"host": "h", "port": 1883, "tls": false}',
-        '{"host": "h", "port": 1883, "topic": "t"}',
-        '{"host": "h", "port": 1883, "topic": "t", "tls": "false"}',
+        '{"host": "192.0.2.1", "topic": "t", "tls": false}',
+        '{"host": "192.0.2.1", "port": "1883", "topic": "t", "tls": false}',
+        '{"host": "192.0.2.1", "port": 1883, "tls": false}',
+        '{"host": "192.0.2.1", "port": 1883, "topic": "t"}',
+        '{"host": "192.0.2.1", "port": 1883, "topic": "t", "tls": "false"}',
         '{"host": "", "port": 1883, "topic": "t", "tls": false}',
+        '{"host": "mqtt.example.com", "port": 1883, "topic": "t", "tls": false}',
     ],
 )
 def test_missing_or_invalid_required_fields_return_none(tmp_path: Path, data: str) -> None:

--- a/tests/test_notification_channel.py
+++ b/tests/test_notification_channel.py
@@ -9,7 +9,7 @@ from tapmap.notifications.channel import dispatch_notification
 
 
 class _RecordingChannel:
-    """Test double that records every event handed to it."""
+    """Record events sent to the channel."""
 
     def __init__(self) -> None:
         self.received: list[dict[str, Any]] = []
@@ -19,19 +19,17 @@ class _RecordingChannel:
 
 
 class _FailingChannel:
-    """Test double whose send() always raises."""
+    """Raise on every send."""
 
     def send(self, event: dict[str, Any]) -> None:
         raise RuntimeError("channel unavailable")
 
 
 def test_empty_channel_list_is_a_no_op() -> None:
-    """Dispatching with no channels configured does nothing and does not raise."""
     dispatch_notification({"ip": "8.8.8.8"}, [])
 
 
 def test_event_is_delivered_to_every_channel() -> None:
-    """The same event is handed to each configured channel."""
     a, b = _RecordingChannel(), _RecordingChannel()
     event = {"ip": "8.8.8.8"}
 
@@ -42,7 +40,6 @@ def test_event_is_delivered_to_every_channel() -> None:
 
 
 def test_one_channel_failing_does_not_prevent_another() -> None:
-    """A channel that raises does not stop delivery to the remaining channels."""
     recorder = _RecordingChannel()
     event = {"ip": "8.8.8.8"}
 
@@ -52,7 +49,6 @@ def test_one_channel_failing_does_not_prevent_another() -> None:
 
 
 def test_channel_failure_is_logged_and_not_raised(caplog: Any) -> None:
-    """A failing channel's exception is logged, never propagated to the caller."""
     with caplog.at_level(logging.ERROR, logger="tapmap.notifications.channel"):
         dispatch_notification({"ip": "8.8.8.8"}, [_FailingChannel()])
 

--- a/tests/test_notification_channel.py
+++ b/tests/test_notification_channel.py
@@ -1,0 +1,59 @@
+"""Tests for the notification channel dispatcher."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tapmap.notifications.channel import dispatch_notification
+
+
+class _RecordingChannel:
+    """Test double that records every event handed to it."""
+
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+
+    def send(self, event: dict[str, Any]) -> None:
+        self.received.append(event)
+
+
+class _FailingChannel:
+    """Test double whose send() always raises."""
+
+    def send(self, event: dict[str, Any]) -> None:
+        raise RuntimeError("channel unavailable")
+
+
+def test_empty_channel_list_is_a_no_op() -> None:
+    """Dispatching with no channels configured does nothing and does not raise."""
+    dispatch_notification({"ip": "8.8.8.8"}, [])
+
+
+def test_event_is_delivered_to_every_channel() -> None:
+    """The same event is handed to each configured channel."""
+    a, b = _RecordingChannel(), _RecordingChannel()
+    event = {"ip": "8.8.8.8"}
+
+    dispatch_notification(event, [a, b])
+
+    assert a.received == [event]
+    assert b.received == [event]
+
+
+def test_one_channel_failing_does_not_prevent_another() -> None:
+    """A channel that raises does not stop delivery to the remaining channels."""
+    recorder = _RecordingChannel()
+    event = {"ip": "8.8.8.8"}
+
+    dispatch_notification(event, [_FailingChannel(), recorder])
+
+    assert recorder.received == [event]
+
+
+def test_channel_failure_is_logged_and_not_raised(caplog: Any) -> None:
+    """A failing channel's exception is logged, never propagated to the caller."""
+    with caplog.at_level(logging.ERROR, logger="tapmap.notifications.channel"):
+        dispatch_notification({"ip": "8.8.8.8"}, [_FailingChannel()])
+
+    assert "Notification channel failed" in caplog.text

--- a/tests/test_notification_mqtt.py
+++ b/tests/test_notification_mqtt.py
@@ -19,7 +19,7 @@ from tapmap.runtime import RuntimeContext
 
 
 class _FakeKeyring:
-    """In-memory stand-in for the keyring backend."""
+    """Provide an in-memory keyring backend."""
 
     def __init__(self) -> None:
         self._store: dict[tuple[str, str], str] = {}
@@ -47,14 +47,14 @@ def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
 
 
 class _FakePublishInfo:
-    """Stand-in for paho's MQTTMessageInfo, carrying only the .rc field send() reads."""
+    """Provide the publish result code used by send()."""
 
     def __init__(self, rc: int) -> None:
         self.rc = rc
 
 
 class _FakeMqttClient:
-    """Records every call a real paho Client would make, without any network I/O."""
+    """Record MQTT client calls without network access."""
 
     def __init__(self, callback_api_version: Any, protocol: Any = None, **_: Any) -> None:
         self.callback_api_version = callback_api_version
@@ -103,7 +103,7 @@ class _FakeMqttClient:
 
 @pytest.fixture
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> type[_FakeMqttClient]:
-    """Replace paho's Client with the fake for the duration of the test."""
+    """Replace the MQTT client with the test fake."""
     monkeypatch.setattr("paho.mqtt.client.Client", _FakeMqttClient)
     return _FakeMqttClient
 
@@ -228,7 +228,6 @@ def test_paho_unavailable_returns_none(
 def test_keyring_failure_returns_none_and_does_not_raise(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A missing/broken keyring backend must not prevent TapMap startup."""
     runtime = _runtime_ctx(tmp_path, is_docker=False)
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
 
@@ -238,7 +237,7 @@ def test_keyring_failure_returns_none_and_does_not_raise(
     monkeypatch.setattr(keyring, "get_password", _raise)
 
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
-        result = create_mqtt_channel(runtime)  # must not raise
+        result = create_mqtt_channel(runtime)
 
     assert result is None
     assert "keyring" in caplog.text.lower()
@@ -269,7 +268,6 @@ def test_tls_setup_failure_returns_none_and_does_not_raise(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A broken system TLS/CA store must not prevent TapMap startup."""
     runtime = _runtime_ctx(tmp_path)
     save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=True, port=8883))
 
@@ -279,7 +277,7 @@ def test_tls_setup_failure_returns_none_and_does_not_raise(
     monkeypatch.setattr(_FakeMqttClient, "tls_set", _raise)
 
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
-        result = create_mqtt_channel(runtime)  # must not raise
+        result = create_mqtt_channel(runtime)
 
     assert result is None
     assert "tls" in caplog.text.lower()
@@ -331,7 +329,6 @@ def test_no_auth_no_tls_does_not_set_credentials_or_tls(
 def test_on_connect_fail_is_registered(
     tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
 ) -> None:
-    """create_mqtt_channel wires on_connect_fail, so pre-CONNACK failures are logged."""
     runtime = _runtime_ctx(tmp_path)
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
 
@@ -422,7 +419,7 @@ def test_send_publishes_with_qos_0_and_retain_false(
     _topic, payload, qos, retain = channel._client.published[0]
     assert qos == 0
     assert retain is False
-    assert isinstance(payload, str)  # published as a JSON-serialized string, not a dict
+    assert isinstance(payload, str)
 
 
 # --- send(): checking the immediate publish() result ---
@@ -438,7 +435,7 @@ def test_send_does_not_log_when_publish_succeeds_immediately(
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
     channel = create_mqtt_channel(runtime)
     assert channel is not None
-    channel._client.publish_rc = 0  # MQTT_ERR_SUCCESS
+    channel._client.publish_rc = 0
 
     with caplog.at_level(logging.DEBUG, logger="tapmap.notifications.mqtt"):
         channel.send(_event())
@@ -456,7 +453,7 @@ def test_send_logs_at_debug_when_publish_fails_immediately(
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
     channel = create_mqtt_channel(runtime)
     assert channel is not None
-    channel._client.publish_rc = 4  # MQTT_ERR_NO_CONN
+    channel._client.publish_rc = 4
 
     with caplog.at_level(logging.DEBUG, logger="tapmap.notifications.mqtt"):
         channel.send(_event())
@@ -468,16 +465,15 @@ def test_send_logs_at_debug_when_publish_fails_immediately(
 def test_send_does_not_retry_or_raise_on_publish_failure(
     tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
 ) -> None:
-    """QoS 0 best-effort: a failed immediate publish is not retried or raised."""
     runtime = _runtime_ctx(tmp_path)
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
     channel = create_mqtt_channel(runtime)
     assert channel is not None
-    channel._client.publish_rc = 4  # MQTT_ERR_NO_CONN
+    channel._client.publish_rc = 4
 
-    channel.send(_event())  # must not raise
+    channel.send(_event())
 
-    assert len(channel._client.published) == 1  # exactly one publish() call, no retry
+    assert len(channel._client.published) == 1
 
 
 # --- plaintext-credentials-without-TLS runtime warning ---
@@ -534,28 +530,9 @@ def test_no_warning_when_no_auth(
 # --- close/teardown ---
 
 
-def test_close_stops_loop_and_disconnects(
-    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
-) -> None:
-    runtime = _runtime_ctx(tmp_path)
-    save_mqtt_config(mqtt_config_path(tmp_path), _config())
-    channel = create_mqtt_channel(runtime)
-    assert channel is not None
-
-    channel.close()
-
-    assert channel._client.loop_stop_called is True
-    assert channel._client.disconnect_called is True
-
-
 def test_close_calls_disconnect_before_loop_stop(
     tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
 ) -> None:
-    """disconnect() must run before loop_stop().
-
-    disconnect() only queues the DISCONNECT packet; the still-running
-    network thread is what actually flushes it before exiting.
-    """
     runtime = _runtime_ctx(tmp_path)
     save_mqtt_config(mqtt_config_path(tmp_path), _config())
     channel = create_mqtt_channel(runtime)
@@ -584,7 +561,7 @@ def test_send_failure_is_caught_by_dispatch_notification(
 
     channel._client.publish = _raise  # type: ignore[assignment]
 
-    dispatch_notification(_event(), [channel])  # must not raise
+    dispatch_notification(_event(), [channel])
 
 
 # --- MQTT lifecycle callbacks: logging and failure-repetition suppression ---
@@ -600,7 +577,7 @@ class _FakeReasonCode:
 
 
 def _channel() -> MqttChannel:
-    """A MqttChannel whose callbacks can be exercised without a real client."""
+    """Create an MQTT channel for callback tests."""
     return MqttChannel(_FakeMqttClient("v2"), "topic")
 
 
@@ -626,7 +603,6 @@ def test_on_connect_logs_warning_on_failure(caplog: pytest.LogCaptureFixture) ->
 def test_on_connect_repeated_identical_failure_is_suppressed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A broker that keeps rejecting the same way must not warn on every retry."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         for _ in range(5):
@@ -655,7 +631,6 @@ def test_on_connect_different_failure_reason_logs_again(
 
 
 def test_on_connect_failure_after_success_logs_again(caplog: pytest.LogCaptureFixture) -> None:
-    """A successful connection resets failure suppression for the next episode."""
     channel = _channel()
     with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
         channel._on_connect(None, None, None, _FakeReasonCode(is_failure=True), None)
@@ -669,7 +644,6 @@ def test_on_connect_failure_after_success_logs_again(caplog: pytest.LogCaptureFi
 def test_on_disconnect_logs_warning_after_established_connection_drops(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failure-flagged disconnect following a live connection is a real, new failure."""
     channel = _channel()
     with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
         channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
@@ -683,7 +657,6 @@ def test_on_disconnect_logs_warning_after_established_connection_drops(
 def test_on_disconnect_logs_info_on_normal_disconnect(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A clean, intentional disconnect (e.g. at shutdown) is not a warning."""
     channel = _channel()
     with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
         channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
@@ -697,7 +670,6 @@ def test_on_disconnect_logs_info_on_normal_disconnect(
 def test_on_disconnect_without_prior_connect_is_not_logged(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The same-attempt echo after a rejected CONNACK is redundant and not logged."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         channel._on_disconnect(None, None, None, _FakeReasonCode(is_failure=True), None)
@@ -709,11 +681,6 @@ def test_on_disconnect_without_prior_connect_is_not_logged(
 def test_connect_failure_and_matching_disconnect_produce_one_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Reproduces the real pair for one rejected CONNACK.
-
-    "MQTT connection failed: Not authorized" / "MQTT disconnected: Unspecified
-    error". Only the meaningful first warning (from on_connect) should log.
-    """
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         channel._on_connect(
@@ -730,7 +697,6 @@ def test_connect_failure_and_matching_disconnect_produce_one_warning(
 def test_repeated_connect_disconnect_failure_pairs_produce_one_warning_total(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Paho's automatic reconnect repeats the connect/disconnect pair; only the first logs."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         for _ in range(3):
@@ -749,7 +715,6 @@ def test_repeated_connect_disconnect_failure_pairs_produce_one_warning_total(
 
 
 def test_on_connect_fail_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """A pre-CONNACK failure (DNS/TCP/TLS) is logged - otherwise it is silent."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         channel._on_connect_fail(None, None)
@@ -759,7 +724,6 @@ def test_on_connect_fail_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_on_connect_fail_does_not_invent_a_reason(caplog: pytest.LogCaptureFixture) -> None:
-    """Paho gives on_connect_fail no reason; the message must not claim one."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         channel._on_connect_fail(None, None)
@@ -772,7 +736,6 @@ def test_on_connect_fail_does_not_invent_a_reason(caplog: pytest.LogCaptureFixtu
 
 
 def test_on_connect_fail_repeated_is_suppressed(caplog: pytest.LogCaptureFixture) -> None:
-    """A broker that stays unreachable must not warn on every automatic retry."""
     channel = _channel()
     with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
         for _ in range(5):
@@ -790,14 +753,3 @@ def test_on_connect_fail_after_recovery_logs_again(caplog: pytest.LogCaptureFixt
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 2
-
-
-def test_mqtt_channel_is_a_notification_channel(
-    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
-) -> None:
-    """MqttChannel satisfies the NotificationChannel protocol (has a send() method)."""
-    runtime = _runtime_ctx(tmp_path)
-    save_mqtt_config(mqtt_config_path(tmp_path), _config())
-    channel = create_mqtt_channel(runtime)
-    assert isinstance(channel, MqttChannel)
-    assert callable(channel.send)

--- a/tests/test_notification_mqtt.py
+++ b/tests/test_notification_mqtt.py
@@ -130,7 +130,7 @@ def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
 
 def _config(**overrides: object) -> MqttConfig:
     values: dict[str, object] = {
-        "host": "broker.local",
+        "host": "192.0.2.1",
         "port": 1883,
         "topic": "tapmap/significant_connections",
         "tls": False,
@@ -173,13 +173,7 @@ def _event(**overrides: object) -> dict[str, Any]:
 def test_build_payload_excludes_exe() -> None:
     payload = _build_payload(_event())
     assert "exe" not in payload
-
-
-def test_build_payload_adds_hostname() -> None:
-    payload = _build_payload(_event())
-    assert "hostname" in payload
-    assert isinstance(payload["hostname"], str)
-    assert payload["hostname"]
+    assert "hostname" not in payload
 
 
 def test_build_payload_preserves_every_other_field_unchanged() -> None:
@@ -322,7 +316,7 @@ def test_no_auth_no_tls_does_not_set_credentials_or_tls(
     client = channel._client
     assert client.username is None
     assert client.tls_set_called is False
-    assert client.connect_async_calls == [("broker.local", 1883)]
+    assert client.connect_async_calls == [("192.0.2.1", 1883)]
     assert client.loop_start_called is True
 
 
@@ -390,7 +384,7 @@ def test_tls_enabled_calls_tls_set(
 
     assert channel is not None
     assert channel._client.tls_set_called is True
-    assert channel._client.connect_async_calls == [("broker.local", 8883)]
+    assert channel._client.connect_async_calls == [("192.0.2.1", 8883)]
 
 
 def test_topic_from_config_is_used_by_send(

--- a/tests/test_notification_mqtt.py
+++ b/tests/test_notification_mqtt.py
@@ -1,0 +1,803 @@
+"""Tests for the MQTT notification channel."""
+
+from __future__ import annotations
+
+import logging
+import ssl
+import sys
+from pathlib import Path
+from typing import Any
+
+import keyring
+import keyring.errors
+import pytest
+
+from tapmap.app import APP_META
+from tapmap.mqtt_config import MqttConfig, mqtt_config_path, save_mqtt_config
+from tapmap.notifications.mqtt import MqttChannel, _build_payload, create_mqtt_channel
+from tapmap.runtime import RuntimeContext
+
+
+class _FakeKeyring:
+    """In-memory stand-in for the keyring backend."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, key: str) -> str | None:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        try:
+            del self._store[(service, key)]
+        except KeyError:
+            raise keyring.errors.PasswordDeleteError("not found") from None
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
+    fake = _FakeKeyring()
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    return fake
+
+
+class _FakePublishInfo:
+    """Stand-in for paho's MQTTMessageInfo, carrying only the .rc field send() reads."""
+
+    def __init__(self, rc: int) -> None:
+        self.rc = rc
+
+
+class _FakeMqttClient:
+    """Records every call a real paho Client would make, without any network I/O."""
+
+    def __init__(self, callback_api_version: Any, protocol: Any = None, **_: Any) -> None:
+        self.callback_api_version = callback_api_version
+        self.protocol = protocol
+        self.on_connect: Any = None
+        self.on_disconnect: Any = None
+        self.on_connect_fail: Any = None
+        self.username: str | None = None
+        self.password: str | None = None
+        self.tls_set_called = False
+        self.connect_async_calls: list[tuple[str, int]] = []
+        self.loop_start_called = False
+        self.loop_stop_called = False
+        self.disconnect_called = False
+        self.published: list[tuple[str, str, int, bool]] = []
+        self.publish_rc = 0
+        self.call_order: list[str] = []
+
+    def username_pw_set(self, username: str | None, password: str | None = None) -> None:
+        self.username = username
+        self.password = password
+
+    def tls_set(self, *args: Any, **kwargs: Any) -> None:
+        self.tls_set_called = True
+
+    def connect_async(self, host: str, port: int = 1883, **kwargs: Any) -> None:
+        self.connect_async_calls.append((host, port))
+
+    def loop_start(self) -> None:
+        self.loop_start_called = True
+
+    def loop_stop(self) -> None:
+        self.loop_stop_called = True
+        self.call_order.append("loop_stop")
+
+    def disconnect(self) -> None:
+        self.disconnect_called = True
+        self.call_order.append("disconnect")
+
+    def publish(
+        self, topic: str, payload: str | None = None, qos: int = 0, retain: bool = False, **_: Any
+    ) -> _FakePublishInfo:
+        self.published.append((topic, payload, qos, retain))
+        return _FakePublishInfo(self.publish_rc)
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> type[_FakeMqttClient]:
+    """Replace paho's Client with the fake for the duration of the test."""
+    monkeypatch.setattr("paho.mqtt.client.Client", _FakeMqttClient)
+    return _FakeMqttClient
+
+
+def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
+    return RuntimeContext(
+        meta=APP_META,
+        app_data_dir=tmp_path,
+        run_dir=tmp_path,
+        is_frozen=False,
+        net_backend="psutil",
+        net_backend_version="test",
+        server_host="127.0.0.1",
+        server_port=8050,
+        launch_browser=True,
+        cache_retention_min=0,
+        is_docker=is_docker,
+        location_override=None,
+        security_extensions_dir=tmp_path,
+        tray_icon_path=tmp_path / "tapmap.ico",
+        notification_learning_days=7,
+    )
+
+
+def _config(**overrides: object) -> MqttConfig:
+    values: dict[str, object] = {
+        "host": "broker.local",
+        "port": 1883,
+        "topic": "tapmap/significant_connections",
+        "tls": False,
+    }
+    values.update(overrides)
+    return MqttConfig(**values)  # type: ignore[arg-type]
+
+
+def _event(**overrides: object) -> dict[str, Any]:
+    values: dict[str, object] = {
+        "timestamp": "2026-09-08T12:00:00",
+        "reasons": ["new_country"],
+        "pid": 1234,
+        "proto": "tcp",
+        "ip": "8.8.8.8",
+        "port": 443,
+        "service": "https",
+        "lat": 37.4,
+        "lon": -122.1,
+        "process_name": "firefox.exe",
+        "exe": "C:\\Users\\ola\\firefox.exe",
+        "city": "Mountain View",
+        "country": "United States",
+        "country_code": "US",
+        "asn": 15169,
+        "asn_org": "Google LLC",
+        "app_name": "Firefox",
+        "app_creator": None,
+        "app_verification_status": None,
+        "app_signature_state": None,
+        "app_signature_state_details": None,
+    }
+    values.update(overrides)
+    return values
+
+
+# --- payload building ---
+
+
+def test_build_payload_excludes_exe() -> None:
+    payload = _build_payload(_event())
+    assert "exe" not in payload
+
+
+def test_build_payload_adds_hostname() -> None:
+    payload = _build_payload(_event())
+    assert "hostname" in payload
+    assert isinstance(payload["hostname"], str)
+    assert payload["hostname"]
+
+
+def test_build_payload_preserves_every_other_field_unchanged() -> None:
+    event = _event()
+    payload = _build_payload(event)
+    for key, value in event.items():
+        if key == "exe":
+            continue
+        assert payload[key] == value
+
+
+def test_build_payload_preserves_none_values() -> None:
+    payload = _build_payload(_event())
+    assert payload["app_verification_status"] is None
+    assert payload["app_creator"] is None
+
+
+# --- create_mqtt_channel: presence/availability gating ---
+
+
+def test_no_mqtt_json_returns_none(tmp_path: Path) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    assert create_mqtt_channel(runtime) is None
+
+
+def test_malformed_mqtt_json_returns_none(tmp_path: Path) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    (tmp_path / "mqtt.json").write_text("{not valid json", encoding="utf-8")
+    assert create_mqtt_channel(runtime) is None
+
+
+def test_paho_unavailable_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    monkeypatch.setitem(sys.modules, "paho.mqtt.client", None)
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        result = create_mqtt_channel(runtime)
+
+    assert result is None
+    assert "paho-mqtt is not installed" in caplog.text
+
+
+def test_keyring_failure_returns_none_and_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A missing/broken keyring backend must not prevent TapMap startup."""
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise keyring.errors.NoKeyringError("no recommended backend was available")
+
+    monkeypatch.setattr(keyring, "get_password", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        result = create_mqtt_channel(runtime)  # must not raise
+
+    assert result is None
+    assert "keyring" in caplog.text.lower()
+
+
+def test_keyring_failure_does_not_expose_credentials_in_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise keyring.errors.NoKeyringError("no recommended backend was available")
+
+    monkeypatch.setattr(keyring, "get_password", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        create_mqtt_channel(runtime)
+
+    assert "secret" not in caplog.text.lower()
+    assert "alice" not in caplog.text.lower()
+
+
+def test_tls_setup_failure_returns_none_and_does_not_raise(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken system TLS/CA store must not prevent TapMap startup."""
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=True, port=8883))
+
+    def _raise(self: _FakeMqttClient, *args: Any, **kwargs: Any) -> None:
+        raise ssl.SSLError("unable to get local issuer certificate")
+
+    monkeypatch.setattr(_FakeMqttClient, "tls_set", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        result = create_mqtt_channel(runtime)  # must not raise
+
+    assert result is None
+    assert "tls" in caplog.text.lower()
+
+
+def test_tls_setup_failure_does_not_expose_credentials_in_logs(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=True, port=8883))
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    def _raise(self: _FakeMqttClient, *args: Any, **kwargs: Any) -> None:
+        raise ssl.SSLError("unable to get local issuer certificate")
+
+    monkeypatch.setattr(_FakeMqttClient, "tls_set", _raise)
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        create_mqtt_channel(runtime)
+
+    assert "secret1" not in caplog.text
+    assert "alice" not in caplog.text
+
+
+# --- create_mqtt_channel: client construction wiring ---
+
+
+def test_no_auth_no_tls_does_not_set_credentials_or_tls(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    client = channel._client
+    assert client.username is None
+    assert client.tls_set_called is False
+    assert client.connect_async_calls == [("broker.local", 1883)]
+    assert client.loop_start_called is True
+
+
+def test_on_connect_fail_is_registered(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    """create_mqtt_channel wires on_connect_fail, so pre-CONNACK failures are logged."""
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    assert channel._client.on_connect_fail == channel._on_connect_fail
+
+
+def test_desktop_credentials_come_from_keyring(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=False)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+    fake_keyring.set_password("tapmap_mqtt", "password", "secret1")
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    assert channel._client.username == "alice"
+    assert channel._client.password == "secret1"
+
+
+def test_docker_credentials_come_from_config_file(
+    tmp_path: Path, fake_client: type[_FakeMqttClient]
+) -> None:
+    runtime = _runtime_ctx(tmp_path, is_docker=True)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(username="alice", password="secret1"))
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    assert channel._client.username == "alice"
+    assert channel._client.password == "secret1"
+
+
+def test_username_without_password_is_passed_through(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    assert channel._client.username == "alice"
+    assert channel._client.password is None
+
+
+def test_tls_enabled_calls_tls_set(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=True, port=8883))
+
+    channel = create_mqtt_channel(runtime)
+
+    assert channel is not None
+    assert channel._client.tls_set_called is True
+    assert channel._client.connect_async_calls == [("broker.local", 8883)]
+
+
+def test_topic_from_config_is_used_by_send(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(topic="custom/topic"))
+
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+    channel.send(_event())
+
+    assert channel._client.published[0][0] == "custom/topic"
+
+
+def test_send_publishes_with_qos_0_and_retain_false(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+    channel.send(_event())
+
+    _topic, payload, qos, retain = channel._client.published[0]
+    assert qos == 0
+    assert retain is False
+    assert isinstance(payload, str)  # published as a JSON-serialized string, not a dict
+
+
+# --- send(): checking the immediate publish() result ---
+
+
+def test_send_does_not_log_when_publish_succeeds_immediately(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+    channel._client.publish_rc = 0  # MQTT_ERR_SUCCESS
+
+    with caplog.at_level(logging.DEBUG, logger="tapmap.notifications.mqtt"):
+        channel.send(_event())
+
+    assert caplog.records == []
+
+
+def test_send_logs_at_debug_when_publish_fails_immediately(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+    channel._client.publish_rc = 4  # MQTT_ERR_NO_CONN
+
+    with caplog.at_level(logging.DEBUG, logger="tapmap.notifications.mqtt"):
+        channel.send(_event())
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+
+
+def test_send_does_not_retry_or_raise_on_publish_failure(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    """QoS 0 best-effort: a failed immediate publish is not retried or raised."""
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+    channel._client.publish_rc = 4  # MQTT_ERR_NO_CONN
+
+    channel.send(_event())  # must not raise
+
+    assert len(channel._client.published) == 1  # exactly one publish() call, no retry
+
+
+# --- plaintext-credentials-without-TLS runtime warning ---
+
+
+def test_warns_once_when_auth_configured_without_tls(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=False))
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        create_mqtt_channel(runtime)
+
+    warnings = [r for r in caplog.records if "plaintext" in r.message]
+    assert len(warnings) == 1
+
+
+def test_no_warning_when_tls_enabled(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=True, port=8883))
+    fake_keyring.set_password("tapmap_mqtt", "username", "alice")
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        create_mqtt_channel(runtime)
+
+    assert not any("plaintext" in r.message for r in caplog.records)
+
+
+def test_no_warning_when_no_auth(
+    tmp_path: Path,
+    fake_client: type[_FakeMqttClient],
+    fake_keyring: _FakeKeyring,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config(tls=False))
+
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        create_mqtt_channel(runtime)
+
+    assert not any("plaintext" in r.message for r in caplog.records)
+
+
+# --- close/teardown ---
+
+
+def test_close_stops_loop_and_disconnects(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+
+    channel.close()
+
+    assert channel._client.loop_stop_called is True
+    assert channel._client.disconnect_called is True
+
+
+def test_close_calls_disconnect_before_loop_stop(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    """disconnect() must run before loop_stop().
+
+    disconnect() only queues the DISCONNECT packet; the still-running
+    network thread is what actually flushes it before exiting.
+    """
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+
+    channel.close()
+
+    assert channel._client.call_order == ["disconnect", "loop_stop"]
+
+
+# --- failure isolation through the real dispatcher ---
+
+
+def test_send_failure_is_caught_by_dispatch_notification(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    from tapmap.notifications.channel import dispatch_notification
+
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert channel is not None
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("broker unreachable")
+
+    channel._client.publish = _raise  # type: ignore[assignment]
+
+    dispatch_notification(_event(), [channel])  # must not raise
+
+
+# --- MQTT lifecycle callbacks: logging and failure-repetition suppression ---
+
+
+class _FakeReasonCode:
+    def __init__(self, *, is_failure: bool, reason: str = "Not authorized") -> None:
+        self.is_failure = is_failure
+        self._reason = reason
+
+    def __str__(self) -> str:
+        return "Success" if not self.is_failure else self._reason
+
+
+def _channel() -> MqttChannel:
+    """A MqttChannel whose callbacks can be exercised without a real client."""
+    return MqttChannel(_FakeMqttClient("v2"), "topic")
+
+
+def test_on_connect_logs_info_on_success(caplog: pytest.LogCaptureFixture) -> None:
+    channel = _channel()
+    with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
+
+    assert any(r.levelno == logging.INFO for r in caplog.records)
+    assert channel._connected is True
+    assert channel._last_reported_failure is None
+
+
+def test_on_connect_logs_warning_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=True), None)
+
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+    assert channel._last_reported_failure is not None
+
+
+def test_on_connect_repeated_identical_failure_is_suppressed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A broker that keeps rejecting the same way must not warn on every retry."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        for _ in range(5):
+            channel._on_connect(None, None, None, _FakeReasonCode(is_failure=True), None)
+
+    assert len(caplog.records) == 1
+
+
+def test_on_connect_different_failure_reason_logs_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(
+            None, None, None, _FakeReasonCode(is_failure=True, reason="Not authorized"), None
+        )
+        channel._on_connect(
+            None,
+            None,
+            None,
+            _FakeReasonCode(is_failure=True, reason="Bad user name or password"),
+            None,
+        )
+
+    assert len(caplog.records) == 2
+
+
+def test_on_connect_failure_after_success_logs_again(caplog: pytest.LogCaptureFixture) -> None:
+    """A successful connection resets failure suppression for the next episode."""
+    channel = _channel()
+    with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=True), None)
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=True), None)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+
+
+def test_on_disconnect_logs_warning_after_established_connection_drops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failure-flagged disconnect following a live connection is a real, new failure."""
+    channel = _channel()
+    with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
+        channel._on_disconnect(None, None, None, _FakeReasonCode(is_failure=True), None)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert channel._connected is False
+
+
+def test_on_disconnect_logs_info_on_normal_disconnect(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A clean, intentional disconnect (e.g. at shutdown) is not a warning."""
+    channel = _channel()
+    with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
+        channel._on_disconnect(None, None, None, _FakeReasonCode(is_failure=False), None)
+
+    assert any(r.levelno == logging.INFO for r in caplog.records)
+    assert not any(r.levelno == logging.WARNING for r in caplog.records)
+    assert channel._connected is False
+
+
+def test_on_disconnect_without_prior_connect_is_not_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The same-attempt echo after a rejected CONNACK is redundant and not logged."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_disconnect(None, None, None, _FakeReasonCode(is_failure=True), None)
+
+    assert caplog.records == []
+    assert channel._last_reported_failure is None
+
+
+def test_connect_failure_and_matching_disconnect_produce_one_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Reproduces the real pair for one rejected CONNACK.
+
+    "MQTT connection failed: Not authorized" / "MQTT disconnected: Unspecified
+    error". Only the meaningful first warning (from on_connect) should log.
+    """
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_connect(
+            None, None, None, _FakeReasonCode(is_failure=True, reason="Not authorized"), None
+        )
+        channel._on_disconnect(
+            None, None, None, _FakeReasonCode(is_failure=True, reason="Unspecified error"), None
+        )
+
+    assert len(caplog.records) == 1
+    assert "Not authorized" in caplog.records[0].getMessage()
+
+
+def test_repeated_connect_disconnect_failure_pairs_produce_one_warning_total(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Paho's automatic reconnect repeats the connect/disconnect pair; only the first logs."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        for _ in range(3):
+            channel._on_connect(
+                None, None, None, _FakeReasonCode(is_failure=True, reason="Not authorized"), None
+            )
+            channel._on_disconnect(
+                None,
+                None,
+                None,
+                _FakeReasonCode(is_failure=True, reason="Unspecified error"),
+                None,
+            )
+
+    assert len(caplog.records) == 1
+
+
+def test_on_connect_fail_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A pre-CONNACK failure (DNS/TCP/TLS) is logged - otherwise it is silent."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_connect_fail(None, None)
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+
+
+def test_on_connect_fail_does_not_invent_a_reason(caplog: pytest.LogCaptureFixture) -> None:
+    """Paho gives on_connect_fail no reason; the message must not claim one."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        channel._on_connect_fail(None, None)
+
+    message = caplog.records[0].getMessage().lower()
+    assert "tls" not in message
+    assert "ssl" not in message
+    assert "dns" not in message
+    assert "refused" not in message
+
+
+def test_on_connect_fail_repeated_is_suppressed(caplog: pytest.LogCaptureFixture) -> None:
+    """A broker that stays unreachable must not warn on every automatic retry."""
+    channel = _channel()
+    with caplog.at_level(logging.WARNING, logger="tapmap.notifications.mqtt"):
+        for _ in range(5):
+            channel._on_connect_fail(None, None)
+
+    assert len(caplog.records) == 1
+
+
+def test_on_connect_fail_after_recovery_logs_again(caplog: pytest.LogCaptureFixture) -> None:
+    channel = _channel()
+    with caplog.at_level(logging.INFO, logger="tapmap.notifications.mqtt"):
+        channel._on_connect_fail(None, None)
+        channel._on_connect(None, None, None, _FakeReasonCode(is_failure=False), None)
+        channel._on_connect_fail(None, None)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+
+
+def test_mqtt_channel_is_a_notification_channel(
+    tmp_path: Path, fake_client: type[_FakeMqttClient], fake_keyring: _FakeKeyring
+) -> None:
+    """MqttChannel satisfies the NotificationChannel protocol (has a send() method)."""
+    runtime = _runtime_ctx(tmp_path)
+    save_mqtt_config(mqtt_config_path(tmp_path), _config())
+    channel = create_mqtt_channel(runtime)
+    assert isinstance(channel, MqttChannel)
+    assert callable(channel.send)

--- a/tests/test_notification_policy.py
+++ b/tests/test_notification_policy.py
@@ -1,0 +1,41 @@
+"""Tests for the notification learning-period policy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tapmap.state.notification_policy import is_learning_period_over
+
+
+def _insights_with_active_days(n: int) -> dict[str, Any]:
+    """Return an insights dict whose countries dimension has exactly n distinct active days."""
+    mask = (1 << n) - 1 if n > 0 else 0
+    return {"countries": {"US": {"l": 1, "m": mask}}}
+
+
+def test_below_threshold_is_not_eligible() -> None:
+    """Fewer active days than the threshold: learning period is not over."""
+    insights = _insights_with_active_days(6)
+    assert is_learning_period_over(insights, min_active_days=7) is False
+
+
+def test_exactly_at_threshold_is_eligible() -> None:
+    """Exactly the threshold's worth of active days: learning period is over (>=, not >)."""
+    insights = _insights_with_active_days(7)
+    assert is_learning_period_over(insights, min_active_days=7) is True
+
+
+def test_above_threshold_is_eligible() -> None:
+    """More active days than the threshold: learning period is over."""
+    insights = _insights_with_active_days(10)
+    assert is_learning_period_over(insights, min_active_days=7) is True
+
+
+def test_empty_insights_is_not_eligible_for_positive_threshold() -> None:
+    """No history at all: not eligible when the threshold is positive."""
+    assert is_learning_period_over({}, min_active_days=7) is False
+
+
+def test_zero_threshold_is_always_eligible() -> None:
+    """A zero threshold disables the learning period: always eligible, even with no history."""
+    assert is_learning_period_over({}, min_active_days=0) is True

--- a/tests/test_notification_policy.py
+++ b/tests/test_notification_policy.py
@@ -8,34 +8,29 @@ from tapmap.state.notification_policy import is_learning_period_over
 
 
 def _insights_with_active_days(n: int) -> dict[str, Any]:
-    """Return an insights dict whose countries dimension has exactly n distinct active days."""
+    """Return Insights with the requested number of active days."""
     mask = (1 << n) - 1 if n > 0 else 0
     return {"countries": {"US": {"l": 1, "m": mask}}}
 
 
 def test_below_threshold_is_not_eligible() -> None:
-    """Fewer active days than the threshold: learning period is not over."""
     insights = _insights_with_active_days(6)
     assert is_learning_period_over(insights, min_active_days=7) is False
 
 
 def test_exactly_at_threshold_is_eligible() -> None:
-    """Exactly the threshold's worth of active days: learning period is over (>=, not >)."""
     insights = _insights_with_active_days(7)
     assert is_learning_period_over(insights, min_active_days=7) is True
 
 
 def test_above_threshold_is_eligible() -> None:
-    """More active days than the threshold: learning period is over."""
     insights = _insights_with_active_days(10)
     assert is_learning_period_over(insights, min_active_days=7) is True
 
 
 def test_empty_insights_is_not_eligible_for_positive_threshold() -> None:
-    """No history at all: not eligible when the threshold is positive."""
     assert is_learning_period_over({}, min_active_days=7) is False
 
 
 def test_zero_threshold_is_always_eligible() -> None:
-    """A zero threshold disables the learning period: always eligible, even with no history."""
     assert is_learning_period_over({}, min_active_days=0) is True

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -168,43 +168,36 @@ class TestGetCacheRetentionMin:
 
 
 class TestGetNotificationLearningDays:
-    """Test _get_notification_learning_days() env var parser."""
+    """Test notification learning-period configuration."""
 
     def test_default_returns_config(self) -> None:
-        """Missing env var returns config default."""
         with patch.dict(os.environ, {}, clear=True):
             assert _get_notification_learning_days() == 7
 
     def test_valid_value(self) -> None:
-        """An integer within the valid range (0-30) is accepted."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "14"}, clear=True):
             assert _get_notification_learning_days() == 14
 
     def test_zero_is_accepted(self) -> None:
-        """Zero is a valid, meaningful value (no learning period), not an error."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "0"}, clear=True):
             assert _get_notification_learning_days() == 0
 
     def test_thirty_is_accepted(self) -> None:
-        """30 is the upper bound of the valid range and is accepted."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "30"}, clear=True):
             assert _get_notification_learning_days() == 30
 
     @pytest.mark.parametrize("value", ["-1", "-15"])
     def test_negative_values_return_config_default(self, value: str) -> None:
-        """Negative values are invalid and fall back to the config default, not clamped."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
             assert _get_notification_learning_days() == 7
 
     @pytest.mark.parametrize("value", ["31", "45", "100"])
     def test_values_above_thirty_return_config_default(self, value: str) -> None:
-        """Values above 30 are invalid (distinct_active_days() can never exceed 30)."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
             assert _get_notification_learning_days() == 7
 
     @pytest.mark.parametrize("value", ["abc", "1.5", ""])
     def test_invalid_values_return_config_default(self, value: str) -> None:
-        """Non-integer values fall back to config default."""
         with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
             assert _get_notification_learning_days() == 7
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -13,6 +13,7 @@ from tapmap.runtime import (
     _get_cache_retention_min,
     _get_launch_browser,
     _get_location_override,
+    _get_notification_learning_days,
     _get_security_extensions_dir,
 )
 
@@ -164,6 +165,48 @@ class TestGetCacheRetentionMin:
         """Invalid values fall back to config default."""
         with patch.dict(os.environ, {"TAPMAP_CACHE_RETENTION_MIN": value}, clear=True):
             assert _get_cache_retention_min() == 0
+
+
+class TestGetNotificationLearningDays:
+    """Test _get_notification_learning_days() env var parser."""
+
+    def test_default_returns_config(self) -> None:
+        """Missing env var returns config default."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert _get_notification_learning_days() == 7
+
+    def test_valid_value(self) -> None:
+        """An integer within the valid range (0-30) is accepted."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "14"}, clear=True):
+            assert _get_notification_learning_days() == 14
+
+    def test_zero_is_accepted(self) -> None:
+        """Zero is a valid, meaningful value (no learning period), not an error."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "0"}, clear=True):
+            assert _get_notification_learning_days() == 0
+
+    def test_thirty_is_accepted(self) -> None:
+        """30 is the upper bound of the valid range and is accepted."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": "30"}, clear=True):
+            assert _get_notification_learning_days() == 30
+
+    @pytest.mark.parametrize("value", ["-1", "-15"])
+    def test_negative_values_return_config_default(self, value: str) -> None:
+        """Negative values are invalid and fall back to the config default, not clamped."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
+            assert _get_notification_learning_days() == 7
+
+    @pytest.mark.parametrize("value", ["31", "45", "100"])
+    def test_values_above_thirty_return_config_default(self, value: str) -> None:
+        """Values above 30 are invalid (distinct_active_days() can never exceed 30)."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
+            assert _get_notification_learning_days() == 7
+
+    @pytest.mark.parametrize("value", ["abc", "1.5", ""])
+    def test_invalid_values_return_config_default(self, value: str) -> None:
+        """Non-integer values fall back to config default."""
+        with patch.dict(os.environ, {"TAPMAP_NOTIFICATION_LEARNING_DAYS": value}, clear=True):
+            assert _get_notification_learning_days() == 7
 
 
 class TestGetSecurityExtensionsDir:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -187,7 +187,6 @@ def test_create_tray_icon_wires_open_and_quit_callbacks(tmp_path: Path, monkeypa
 
 
 def test_tapmap_has_no_mqtt_channel_without_mqtt_json(tmp_path: Path) -> None:
-    """No mqtt.json: the MQTT channel is absent from notification_channels."""
     app = TapMap(_runtime_ctx(tmp_path))
     try:
         assert app.mqtt_channel is None
@@ -197,7 +196,6 @@ def test_tapmap_has_no_mqtt_channel_without_mqtt_json(tmp_path: Path) -> None:
 
 
 def test_tapmap_has_mqtt_channel_with_valid_mqtt_json(tmp_path: Path) -> None:
-    """A valid mqtt.json: the MQTT channel is present in notification_channels."""
     save_mqtt_config(
         mqtt_config_path(tmp_path),
         MqttConfig(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -11,6 +11,7 @@ import tapmap
 from tapmap import app as app_module
 from tapmap.app import APP_META, TapMap, _build_arg_parser
 from tapmap.autostart import linux_autostart, macos_autostart, windows_autostart
+from tapmap.mqtt_config import MqttConfig, mqtt_config_path, save_mqtt_config
 from tapmap.runtime import RuntimeContext
 from tapmap.state.autostart import (
     AutostartDecision,
@@ -181,6 +182,32 @@ def test_create_tray_icon_wires_open_and_quit_callbacks(tmp_path: Path, monkeypa
 
         captured["on_quit"]()
         app.lifecycle.wait_for_shutdown()  # must not block: on_quit() already requested it
+    finally:
+        app.close()
+
+
+def test_tapmap_has_no_mqtt_channel_without_mqtt_json(tmp_path: Path) -> None:
+    """No mqtt.json: the MQTT channel is absent from notification_channels."""
+    app = TapMap(_runtime_ctx(tmp_path))
+    try:
+        assert app.mqtt_channel is None
+        assert app.connection_analyzer.notification_channels == []
+    finally:
+        app.close()
+
+
+def test_tapmap_has_mqtt_channel_with_valid_mqtt_json(tmp_path: Path) -> None:
+    """A valid mqtt.json: the MQTT channel is present in notification_channels."""
+    save_mqtt_config(
+        mqtt_config_path(tmp_path),
+        MqttConfig(
+            host="broker.local", port=1883, topic="tapmap/significant_connections", tls=False
+        ),
+    )
+    app = TapMap(_runtime_ctx(tmp_path))
+    try:
+        assert app.mqtt_channel is not None
+        assert app.connection_analyzer.notification_channels == [app.mqtt_channel]
     finally:
         app.close()
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -199,7 +199,7 @@ def test_tapmap_has_mqtt_channel_with_valid_mqtt_json(tmp_path: Path) -> None:
     save_mqtt_config(
         mqtt_config_path(tmp_path),
         MqttConfig(
-            host="broker.local", port=1883, topic="tapmap/significant_connections", tls=False
+            host="192.0.2.1", port=1883, topic="tapmap/significant_connections", tls=False
         ),
     )
     app = TapMap(_runtime_ctx(tmp_path))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -56,6 +56,7 @@ def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
         location_override=None,
         security_extensions_dir=tmp_path,
         tray_icon_path=tmp_path / "tapmap.ico",
+        notification_learning_days=7,
     )
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,6 +5,8 @@ import platform
 from pathlib import Path
 from typing import Any
 
+import keyring
+import keyring.errors
 import pytest
 
 import tapmap
@@ -38,6 +40,34 @@ class _FakeReader:
 
     def close(self):
         self.closed = True
+
+
+class _FakeKeyring:
+    """Provide an in-memory keyring backend."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, key: str) -> str | None:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        try:
+            del self._store[(service, key)]
+        except KeyError:
+            raise keyring.errors.PasswordDeleteError("not found") from None
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
+    fake = _FakeKeyring()
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    return fake
 
 
 def _runtime_ctx(tmp_path: Path, *, is_docker: bool = False) -> RuntimeContext:
@@ -195,7 +225,9 @@ def test_tapmap_has_no_mqtt_channel_without_mqtt_json(tmp_path: Path) -> None:
         app.close()
 
 
-def test_tapmap_has_mqtt_channel_with_valid_mqtt_json(tmp_path: Path) -> None:
+def test_tapmap_has_mqtt_channel_with_valid_mqtt_json(
+    tmp_path: Path, fake_keyring: _FakeKeyring
+) -> None:
     save_mqtt_config(
         mqtt_config_path(tmp_path),
         MqttConfig(


### PR DESCRIPTION
## Summary

Add optional MQTT notifications for new Significant Connections.

Notifications build on the existing Significant Connections detection. Events are stored independently of notification delivery, and a learning period prevents notifications while TapMap is still building its initial Insights history.

MQTT can be configured with `tapmap --configure-mqtt` and supports TLS and optional authentication. Broker addresses are restricted to IPv4 or IPv6 addresses so TapMap does not perform DNS lookups when connecting to the broker.

MQTT delivery is best effort. Messages use QoS 0, are not retained, and TapMap automatically reconnects after connection loss.

Desktop credentials are stored in the operating system keyring. Docker stores MQTT configuration and credentials in the persistent `/data` directory.

The default notification learning period is 7 active Insights days and can be configured with `TAPMAP_NOTIFICATION_LEARNING_DAYS`.

## Testing

MQTT was manually tested on Windows, Linux, macOS, and Docker, including configuration and persistence, TLS and authentication, message delivery and payloads, learning-period behavior, connection loss and reconnection, unavailable brokers, authentication rejection and recovery, invalid configuration, and clean shutdown.

The automated test suite and Ruff checks pass.

## Documentation

Add MQTT documentation and update Help, About, Docker, environment variables, privacy information, and architecture documentation.
