### PR TITLE
fix: handle PyGObject tray failure on Debian

### DIFF
--- a/src/tapmap/tray.py
+++ b/src/tapmap/tray.py
@@ -40,7 +40,8 @@ def create_tray_icon(
             title=tooltip,
             menu=menu,
         )
-    except (ImportError, OSError, ValueError):
+    except (AssertionError, ImportError, OSError, ValueError):
         # gi.require_version() raises ValueError when the AppIndicator typelib is missing.
+        # PyGObject can raise AssertionError while loading overrides against newer GLib.
         logger.warning("Tray icon unavailable; continuing without one.", exc_info=True)
         return None

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -107,3 +107,22 @@ def test_create_tray_icon_returns_none_when_creation_raises_value_error(monkeypa
         on_quit=lambda: None,
     )
     assert icon is None
+
+
+def test_create_tray_icon_returns_none_when_creation_raises_assertion_error(monkeypatch) -> None:
+    """Return None when tray icon creation raises AssertionError."""
+    import pystray
+
+    def _raise(*args, **kwargs):
+        """Simulate a PyGObject override-loading failure."""
+        raise AssertionError("unix_signal_add_full was set deprecated but wasn't added to __all__")
+
+    monkeypatch.setattr(pystray, "Icon", _raise)
+
+    icon = create_tray_icon(
+        icon_path=_ICON_PATH,
+        tooltip="TapMap",
+        on_open=lambda: None,
+        on_quit=lambda: None,
+    )
+    assert icon is None


### PR DESCRIPTION

Handle the PyGObject `AssertionError` triggered by newer GLib versions on Debian so TapMap continues without a system tray instead of crashing on startup.

Add regression coverage for the failure.

Fixes #189